### PR TITLE
Include MS-Windows and OSX platforms in CI test runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,19 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.sys.os}}
+
+    strategy:
+      matrix:
+        sys:
+          - { os: macos-latest, shell: bash }
+          - { os: ubuntu-latest, shell: bash }
+          - { os: windows-latest, shell: powershell }
+
+    defaults:
+      run:
+        shell: ${{matrix.sys.shell}}
+
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Hi,

could you please consider an updated workflow action to include platform support for MS-Windows foremost as per #41 feature request, and OSX as a nice to have.

I hope introducing more CI work won't affect `nextjournal`'s CI accounting costs (I assume there is none).

The MS-Windows build currently is rightly failing due to https://github.com/nextjournal/viewers/issues/29, waiting for the https://github.com/nextjournal/viewers/pull/33 fix:

```
Run clojure -X:test
  clojure -X:test
  shell: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.EXE -command ". '{0}'"
  env:
    JAVA_HOME_11.0.7_x64: C:\hostedtoolcache\windows\jdk\11.0.7\x64
    JAVA_HOME: C:\hostedtoolcache\windows\jdk\11.0.7\x64
    JAVA_HOME_11_0_7_X64: C:\hostedtoolcache\windows\jdk\11.0.7\x64
Cloning: https://github.com/cognitect-labs/test-runner.git
Checking out: https://github.com/cognitect-labs/test-runner.git at 48c3c67f98362ba1e20526db4eeb6996209c050a
Downloading: org/clojure/tools.namespace/1.1.0/tools.namespace-1.1.0.pom from central
...

Running tests in #{"test"}
Execution error (PolyglotException) at sun.nio.fs.WindowsPathParser/normalize (WindowsPathParser.java:182).
java.nio.file.InvalidPathException: Illegal char <:> at index 4: file:/C:/Users/runneradmin/.m2/repository/io/github/nextjournal/markdown/0.1.38/markdown-0.1.38.jar!/js/markdown.mjs

Full report at:
C:\Users\RUNNER~1\AppData\Local\Temp\clojure-1443421123760716439.edn
Error: Process completed with exit code 1.
```

All ubuntu and os x tests are passing (not many tests at the moment, but demonstrate that they CI is working). 

Thanks