### PR TITLE
Fix file watcher regression

### DIFF
--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -175,16 +175,14 @@
   "Returns whether `path` points to a file that should be shown."
   [path]
   ;; file names starting with .# are most likely Emacs lock files and should be ignored.
-  (->> path .getFileName .toString
-       (re-matches #"(?!^\.#).+\.(md|clj|cljc)$")
-       some?))
+  (some? (re-matches #"(?!^\.#).+\.(md|clj|cljc)$" (.. path getFileName toString))))
 
-#_(supported-file? (-> "foo_bar.clj" (java.nio.file.Paths/get (into-array String []))))
-#_(supported-file? (-> "xyz/foo.md" (java.nio.file.Paths/get (into-array String []))))
-#_(supported-file? (-> "xyz/foo.clj" (java.nio.file.Paths/get (into-array String []))))
-#_(supported-file? (-> "xyz/a.#name.cljc" (java.nio.file.Paths/get (into-array String []))))
-#_(supported-file? (-> ".#name.clj" (java.nio.file.Paths/get (into-array String []))))
-#_(supported-file? (-> "xyz/.#name.cljc" (java.nio.file.Paths/get (into-array String []))))
+#_(supported-file? (fs/path "foo_bar.clj"))
+#_(supported-file? (fs/path "xyz/foo.md"))
+#_(supported-file? (fs/path "xyz/foo.clj"))
+#_(supported-file? (fs/path "xyz/a.#name.cljc"))
+#_(supported-file? (fs/path ".#name.clj"))
+#_(supported-file? (fs/path "xyz/.#name.cljc"))
 
 
 (defn file-event [{:keys [type path]}]

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -175,16 +175,16 @@
   "Returns whether `path` points to a file that should be shown."
   [path]
   ;; file names starting with .# are most likely Emacs lock files and should be ignored.
-  (->> path io/file .getName
+  (->> path .getFileName .toString
        (re-matches #"(?!^\.#).+\.(md|clj|cljc)$")
        some?))
 
-#_(supported-file? "foo_bar.clj")
-#_(supported-file? "xyz/foo.md")
-#_(supported-file? "xyz/foo.clj")
-#_(supported-file? "xyz/abc.#name.cljc")
-#_(supported-file? ".#name.clj")
-#_(supported-file? "xyz/.#name.cljc")
+#_(supported-file? (-> "foo_bar.clj" (java.nio.file.Paths/get (into-array String []))))
+#_(supported-file? (-> "xyz/foo.md" (java.nio.file.Paths/get (into-array String []))))
+#_(supported-file? (-> "xyz/foo.clj" (java.nio.file.Paths/get (into-array String []))))
+#_(supported-file? (-> "xyz/a.#name.cljc" (java.nio.file.Paths/get (into-array String []))))
+#_(supported-file? (-> ".#name.clj" (java.nio.file.Paths/get (into-array String []))))
+#_(supported-file? (-> "xyz/.#name.cljc" (java.nio.file.Paths/get (into-array String []))))
 
 
 (defn file-event [{:keys [type path]}]


### PR DESCRIPTION
Hi,

could you please consider fix for issue #27.

It is caused by the recent #23 commit which uses a regexp against the modified filename to determine which files are supported to be shown by the browser.

The original commit converted the modified file's `Path` into an `io/file` for convenience and then extracted the filename as a `String`, but the `Path` to `io/file` conversion fails on OS X throwing an exception (as shown at the end).

The fix is to retrieve the filename string from the `Path` directly.

Also, it might be a good idea to have `clerk/file-event` `try` and `catch` any exception thrown instead of silently failing?

error thrown: (is this a bug?)
```clojure
:error #error {
 :cause No implementation of method: :as-file of protocol: #'clojure.java.io/Coercions found for class: sun.nio.fs.UnixPath
 :via
 [{:type java.lang.IllegalArgumentException
   :message No implementation of method: :as-file of protocol: #'clojure.java.io/Coercions found for class: sun.nio.fs.UnixPath
   :at [clojure.core$_cache_protocol_fn invokeStatic core_deftype.clj 583]}]
 :trace
 [[clojure.core$_cache_protocol_fn invokeStatic core_deftype.clj 583]
  [clojure.java.io$fn__11390$G__11372__11395 invoke io.clj 35]
  [clojure.java.io$file invokeStatic io.clj 424]
  [clojure.java.io$file invoke io.clj 418]
  [nextjournal.clerk$supported_file_QMARK_ invokeStatic NO_SOURCE_FILE 181]
  [nextjournal.clerk$supported_file_QMARK_ invoke NO_SOURCE_FILE 174]
  [nextjournal.clerk$file_event invokeStatic clerk.clj 211]
  [nextjournal.clerk$file_event invoke clerk.clj 209]
  [nextjournal.clerk$serve_BANG_$fn__18760 invoke clerk.clj 289]
  [nextjournal.beholder$fn$reify__6032 onEvent beholder.clj 13]
  [io.methvin.watcher.DirectoryWatcher onEvent DirectoryWatcher.java 352]
  [io.methvin.watcher.DirectoryWatcher watch DirectoryWatcher.java 297]
  [io.methvin.watcher.DirectoryWatcher lambda$watchAsync$0 DirectoryWatcher.java 212]
  [java.util.concurrent.CompletableFuture$AsyncSupply run CompletableFuture.java 1768]
  [java.util.concurrent.CompletableFuture$AsyncSupply exec CompletableFuture.java 1760]
  [java.util.concurrent.ForkJoinTask doExec ForkJoinTask.java 373]
  [java.util.concurrent.ForkJoinPool$WorkQueue topLevelExec ForkJoinPool.java 1182]
  [java.util.concurrent.ForkJoinPool scan ForkJoinPool.java 1655]
  [java.util.concurrent.ForkJoinPool runWorker ForkJoinPool.java 1622]
  [java.util.concurrent.ForkJoinWorkerThread run ForkJoinWorkerThread.java 165]]}
```

(Tested it to work on both OS X and MS Windows)

Thanks!