### PR TITLE
Markdown Notebooks

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -17,14 +17,15 @@
         hiccup/hiccup {:mvn/version "2.0.0-alpha2"}
         lambdaisland/uri {:mvn/version "1.11.86"}
 
+        rewrite-clj/rewrite-clj {:mvn/version "1.0.699-alpha"}
 
-        rewrite-clj/rewrite-clj {:mvn/version "1.0.699-alpha"}}
+        io.github.nextjournal/viewers {:git/sha "1b1374db20b56d14a0f32835c1ce5d9254c23527"
+                                       :deps/root "modules/markdown"}}
 
  :aliases {:sci {:extra-deps  {applied-science/js-interop  {:mvn/version "0.3.0"}
                                borkdude/sci {:mvn/version "0.2.6"}
                                reagent/reagent {:mvn/version "1.1.0"}
-                               io.github.nextjournal/viewers {:git/url "git@github.com:nextjournal/viewers.git"
-                                                              :git/sha "1b1374db20b56d14a0f32835c1ce5d9254c23527"}
+                               io.github.nextjournal/viewers {:git/sha "1b1374db20b56d14a0f32835c1ce5d9254c23527"}
                                metosin/reitit-frontend     {:mvn/version "0.5.15"}}}
 
            :dev {:extra-deps {arrowic/arrowic {:mvn/version "0.1.1"}

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -24,6 +24,7 @@
   (set-dev! false)
   (set-dev! true)
 
+  (clerk/show! "notebooks/markdown.md")
   (clerk/show! "notebooks/onwards.clj")
   (clerk/show! "notebooks/rule_30.clj")
   (clerk/show! "notebooks/how_clerk_works.clj")

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -24,7 +24,6 @@
   (set-dev! false)
   (set-dev! true)
 
-  (clerk/show! "notebooks/markdown.md")
   (clerk/show! "notebooks/onwards.clj")
   (clerk/show! "notebooks/rule_30.clj")
   (clerk/show! "notebooks/how_clerk_works.clj")
@@ -33,15 +32,19 @@
   (clerk/show! "notebooks/recursive.clj")
   (clerk/show! "notebooks/tap.clj")
 
+  (clerk/show! "notebooks/markdown.md")
+
   (clerk/show! "notebooks/viewer_api.clj")
 
-  (clerk/show! "notebooks/sicmutils.clj")
+
   (clerk/show! "notebooks/viewers/vega.clj")
   (clerk/show! "notebooks/viewers/plotly.clj")
   (clerk/show! "notebooks/viewers/table.clj")
   (clerk/show! "notebooks/viewers/tex.clj")
   (clerk/show! "notebooks/viewers/markdown.clj")
   (clerk/show! "notebooks/viewers/html.clj")
+
+  (clerk/show! "notebooks/sicmutils.clj")
 
   (clerk/clear-cache!)
 

--- a/notebooks/markdown.md
+++ b/notebooks/markdown.md
@@ -1,0 +1,57 @@
+# $\mathfrak{M}\!⬇$ Markdown Ingestion
+
+This notebook demoes feeding Clerk with markdown files. We currently make no assumption on the kind of source code passed in fenced blocks, we handle code as if it were clojure. Indented code blocks are treated as inert code blocks.  
+
+```clj
+^:nextjournal.clerk/no-cache
+(ns markdown-example
+  (:require [nextjournal.clerk :as clerk]
+            [nextjournal.markdown :as md]
+            [nextjournal.markdown.transform :as md.transform]))
+```
+
+Nextjournal Markdown library is able to ingest a markdown string
+
+```clojure
+(def markdown-input (slurp "https://daringfireball.net/projects/markdown/syntax.text"))
+```
+
+and parse it into a nested clojure structure
+
+```clojure
+(def parsed (md/parse markdown-input))
+```
+
+which you can manipulate with your favourite clojure functions
+
+```clojure
+(def sliced (update parsed :content #(take 8 %)))
+```
+
+and render back to hiccup with customisable elements. 
+
+At present, Clerk will split top level forms which are grouped togetehr under the same cell, this is to guarantee that Clerk's dependency analysys among forms will still effectively avoid needless recomputations when code changes. Forms are nevertheless still grouped as intended in the document.
+
+```clojure
+(def renderers 
+  (assoc md.transform/default-hiccup-renderers 
+        :doc (partial md.transform/into-markup [:div.viewer-markdown])
+        :ruler (fn [_ _]
+                 [:hr.mt-1.mb-1
+                  {:style {:border "10px solid magenta" 
+                           :border-radius "10px"}}])))
+
+(def hiccup 
+  (md.transform/->hiccup renderers sliced))
+```
+
+and finally render via Clerk's `html` helper.
+
+```clojure
+^{::clerk/visibility :fold}
+(clerk/html hiccup)
+```
+
+## Appendix
+
+Don't forget the closing slice 🍕 of markdown! 

--- a/notebooks/markdown.md
+++ b/notebooks/markdown.md
@@ -37,7 +37,7 @@ At present, Clerk will split top level forms which are grouped togetehr under th
   (assoc md.transform/default-hiccup-renderers 
         :doc (partial md.transform/into-markup [:div.viewer-markdown])
         :ruler (fn [_ _]
-                 [:hr.mt-1.mb-1
+                 [:hr.mt-1.mb-10
                   {:style {:border "10px solid magenta" 
                            :border-radius "10px"}}])))
 

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -177,7 +177,8 @@
 
 (defn file-event [{:keys [type path]}]
   (when (and (contains? #{:modify :create} type)
-             (or (str/ends-with? path ".clj")
+             (or (str/ends-with? path ".md")
+                 (str/ends-with? path ".clj")
                  (str/ends-with? path ".cljc")))
     (binding [*ns* (find-ns 'user)]
       (let [rel-path (str/replace (str path) (str (fs/canonicalize ".") fs/file-separator) "")
@@ -266,7 +267,7 @@
 ;; static builds
 
 (def clerk-docs
-  (into []
+  (into ["notebooks/markdown.md"]
         (map #(str "notebooks/" % ".clj"))
         ["hello"
          "how_clerk_works"
@@ -284,6 +285,7 @@
          "viewers/table"
          "viewers/tex"
          "viewers/vega"]))
+
 
 (defn build-static-app!
   "Builds a static html app of the notebooks at `paths`."

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -286,7 +286,6 @@
          "viewers/tex"
          "viewers/vega"]))
 
-
 (defn build-static-app!
   "Builds a static html app of the notebooks at `paths`."
   [{:keys [paths out-path live-js?]

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -14,6 +14,8 @@
             [multihash.digest :as digest]
             [rewrite-clj.node :as n]
             [rewrite-clj.parser :as p]
+            [nextjournal.markdown :as markdown]
+            [nextjournal.markdown.transform :as markdown.transform]
             [weavejester.dependency :as dep]))
 
 (defn var-name
@@ -120,15 +122,15 @@
 
 #_(read-string "(ns rule-30 (:require [nextjournal.clerk.viewer :as v]))")
 
-(defn parse-file
-  ([file]
-   (parse-file {} file))
+(def tag-allowed? #{:deref :map :meta :list :quote :reader-macro :set :token :var :vector})
+(defn parse-clojure-file
+  ([file] (parse-clojure-file {} file))
   ([{:as _opts :keys [markdown?]} file]
    (loop [{:as state :keys [doc nodes visibility]} {:nodes (:children (p/parse-file-all file))
                                                     :doc []}]
      (if-let [node (first nodes)]
        (recur (cond
-                (#{:deref :map :meta :list :quote :reader-macro :set :token :var :vector} (n/tag node))
+                (tag-allowed? (n/tag node))
                 (cond-> (-> state
                             (update :nodes rest)
                             (update :doc (fnil conj []) (cond-> {:type :code :text (n/string node)}
@@ -140,14 +142,63 @@
                 (and markdown? (n/comment? node))
                 (-> state
                     (assoc :nodes (drop-while n/comment? nodes))
-                    (update :doc conj {:type :markdown :text (apply str (map (comp remove-leading-semicolons n/string)
-                                                                             (take-while n/comment? nodes)))}))
+                    (update :doc conj {:type :markdown
+                                       :doc (markdown/parse (apply str (map (comp remove-leading-semicolons n/string)
+                                                                            (take-while n/comment? nodes))))}))
                 :else
                 (update state :nodes rest)))
        (select-keys state [:doc :visibility])))))
 
+(defn code-cell? [{:as node :keys [type]}]
+  ;; TODO: assign different types to fenced vs indented code blocks
+  (and (= :code type) (contains? node :info)))
+
+(defn parse-markdown-cell [state markdown-code-cell]
+  (let [clj-nodes (-> markdown-code-cell markdown.transform/->text str/trim p/parse-string-all :children
+                      (->> (filter (comp tag-allowed? n/tag))
+                           (map-indexed (fn [i n] [i n]))))
+        last-idx (dec (count clj-nodes))]
+    (reduce (fn [{:as state :keys [visibility]} [i node]]
+              (-> state
+                  (update :doc conj (cond-> {:type :code :text (n/string node)}
+                                      (not= last-idx i) (assoc :hide-result? true)
+                                      (not= 0 i) (assoc :join-with-cell-above? true)
+                                      (and (not visibility) (-> node n/string read-string ns?)) (assoc :ns? true)))
+                  (cond-> (not visibility) (assoc :visibility (-> node n/string read-string ->doc-visibility)))))
+            state
+            clj-nodes)))
+
+(defn parse-markdown-file [{:keys [markdown?]} file]
+  (loop [{:as state :keys [nodes] ::keys [md-slice]} {:doc [] ::md-slice [] :nodes (:content (markdown/parse (slurp file)))}]
+    (if-some [node (first nodes)]
+      (recur
+       (if (code-cell? node)
+         (cond-> state
+           (seq md-slice)
+           (-> #_state
+               (update :doc conj {:type :markdown :doc {:type :doc :content md-slice}})
+               (assoc ::md-slice []))
+
+           :always
+           (-> #_state
+               (parse-markdown-cell node)
+               (update :nodes rest)))
+
+         (-> state (update :nodes rest) (cond-> markdown? (update ::md-slice conj node)))))
+
+      (-> state
+          (update :doc #(cond-> % (seq md-slice) (conj {:type :markdown :doc {:type :doc :content md-slice}})))
+          (select-keys [:doc :visibility])))))
+
+(defn parse-file
+  ([file] (parse-file {} file))
+  ([opts file] (if (str/ends-with? file ".md")
+                 (parse-markdown-file opts file)
+                 (parse-clojure-file opts file))))
+
 #_(parse-file {:markdown? true} "notebooks/visibility.clj")
 #_(parse-file "notebooks/elements.clj")
+#_(parse-file "notebooks/markdown.md")
 #_(parse-file {:markdown? true} "notebooks/rule_30.clj")
 #_(parse-file "notebooks/src/demo/lib.cljc")
 

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -839,6 +839,7 @@ black")}]))}
 (def code-viewer (comp normalize-viewer code/viewer))
 (def plotly-viewer (comp normalize-viewer plotly/viewer))
 (def vega-lite-viewer (comp normalize-viewer vega-lite/viewer))
+
 (defn markdown-viewer
   "Accept a markdown string or a structure from parsed markdown."
   [data]

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -77,17 +77,15 @@
          (map (fn [x]
                 (let [viewer (viewer/viewer x)
                       blob-id (:blob-id (viewer/value x))]
-                  [:div (cond-> {:class ["viewer" "overflow-x-auto"
-                                         (when (keyword? viewer)
-                                           (str "viewer-" (name viewer)))
-                                         (when-let [inner-viewer-name (some-> x viewer/value viewer/viewer :name name)]
-                                           (str "viewer-" inner-viewer-name))
-                                         (case (or (viewer/width x) (case viewer (:code :code-folded) :wide :prose))
-                                           :wide "w-full max-w-wide"
-                                           :full "w-full"
-                                           "w-full max-w-prose px-8")]}
-                          (:join-with-cell-above? x)
-                          (assoc :style {:margin-top "-1rem" :padding-top 0}))
+                  [:div {:class ["viewer" "overflow-x-auto"
+                                 (when (keyword? viewer)
+                                   (str "viewer-" (name viewer)))
+                                 (when-let [inner-viewer-name (some-> x viewer/value viewer/viewer :name name)]
+                                   (str "viewer-" inner-viewer-name))
+                                 (case (or (viewer/width x) (case viewer (:code :code-folded) :wide :prose))
+                                   :wide "w-full max-w-wide"
+                                   :full "w-full"
+                                   "w-full max-w-prose px-8")]}
                    (cond-> [inspect x]
                      blob-id (with-meta {:key blob-id}))])))
          xs)))

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -94,10 +94,9 @@
 
 #_(nextjournal.clerk/show! "notebooks/hello.clj")
 
-(defn ->display [{:as code-cell :keys [result ns? hide-result?]}]
+(defn ->display [{:as code-cell :keys [result ns?]}]
   (let [{:nextjournal.clerk/keys [visibility]} result
         result? (and (contains? code-cell :result)
-                     (not hide-result?)
                      (not= :hide-result (v/viewer (v/value result)))
                      (not (contains? visibility :hide-ns))
                      (not (and ns? (contains? visibility :hide))))
@@ -120,15 +119,13 @@
   ([{:keys [inline-results?] :or {inline-results? false}} doc]
    (let [{:keys [ns]} (meta doc)]
      (cond-> (into []
-                   (mapcat (fn [{:as cell :keys [type text result doc join-with-cell-above?]}]
+                   (mapcat (fn [{:as cell :keys [type text result doc]}]
                              (case type
                                :markdown [(v/md doc)]
                                :code (let [{:keys [code? fold? result?]} (->display cell)]
                                        (cond-> []
                                          code?
-                                         (conj (cond-> (v/code text)
-                                                 fold? (assoc :nextjournal/viewer :code-folded)
-                                                 join-with-cell-above? (assoc :join-with-cell-above? true)))
+                                         (conj (cond-> (v/code text) fold? (assoc :nextjournal/viewer :code-folded)))
                                          result?
                                          (conj (cond
                                                  (v/registration? (v/value result))
@@ -153,7 +150,7 @@
 (def resource->static-url
   {"/css/app.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VxQBDwk3cvr1bt8YVL5m6bJGrFEmzrSbCrH1roypLjJr4AbbteCKh9Y6gQVYexdY85QA2HG5nQFLWpRp69zFSPDJ9"
    "/css/viewer.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvykE47cdahchdt8fxwHyYwJ7YSmEFcMSyqf4UNs61izpuF1xXpKA4HeZQctDkkU11B5iLVSBjpCQrk5f5mWXS9xv"
-   "/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VtCQuCnwKkbSNUuM19Tdk27F5G73XjkRWEcbx3cYtuU72wfzxfYmpP9VPX2K6CsVDACcWWFkQP4FxdQpg1PbQFCG3"})
+   "/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvjwYaxizFrjskcEWTtLYshVQwcGfd84RoBJsWfkj84Hp94LiXrAwJmQR4Bic6riQshvEqLdm4nDTjQ3GkQVtZgxX"})
 
 (defn ->html [{:keys [conn-ws? live-js?] :or {conn-ws? true live-js? live-js?}} doc]
   (hiccup/html5

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -94,9 +94,10 @@
 
 #_(nextjournal.clerk/show! "notebooks/hello.clj")
 
-(defn ->display [{:as code-cell :keys [result ns?]}]
+(defn ->display [{:as code-cell :keys [result ns? hide-result?]}]
   (let [{:nextjournal.clerk/keys [visibility]} result
         result? (and (contains? code-cell :result)
+                     (not hide-result?)
                      (not= :hide-result (v/viewer (v/value result)))
                      (not (contains? visibility :hide-ns))
                      (not (and ns? (contains? visibility :hide))))
@@ -119,13 +120,15 @@
   ([{:keys [inline-results?] :or {inline-results? false}} doc]
    (let [{:keys [ns]} (meta doc)]
      (cond-> (into []
-                   (mapcat (fn [{:as cell :keys [type text result ns?]}]
+                   (mapcat (fn [{:as cell :keys [type text result doc join-with-cell-above?]}]
                              (case type
-                               :markdown [(v/md text)]
+                               :markdown [(v/md doc)]
                                :code (let [{:keys [code? fold? result?]} (->display cell)]
                                        (cond-> []
                                          code?
-                                         (conj (cond-> (v/code text) fold? (assoc :nextjournal/viewer :code-folded)))
+                                         (conj (cond-> (v/code text)
+                                                 fold? (assoc :nextjournal/viewer :code-folded)
+                                                 join-with-cell-above? (assoc :join-with-cell-above? true)))
                                          result?
                                          (conj (cond
                                                  (v/registration? (v/value result))
@@ -150,7 +153,7 @@
 (def resource->static-url
   {"/css/app.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VxQBDwk3cvr1bt8YVL5m6bJGrFEmzrSbCrH1roypLjJr4AbbteCKh9Y6gQVYexdY85QA2HG5nQFLWpRp69zFSPDJ9"
    "/css/viewer.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvykE47cdahchdt8fxwHyYwJ7YSmEFcMSyqf4UNs61izpuF1xXpKA4HeZQctDkkU11B5iLVSBjpCQrk5f5mWXS9xv"
-   "/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VwG2fdyhJNgY8iUttUnPQvDxXXhM4NbYE76jWE2bkBUJmpKjKMSQhiMYRnuVT1G2zgdfDHAC8bcSGkWoacPFqCnwy"})
+   "/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VtCQuCnwKkbSNUuM19Tdk27F5G73XjkRWEcbx3cYtuU72wfzxfYmpP9VPX2K6CsVDACcWWFkQP4FxdQpg1PbQFCG3"})
 
 (defn ->html [{:keys [conn-ws? live-js?] :or {conn-ws? true live-js? live-js?}} doc]
   (hiccup/html5


### PR DESCRIPTION
- Separate top-level clojure forms grouped under the same markdown cell
- Handle markdown indented code blocks as literal code
- Parse markdown chunks in clojure inputs as well unifying notebook
representations for markdown and clojure files.