### PR TITLE
Allow setting code cell & result visibility 🙈

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -25,7 +25,7 @@
                                borkdude/sci {:mvn/version "0.2.6"}
                                reagent/reagent {:mvn/version "1.1.0"}
                                io.github.nextjournal/viewers {:git/url "git@github.com:nextjournal/viewers.git"
-                                                              :git/sha "a32acfedce17bfa65ef8ac2a077d87823d72c8f3"}
+                                                              :git/sha "7a3c4da0af1a680ba6cca60a3eb31b5536e08e87"}
                                metosin/reitit-frontend     {:mvn/version "0.5.15"}}}
 
            :dev {:extra-deps {arrowic/arrowic {:mvn/version "0.1.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -25,7 +25,7 @@
                                borkdude/sci {:mvn/version "0.2.6"}
                                reagent/reagent {:mvn/version "1.1.0"}
                                io.github.nextjournal/viewers {:git/url "git@github.com:nextjournal/viewers.git"
-                                                              :git/sha "7a3c4da0af1a680ba6cca60a3eb31b5536e08e87"}
+                                                              :git/sha "0ebf86bbb457f819a6f9e8b5a33f34fc62c5b2e5"}
                                metosin/reitit-frontend     {:mvn/version "0.5.15"}}}
 
            :dev {:extra-deps {arrowic/arrowic {:mvn/version "0.1.1"}

--- a/notebooks/visibility.clj
+++ b/notebooks/visibility.clj
@@ -14,4 +14,10 @@
 ;; While this one is completely hidden, without the ability to uncollapse it.
 ^{::clerk/visibility :hide} (shuffle (range 25))
 
+;; In the rare case you'd like to hide the result of a cell, use `clerk/hide-result`.
+^{::clerk/visibility :show}
+(clerk/hide-result (range 500))
+
+;; In a follow-up, we'll remove the `::clerk/visibility` metadata from the code cells to not distract from the essence.
+
 ;; Fin.

--- a/notebooks/visibility.clj
+++ b/notebooks/visibility.clj
@@ -1,6 +1,11 @@
 ;; # Controlling Visibility 🙈
-;; You can control visibility in Clerk by setting the `:nextjournal.clerk/visibility`. Here, we set this to `#{:hide-ns :fold}` to hide the namespace declaration and fold all other code cells.
-^{:nextjournal.clerk/visibility #{:hide-ns :fold}}
+;; You can control visibility in Clerk by setting the `:nextjournal.clerk/visibility` which takes a keyword or a set of keywords. Valid values are:
+;; * `:show` (the default)
+;; * `:hide` to hide the cells w
+;; * `:fold` which shows the cells collapsed and lets users uncollapse them
+
+;; A declartion on the `ns` form let's all code cells in the notebook inherit the value. On the `ns` form you can also use `:fold-ns` or `:hide-ns` if you'd like an option to only apply to the namespace form.
+^{:nextjournal.clerk/visibility #{:fold}}
 (ns visibility
   (:require [clojure.string :as str]
             [nextjournal.clerk :as clerk]))

--- a/notebooks/visibility.clj
+++ b/notebooks/visibility.clj
@@ -1,0 +1,17 @@
+;; # Controlling Visibility 🙈
+;; You can control visibility in Clerk by setting the `:nextjournal.clerk/visibility`. Here, we set this to `#{:hide-ns :fold}` to hide the namespace declaration and fold all other code cells.
+^{:nextjournal.clerk/visibility #{:hide-ns :fold}}
+(ns visibility
+  (:require [clojure.string :as str]
+            [nextjournal.clerk :as clerk]))
+
+;; So a cell will only show the result now while you can uncoallpse the code cell.
+(+ 39 3)
+
+;; If you want, you can override it. So the following cell is shown:
+^{::clerk/visibility :show} (range 25)
+
+;; While this one is completely hidden, without the ability to uncollapse it.
+^{::clerk/visibility :hide} (shuffle (range 25))
+
+;; Fin.

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -202,6 +202,7 @@
 (def code           v/code)
 (def table          #'v/table)
 (def use-headers    #'v/use-headers)
+(def hide-result    #'v/hide-result)
 
 (defmacro with-viewer
   [viewer x]

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -71,10 +71,7 @@
         cas-hash (when (fs/exists? digest-file)
                    (slurp digest-file))
         cached? (boolean (and cas-hash (-> cas-hash ->cache-file fs/exists?)))
-        form-visibility (or (if-let [fv (hashing/->visibility form)]
-                              fv
-                              doc-visibility)
-                            #{:show})]
+        visibility (if-let [fv (hashing/->visibility form)] fv doc-visibility)]
     #_(prn :cached? (cond no-cache? :no-cache
                           cached? true
                           (fs/exists? digest-file) :no-cas-file
@@ -103,7 +100,7 @@
               var-value (cond-> result (var? result) deref)]
           (if (fn? var-value)
             {:nextjournal/value var-value
-             ::visibility form-visibility}
+             ::visibility visibility}
             (do (when-not (or no-cache?
                               (instance? clojure.lang.IDeref var-value)
                               (instance? clojure.lang.MultiFn var-value)
@@ -116,7 +113,7 @@
                       nil)))
                 (-> var-value
                     (wrap-with-blob-id (if no-cache? (view/->hash-str var-value) hash))
-                    (assoc ::visibility form-visibility))))))))
+                    (assoc ::visibility visibility))))))))
 
 #_(read+eval-cached {} {} #{:show} "(subs (slurp \"/usr/share/dict/words\") 0 1000)")
 

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -130,7 +130,9 @@
                 (#{:deref :map :meta :list :quote :reader-macro :set :token :var :vector} (n/tag node))
                 (cond-> (-> state
                             (update :nodes rest)
-                            (update :doc (fnil conj []) {:type :code :text (n/string node)}))
+                            (update :doc (fnil conj []) (cond-> {:type :code :text (n/string node)}
+                                                          (and (not visibility) (-> node n/string read-string ns?))
+                                                          (assoc :ns? true))))
 
                   (and markdown? (not visibility))
                   (assoc :visibility (-> node n/string read-string ->doc-visibility)))

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -144,7 +144,7 @@
                 (update state :nodes rest)))
        (select-keys state [:doc :visibility])))))
 
-#_(parse-file {:markdown? true} "notebooks/viewer_api.clj")
+#_(parse-file {:markdown? true} "notebooks/visibility.clj")
 #_(parse-file "notebooks/elements.clj")
 #_(parse-file {:markdown? true} "notebooks/rule_30.clj")
 #_(parse-file "notebooks/src/demo/lib.cljc")

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -81,7 +81,7 @@
                                    (str "viewer-" (name viewer)))
                                  (when-let [inner-viewer-name (some-> x viewer/value viewer/viewer :name name)]
                                    (str "viewer-" inner-viewer-name))
-                                 (case (or (viewer/width x) (case viewer :code :wide :prose))
+                                 (case (or (viewer/width x) (case viewer (:code :code-folded) :wide :prose))
                                    :wide "w-full max-w-wide"
                                    :full "w-full"
                                    "w-full max-w-prose px-8")]}
@@ -839,6 +839,26 @@ black")}]))}
 (def plotly-viewer (comp normalize-viewer plotly/viewer))
 (def vega-lite-viewer (comp normalize-viewer vega-lite/viewer))
 
+(def expand-icon
+  [:svg {:xmlns "http://www.w3.org/2000/svg" :viewBox "0 0 20 20" :fill "currentColor" :width 12 :height 12}
+   [:path {:fill-rule "evenodd" :d "M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" :clip-rule "evenodd"}]])
+
+(defn foldable-code-viewer [code-string]
+  (r/with-let [!hidden? (r/atom true)]
+    (html (if @!hidden?
+            [:div.w-full.max-w-wide.sans-serif {:style {:background "var(--gray-panel-color)"}}
+             [:button.mx-auto.flex.items-center.rounded-sm.cursor-pointer.bg-indigo-200.hover:bg-indigo-300.leading-none
+              {:style {:font-size "11px" :padding "1px 3px"}
+               :on-click #(swap! !hidden? not)}
+              expand-icon " Show code…"]]
+            [:div.viewer-code.relative {:style {:margin-top 0}}
+             [inspect (code-viewer code-string)]
+             [:button.sans-serif.mx-auto.flex.items-center.rounded-t-sm.cursor-pointer.bg-indigo-200.hover:bg-indigo-300.leading-none.absolute.bottom-0
+              {:style {:font-size "11px" :padding "1px 3px" :left "50%" :transform "translateX(-50%)"}
+               :on-click #(swap! !hidden? not)}
+              [:span {:style {:transform "rotate(180deg)"}} expand-icon] " Hide code…"]]))))
+
+
 (defn url-for [{:keys [blob-id]}]
   (str "/_blob/" blob-id))
 
@@ -865,6 +885,7 @@ black")}]))}
    'mathjax-viewer mathjax-viewer
    'markdown-viewer markdown/viewer
    'code-viewer code-viewer
+   'foldable-code-viewer foldable-code-viewer
    'plotly-viewer plotly-viewer
    'vega-lite-viewer vega-lite-viewer
    'reagent-viewer reagent-viewer

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -126,7 +126,7 @@
 
 (def resource->static-url
   {"/css/app.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VxQBDwk3cvr1bt8YVL5m6bJGrFEmzrSbCrH1roypLjJr4AbbteCKh9Y6gQVYexdY85QA2HG5nQFLWpRp69zFSPDJ9"
-   "/css/viewer.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8Vx9d2KqsZ38vfuiaUYDCMhns2zK5YPJ4JDRHuekrb8udKgLEM7SLfzoBhtEAkHZwspwmaDm19ZUrPzwfQUtPswF1P"
+   "/css/viewer.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvykE47cdahchdt8fxwHyYwJ7YSmEFcMSyqf4UNs61izpuF1xXpKA4HeZQctDkkU11B5iLVSBjpCQrk5f5mWXS9xv"
    "/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VwyMcfayNcoRj7RZhzLTBGyS2hAtk8Teieo3s5GyiNooj4R5JhZdgZ3GuNnSAye7STHZKzhUTfrSsVbEZx79JEFc2"})
 
 (defn ->html [{:keys [conn-ws? live-js?] :or {conn-ws? true live-js? live-js?}} doc]

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -80,7 +80,9 @@
                              (case type
                                :markdown [(v/md text)]
                                :code (let [{:nextjournal.clerk/keys [visibility]} result
-                                           result? (and (contains? x :result) (not (visibility :hide-ns)))
+                                           result? (and (contains? x :result)
+                                                        (not (or (visibility :hide-ns)
+                                                                 (= :hide-result (v/viewer (v/value result))))))
                                            fold? (visibility :fold)
                                            code? (or (visibility :show)
                                                      fold?)]

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -126,7 +126,7 @@
 
 (def resource->static-url
   {"/css/app.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VxQBDwk3cvr1bt8YVL5m6bJGrFEmzrSbCrH1roypLjJr4AbbteCKh9Y6gQVYexdY85QA2HG5nQFLWpRp69zFSPDJ9"
-   "/css/viewer.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvwJaC11sRe6kkEea3iBnhgiVVqAwGdacXea7sAQ1EVVRPHVupsxACFP4xcpQtXJJ5CdBPBDxLGRNYcdyQzNDPCTE"
+   "/css/viewer.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8Vx9d2KqsZ38vfuiaUYDCMhns2zK5YPJ4JDRHuekrb8udKgLEM7SLfzoBhtEAkHZwspwmaDm19ZUrPzwfQUtPswF1P"
    "/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VwyMcfayNcoRj7RZhzLTBGyS2hAtk8Teieo3s5GyiNooj4R5JhZdgZ3GuNnSAye7STHZKzhUTfrSsVbEZx79JEFc2"})
 
 (defn ->html [{:keys [conn-ws? live-js?] :or {conn-ws? true live-js? live-js?}} doc]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -176,6 +176,7 @@
    {:name :vega-lite :render-fn (quote v/vega-lite-viewer) :fetch-fn fetch-all}
    {:name :markdown :render-fn (quote v/markdown-viewer) :fetch-fn fetch-all}
    {:name :code :render-fn (quote v/code-viewer) :fetch-fn fetch-all}
+   {:name :code-folded :render-fn (quote v/foldable-code-viewer) :fetch-fn fetch-all}
    {:name :reagent :render-fn (quote v/reagent-viewer)  :fetch-fn fetch-all}
    {:name :eval! :render-fn (constantly 'nextjournal.clerk.viewer/set-viewers!)}
    {:name :table :render-fn (quote v/table-viewer) :fetch-opts {:n 5}

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -189,7 +189,8 @@
    {:name :object :render-fn '(fn [x] (v/html (v/tagged-value "#object" [v/inspect x])))}
    {:name :file :render-fn '(fn [x] (v/html (v/tagged-value "#file " [v/inspect x])))}
    {:name :clerk/notebook :render-fn (quote v/notebook-viewer) :fetch-fn fetch-all}
-   {:name :clerk/result :render-fn (quote v/result-viewer) :fetch-fn fetch-all}])
+   {:name :clerk/result :render-fn (quote v/result-viewer) :fetch-fn fetch-all}
+   {:name :hide-result :transform-fn (fn [_] nil)}])
 
 (def default-table-cell-viewers
   [{:name :elision :render-fn '(fn [_] (v/html "…"))}
@@ -266,8 +267,8 @@
   ([x viewers]
    (if-let [selected-viewer (viewer x)]
      (cond (keyword? selected-viewer)
-           (if-let [named-viewer (find-named-viewer viewers selected-viewer)]
-             (wrap-value x named-viewer)
+           (if-let [{:as named-viewer :keys [transform-fn]} (find-named-viewer viewers selected-viewer)]
+             (wrap-value (cond-> x transform-fn transform-fn) named-viewer)
              (throw (ex-info (str "cannot find viewer named " selected-viewer) {:selected-viewer selected-viewer :x (value x) :viewers viewers})))
            (instance? Form selected-viewer)
            (wrap-value x selected-viewer))
@@ -569,12 +570,13 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; public convience api
-(def html      (partial with-viewer* :html))
-(def md        (partial with-viewer* :markdown))
-(def plotly    (partial with-viewer* :plotly))
-(def vl        (partial with-viewer* :vega-lite))
-(def tex       (partial with-viewer* :latex))
-(def notebook  (partial with-viewer* :clerk/notebook))
+(def html         (partial with-viewer* :html))
+(def md           (partial with-viewer* :markdown))
+(def plotly       (partial with-viewer* :plotly))
+(def vl           (partial with-viewer* :vega-lite))
+(def tex          (partial with-viewer* :latex))
+(def hide-result  (partial with-viewer* :hide-result))
+(def notebook     (partial with-viewer* :clerk/notebook))
 
 (defn table
   "Displays `xs` in a table.


### PR DESCRIPTION
Control code cell visibility via `:nextjournal.clerk/visibility` metadata with valid values of `:show`, `:hide`, `:fold` or (on namespace forms `:hide-ns` or `:fold-ns`). Multiple appropriate values can be combined in a set. 

- [x] allow setting cell visibility
- [x] validate options
- [x] validate no conflicting options are set (e.g. `:show` and `:hide`). Currently the only valid options are `:hide-ns` with another value.
- [x] implement hiding results via `clerk/hide-result` viewer function.
- [x] fix css spacing

In follow-up: use rewrite-clj to remove display metadata from displayed code.