### PR TITLE
Make viewer fn for hiccup reagent-1.1.0 compatible

### DIFF
--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -240,7 +240,7 @@
    {:name :latex :pred string? :fn #(html (katex/to-html-string %))}
    {:name :mathjax :pred string? :fn (comp normalize-viewer mathjax/viewer)}
    {:name :html :pred string? :fn #(html [:div {:dangerouslySetInnerHTML {:__html %}}])}
-   {:name :hiccup :fn r/as-element}
+   {:name :hiccup :fn #(r/as-element %)}
    {:name :plotly :pred map? :fn (comp normalize-viewer plotly/viewer)}
    {:name :vega-lite :pred map? :fn (comp normalize-viewer vega-lite/viewer)}
    {:name :markdown :pred string? :fn markdown/viewer}


### PR DESCRIPTION
With reagent 1.1.0, arity-2 was added to reagent.core/as-element.

```clj
(defn as-element
  "Turns a vector of Hiccup syntax into a React element. Returns form
  unchanged if it is not a vector."
  ([form] (p/as-element tmpl/default-compiler form))
  ([form compiler] (p/as-element compiler form)))
```

the second argument expecting to be a valid hiccup syntax form. We can no longer use the `r/as-element` var as hiccup viewer function directly,  but we need to explicitly pass just one argument and not 2.

This was a bit hard to track as ductile has reagent at 1.1.0 but Clerk project has it at 0.9. Didn't want to pin versions here as the patch will work for both versions.