### PR TITLE
Add `halt!` to stop Clerk

### DIFF
--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -239,6 +239,12 @@
 
 #_(file->viewer "notebooks/rule_30.clj")
 
+(defn- stop-watcher! []
+  (when-let [{:keys [watcher paths]} @!watcher]
+    (println "Stopping old watcher for paths" (pr-str paths))
+    (beholder/stop watcher)
+    (reset! !watcher nil)))
+
 (defn serve!
   "Main entrypoint to Clerk taking an configurations map.
 
@@ -255,10 +261,7 @@
     :or {port 7777}}]
   (webserver/start! {:port port})
   (reset! !show-filter-fn show-filter-fn)
-  (when-let [{:keys [watcher paths]} @!watcher]
-    (println "Stopping old watcher for paths" (pr-str paths))
-    (beholder/stop watcher)
-    (reset! !watcher nil))
+  (stop-watcher!)
   (when (seq watch-paths)
     (println "Starting new watcher for paths" (pr-str watch-paths))
     (reset! !watcher {:paths watch-paths
@@ -266,6 +269,12 @@
   (when browse?
     (browse/browse-url (str "http://localhost:" port)))
   config)
+
+(defn halt!
+  "Stops the Clerk webserver and file watcher"
+  []
+  (webserver/stop!)
+  (stop-watcher!))
 
 #_(serve! {})
 #_(serve! {:browse? true})

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -239,7 +239,7 @@
 
 #_(file->viewer "notebooks/rule_30.clj")
 
-(defn- stop-watcher! []
+(defn- halt-watcher! []
   (when-let [{:keys [watcher paths]} @!watcher]
     (println "Stopping old watcher for paths" (pr-str paths))
     (beholder/stop watcher)
@@ -259,9 +259,9 @@
   [{:as config
     :keys [browse? watch-paths port show-filter-fn]
     :or {port 7777}}]
-  (webserver/start! {:port port})
+  (webserver/serve! {:port port})
   (reset! !show-filter-fn show-filter-fn)
-  (stop-watcher!)
+  (halt-watcher!)
   (when (seq watch-paths)
     (println "Starting new watcher for paths" (pr-str watch-paths))
     (reset! !watcher {:paths watch-paths
@@ -273,8 +273,8 @@
 (defn halt!
   "Stops the Clerk webserver and file watcher"
   []
-  (webserver/stop!)
-  (stop-watcher!))
+  (webserver/halt!)
+  (halt-watcher!))
 
 #_(serve! {})
 #_(serve! {:browse? true})

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -98,14 +98,14 @@
 
 (defonce !server (atom nil))
 
-(defn stop! []
+(defn halt! []
   (when-let [{:keys [port stop-fn]} @!server]
     (stop-fn)
     (println (str "Webserver running on " port ", stopped."))
     (reset! !server nil)))
 
-(defn start! [{:keys [port] :or {port 7777}}]
-  (stop!)
+(defn serve! [{:keys [port] :or {port 7777}}]
+  (halt!)
   (try
     (reset! !server {:port port :stop-fn (httpkit/run-server #'app {:port port})})
     (println (str "Clerk webserver started on " port "..."))

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -98,11 +98,14 @@
 
 (defonce !server (atom nil))
 
-(defn start! [{:keys [port] :or {port 7777}}]
+(defn stop! []
   (when-let [{:keys [port stop-fn]} @!server]
     (stop-fn)
-    (println (str "Webserver already running on " port ", stopped."))
-    (reset! !server nil))
+    (println (str "Webserver running on " port ", stopped."))
+    (reset! !server nil)))
+
+(defn start! [{:keys [port] :or {port 7777}}]
+  (stop!)
   (try
     (reset! !server {:port port :stop-fn (httpkit/run-server #'app {:port port})})
     (println (str "Clerk webserver started on " port "..."))


### PR DESCRIPTION
It would be great to be able to stop clerk via the repl using a single command. This PR achieves that by

1. Extracting the webserver stop code out of `nextjournal.clerk.webserver/start!` into the `stop!` function
2. Extracting the beholder stop code out of `nextjournal.clerk/serve!` into the `stop-watcher!` function
3. Adding a new function `nextjournal.clerk/halt!` that calls both functions from 1 and 2