### PR TITLE
Show error overlay as viewer to retain scroll position

### DIFF
--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -303,7 +303,7 @@
 
 #_(build-static-app! {})
 #_(build-static-app! {:live-js? false})
-#_(build-static-app! {:paths ["notebooks/viewers/table.clj"]})
+#_(build-static-app! {:paths ["notebooks/viewer_api.clj" "notebooks/rule_30.clj"]})
 
 ;; And, as is the culture of our people, a commend block containing
 ;; pieces of code with which to pilot the system during development.

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -605,16 +605,14 @@
      [:div.fixed.top-0.left-0.w-full.h-full
       [inspect @!error]])])
 
-(defn ^:export reset-doc [new-doc]
-  (doseq [cell (viewer/value new-doc)
+(defn ^:export set-state [{:as state :keys [doc error]}]
+  (doseq [cell (viewer/value doc)
           :when (viewer/registration? cell)
           :let [form (viewer/value cell)]]
     (*eval* form))
-  (if (= :error (-> new-doc viewer/viewer :name))
-    (reset! !error new-doc)
-    (do (when @!error
-          (reset! !error nil))
-        (reset! !doc new-doc))))
+  (when (contains? state :doc)
+    (reset! !doc doc))
+  (reset! !error error))
 
 (dc/defcard eval-viewer
   "Viewers that are lists are evaluated using sci."

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -347,6 +347,28 @@
                                                     [inspect (update opts :path conj i j) d]]) row))))) (viewer/value rows)))])))))
 
 
+(defn throwable-viewer [{:keys [via trace]}]
+  (html
+   [:div.w-screen.h-screen.overflow-y-auto.bg-gray-100.p-6.text-xs.monospace.flex.flex-col
+    [:div.rounded-md.shadow-lg.border.border-gray-300.bg-white.max-w-6xl.mx-auto
+     (into
+      [:div]
+      (map
+       (fn [{:as _ex :keys [type message data _trace]}]
+         [:div.p-4.bg-red-100.border-b.border-gray-300.rounded-t-md
+          [:div.font-bold "Unhandled " type]
+          [:div.font-bold.mt-1 message]
+          [:div.mt-1 (pr-str data)]])
+       via))
+     [:div.py-6
+      [:table.w-full
+       (into [:tbody]
+             (map (fn [[call _x file line]]
+                    [:tr.hover:bg-red-100.leading-tight
+                     [:td.text-right.px-6 file ":"]
+                     [:td.text-right.pr-6 line]
+                     [:td.py-1.pr-6 call]]))
+             trace)]]]]))
 
 (defn tagged-value [tag value]
   [:span.inspected-value.whitespace-nowrap
@@ -892,6 +914,7 @@ black")}]))}
    'with-viewers with-viewers
    'clerk-eval clerk-eval
 
+   'throwable-viewer throwable-viewer
    'notebook-viewer notebook
    'katex-viewer katex-viewer
    'mathjax-viewer mathjax-viewer

--- a/src/nextjournal/clerk/static_app.cljs
+++ b/src/nextjournal/clerk/static_app.cljs
@@ -9,7 +9,7 @@
   (r/atom {}))
 
 (defn show [{:keys [path]}]
-  (sci-viewer/reset-doc (@path->doc path))
+  (sci-viewer/set-state {:doc (@path->doc path)})
   [:<>
    [:div.flex.flex-col.items-center
     [:div.mt-8.flex.items-center.text-xs.w-full.max-w-prose.px-8.sans-serif.text-gray-400

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -163,7 +163,7 @@
    "/css/viewer.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvykE47cdahchdt8fxwHyYwJ7YSmEFcMSyqf4UNs61izpuF1xXpKA4HeZQctDkkU11B5iLVSBjpCQrk5f5mWXS9xv"
    "/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvjwYaxizFrjskcEWTtLYshVQwcGfd84RoBJsWfkj84Hp94LiXrAwJmQR4Bic6riQshvEqLdm4nDTjQ3GkQVtZgxX"})
 
-(defn ->html [{:keys [conn-ws? live-js?] :or {conn-ws? true live-js? live-js?}} doc]
+(defn ->html [{:keys [conn-ws? live-js?] :or {conn-ws? true live-js? live-js?}} state]
   (hiccup/html5
    [:head
     [:meta {:charset "UTF-8"}]
@@ -175,12 +175,12 @@
    [:body
     [:div#clerk]
     [:script "let viewer = nextjournal.clerk.sci_viewer
-let doc = " (-> doc ->edn pr-str) "
-viewer.reset_doc(viewer.read_string(doc))
+let state = " (-> state ->edn pr-str) "
+viewer.set_state(viewer.read_string(state))
 viewer.mount(document.getElementById('clerk'))\n"
      (when conn-ws?
        "const ws = new WebSocket(document.location.origin.replace(/^http/, 'ws') + '/_ws')
-ws.onmessage = msg => viewer.reset_doc(viewer.read_string(msg.data))
+ws.onmessage = msg => viewer.set_state(viewer.read_string(msg.data))
 window.ws_send = msg => ws.send(msg)")]]))
 
 
@@ -200,8 +200,8 @@ let app = nextjournal.clerk.static_app
 let docs = viewer.read_string(" (-> docs ->edn pr-str) ")
 app.init(docs)\n"]]))
 
-(defn doc->html [doc]
-  (->html {} (doc->viewer {} doc)))
+(defn doc->html [doc error]
+  (->html {} {:doc (doc->viewer {} doc) :error error}))
 
 (defn doc->static-html [doc]
   (->html {:conn-ws? false :live-js? false} (doc->viewer {:inline-results? true} doc)))

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -8,12 +8,6 @@
             [multihash.digest :as digest]
             [taoensso.nippy :as nippy]))
 
-
-(defn ex->viewer [e]
-  (v/exception (Throwable->map e)))
-
-#_(doc->viewer (nextjournal.clerk/eval-file "notebooks/elements.clj"))
-
 (defn var->data [v]
   (v/wrapped-with-viewer v))
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -419,64 +419,64 @@
 
 
 (let [n (normalize-table-data (repeat 60 ["Adelie" "Biscoe" 50 30 200 5000 :female]))]
-(update n :rows describe))
+  (update n :rows describe))
 
 (def t' (with-viewer* :table (repeat 60 ["Adelie" "Biscoe" 50 30 200 5000 :female])))
 
 (let [xs t']
-(describe xs))
+  (describe xs))
 #_
 (describe (table
            {:a (range 30)
             :b (map inc (range 30))}))
 
 (comment
-(describe 123)
-(-> (describe (range 100)) value peek)
-(describe {:hello [1 2 3]})
-(describe {:one [1 2 3] 1 2 3 4})
-(describe [1 2 [1 [2] 3] 4 5])
-(describe (clojure.java.io/file "notebooks"))
-(describe {:viewers [{:pred sequential? :render-fn pr-str}]} (range 100))
-(describe (map vector (range)))
-(describe (subs (slurp "/usr/share/dict/words") 0 1000))
-(describe (plotly {:data [{:z [[1 2 3] [3 2 1]] :type "surface"}]}))
-(describe (with-viewer* :html [:h1 "hi"]))
-(describe (with-viewer* :html [:ul (for [x (range 3)] [:li x])]))
-(describe (range))
-(describe {1 [2]})
-(describe (with-viewer* (->Form '(fn [name] (html [:<> "Hello " name]))) "James")))
+  (describe 123)
+  (-> (describe (range 100)) value peek)
+  (describe {:hello [1 2 3]})
+  (describe {:one [1 2 3] 1 2 3 4})
+  (describe [1 2 [1 [2] 3] 4 5])
+  (describe (clojure.java.io/file "notebooks"))
+  (describe {:viewers [{:pred sequential? :render-fn pr-str}]} (range 100))
+  (describe (map vector (range)))
+  (describe (subs (slurp "/usr/share/dict/words") 0 1000))
+  (describe (plotly {:data [{:z [[1 2 3] [3 2 1]] :type "surface"}]}))
+  (describe (with-viewer* :html [:h1 "hi"]))
+  (describe (with-viewer* :html [:ul (for [x (range 3)] [:li x])]))
+  (describe (range))
+  (describe {1 [2]})
+  (describe (with-viewer* (->Form '(fn [name] (html [:<> "Hello " name]))) "James")))
 
 
 (defn desc->values
-"Takes a `description` and returns its value. Inverse of `describe`. Mostly useful for debugging."
-[desc]
-(let [x (value desc)
-      viewer (viewer desc)]
-  (if (= viewer :elision)
-    '…
-    (cond->> x
-      (vector? x)
-      (into (case (:name viewer) (:map :table) {} [])
-            (map desc->values))))))
+  "Takes a `description` and returns its value. Inverse of `describe`. Mostly useful for debugging."
+  [desc]
+  (let [x (value desc)
+        viewer (viewer desc)]
+    (if (= viewer :elision)
+      '…
+      (cond->> x
+        (vector? x)
+        (into (case (:name viewer) (:map :table) {} [])
+              (map desc->values))))))
 
 #_(desc->values (describe [1 [2 {:a :b} 2] 3 (range 100)]))
 #_(desc->values (describe (with-viewer* :table (normalize-table-data (repeat 60 ["Adelie" "Biscoe" 50 30 200 5000 :female])))))
 
 (defn path-to-value [path]
-(conj (interleave path (repeat :nextjournal/value)) :nextjournal/value))
+  (conj (interleave path (repeat :nextjournal/value)) :nextjournal/value))
 
 
 (defn merge-descriptions [root more]
-(update-in root (path-to-value (:path more))
-           (fn [value]
-             (let [{:keys [offset path]} (-> value peek :nextjournal/value)
-                   path-from-value (conj path offset)
-                   path-from-more (or (:replace-path more) ;; string case, TODO find a better way to unify
-                                      (-> more :nextjournal/value first :path))]
-               (when (not= path-from-value path-from-more)
-                 (throw (ex-info "paths mismatch" {:path-from-value path-from-value :path-from-more path-from-more})))
-               (into (pop value) (:nextjournal/value more))))))
+  (update-in root (path-to-value (:path more))
+             (fn [value]
+               (let [{:keys [offset path]} (-> value peek :nextjournal/value)
+                     path-from-value (conj path offset)
+                     path-from-more (or (:replace-path more) ;; string case, TODO find a better way to unify
+                                        (-> more :nextjournal/value first :path))]
+                 (when (not= path-from-value path-from-more)
+                   (throw (ex-info "paths mismatch" {:path-from-value path-from-value :path-from-more path-from-more})))
+                 (into (pop value) (:nextjournal/value more))))))
 
 (comment ;; test cases for merge-descriptions, TODO: simplify
   (let [value (range 30)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -140,6 +140,11 @@
     (and (sequential? data) (sequential? (first data))) (normalize-seq-of-seq data)
     :else nil))
 
+(defn demunge-ex-data [ex-data]
+  (update ex-data :trace (fn [traces] (mapv #(update % 0 (comp demunge pr-str)) traces))))
+
+#_(demunge-ex-data (datafy/datafy (ex-info "foo" {:bar :baz})))
+
 (def elide-string-length 100)
 
 (declare with-viewer*)
@@ -169,7 +174,7 @@
    {:pred inst? :render-fn '(fn [x] (v/html (v/tagged-value "#inst" [:span.syntax-string.inspected-value "\"" (str x) "\""])))}
    {:pred var? :transform-fn symbol :render-fn '(fn [x] (v/html [:span.inspected-value [:span.syntax-tag "#'" (str x)]]))}
    {:pred (fn [e] (instance? #?(:clj Throwable :cljs js/Error) e)) :fetch-fn fetch-all
-    :name :error :render-fn (quote v/throwable-viewer) :transform-fn datafy/datafy}
+    :name :error :render-fn (quote v/throwable-viewer) :transform-fn (comp demunge-ex-data datafy/datafy)}
    {:pred (fn [_] true) :transform-fn pr-str :render-fn '(fn [x] (v/html [:span.inspected-value.whitespace-nowrap.text-gray-700 x]))}
    {:name :elision :render-fn (quote v/elision-viewer)}
    {:name :latex :render-fn (quote v/katex-viewer) :fetch-fn fetch-all}

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -85,7 +85,8 @@
 #_(update-doc! help-doc)
 
 (defn show-error! [e]
-  (broadcast! (view/ex->viewer e)))
+  (broadcast! (v/describe e)))
+
 
 #_(clojure.java.browse/browse-url "http://localhost:7777")
 

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -12,6 +12,7 @@
 
 (defonce !clients (atom #{}))
 (defonce !doc (atom help-doc))
+(defonce !error (atom nil))
 
 
 #_(view/doc->viewer @!doc)
@@ -74,18 +75,18 @@
         "_ws" {:status 200 :body "upgrading..."}
         {:status  200
          :headers {"Content-Type" "text/html"}
-         :body    (view/doc->html @!doc)})
+         :body    (view/doc->html @!doc @!error)})
       (catch Throwable e
         {:status  500
          :body    (with-out-str (pprint/pprint (Throwable->map e)))}))))
 
 (defn update-doc! [doc]
-  (broadcast! (view/doc->viewer (reset! !doc doc))))
+  (broadcast! {:doc (view/doc->viewer (reset! !doc doc))}))
 
 #_(update-doc! help-doc)
 
 (defn show-error! [e]
-  (broadcast! (v/describe e)))
+  (broadcast! {:error (reset! !error (v/describe e))}))
 
 
 #_(clojure.java.browse/browse-url "http://localhost:7777")


### PR DESCRIPTION
We change how an error is displayed in order to not lose the document scroll position when an error occurs.