### PR TITLE
Make evaluation/cache return variables instead of what they point to (for def/defn)

### DIFF
--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -58,8 +58,8 @@
      {:result ret#
       :time-ms (/ (double (- (. System (nanoTime)) start#)) 1000000.0)}))
 
-(defn- wrapped-var [var]
-  {::wrapped-var var})
+(defn- var-from-def [var]
+  {::var-from-def var})
 
 (defn- lookup-cached-result [results-last-run introduced-var hash cas-hash visibility]
   (try
@@ -67,7 +67,7 @@
                     (thaw-from-cas cas-hash))]
       (when introduced-var
         (intern *ns* (-> introduced-var symbol name symbol) value))
-      (wrapped-with-metadata (if introduced-var (wrapped-var introduced-var) value) visibility hash))
+      (wrapped-with-metadata (if introduced-var (var-from-def introduced-var) value) visibility hash))
     (catch Exception _e
       ;; TODO better report this error, anything that can't be read shouldn't be cached in the first place
       #_(prn :thaw-error e)
@@ -97,7 +97,7 @@
     (let [blob-id (cond no-cache? (view/->hash-str var-value)
                         (fn? var-value) nil
                         :else hash)]
-      (wrapped-with-metadata (cond-> result introduced-var wrapped-var) visibility blob-id))))
+      (wrapped-with-metadata (cond-> result introduced-var var-from-def) visibility blob-id))))
 
 (defn- ensure-cache-dir! []
   (let [cache-dir (config/cache-dir)]

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -73,7 +73,7 @@
   (try
     (let [value (or (get results-last-run hash)
                     (thaw-from-cas cas-hash))]
-      (when introduced-var
+      (when (and introduced-var (not (::var-from-def value)))
         (intern *ns* (-> introduced-var symbol name symbol) value))
       (wrapped-with-metadata (if introduced-var (var-from-def introduced-var) value) visibility hash))
     (catch Exception _e

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -59,7 +59,15 @@
       :time-ms (/ (double (- (. System (nanoTime)) start#)) 1000000.0)}))
 
 (defn- var-from-def [var]
-  {::var-from-def var})
+  (let [resolved-var (cond (var? var)
+                           var
+
+                           (symbol? var)
+                           (find-var var)
+
+                           :else
+                           (throw (ex-info "Unable to resolve into a variable" {:data var})))]
+    {::var-from-def resolved-var}))
 
 (defn- lookup-cached-result [results-last-run introduced-var hash cas-hash visibility]
   (try

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -77,13 +77,11 @@
       (fs/create-dirs (config/cache-dir)))
     (or (when (and (not no-cache?) cached?)
           (try
-            (let [{:as result :nextjournal/keys [value]} (wrapped-with-metadata (or (get results-last-run hash)
-                                                                                    (thaw-from-cas cas-hash))
-                                                                                visibility
-                                                                                hash)]
+            (let [value (or (get results-last-run hash)
+                            (thaw-from-cas cas-hash))]
               (when var
                 (intern *ns* (-> var symbol name symbol) value))
-              result)
+              (wrapped-with-metadata (if var var value) visibility hash))
             (catch Exception _e
               ;; TODO better report this error, anything that can't be read shouldn't be cached in the first place
               #_(prn :thaw-error e)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -157,8 +157,8 @@
 
 (defn fetch-all [_ x] x)
 
-(defn- wrapped-var? [x]
-  (get x :nextjournal.clerk/wrapped-var))
+(defn- var-from-def? [x]
+  (get x :nextjournal.clerk/var-from-def))
 
 (declare !viewers)
 
@@ -175,7 +175,7 @@
    {:pred boolean? :render-fn '(fn [x] (v/html [:span.syntax-bool.inspected-value (str x)]))}
    {:pred fn? :name :fn :render-fn '(fn [x] (v/html [:span.inspected-value [:span.syntax-tag "#function"] "[" x "]"]))}
    {:pred map-entry? :name :map-entry :render-fn '(fn [xs opts] (v/html (into [:<>] (comp (v/inspect-children opts) (interpose " ")) xs))) :fetch-opts {:n 2}}
-   {:pred wrapped-var? :transform-fn (fn [x] (-> x :nextjournal.clerk/wrapped-var deref))}
+   {:pred var-from-def? :transform-fn (fn [x] (-> x :nextjournal.clerk/var-from-def deref))}
    {:pred vector? :render-fn 'v/coll-viewer :opening-paren "[" :closing-paren "]" :fetch-opts {:n 20}}
    {:pred set? :render-fn 'v/coll-viewer :opening-paren "#{" :closing-paren "}" :fetch-opts {:n 20}}
    {:pred sequential? :render-fn 'v/coll-viewer :opening-paren "(" :closing-paren ")" :fetch-opts {:n 20}}

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -175,7 +175,7 @@
    {:pred boolean? :render-fn '(fn [x] (v/html [:span.syntax-bool.inspected-value (str x)]))}
    {:pred fn? :name :fn :render-fn '(fn [x] (v/html [:span.inspected-value [:span.syntax-tag "#function"] "[" x "]"]))}
    {:pred map-entry? :name :map-entry :render-fn '(fn [xs opts] (v/html (into [:<>] (comp (v/inspect-children opts) (interpose " ")) xs))) :fetch-opts {:n 2}}
-   {:pred wrapped-var? :transform-fn '(fn [x] (-> x :nextjournal.clerk/wrapped-var deref)) :render-fn '(fn [x] x)}
+   {:pred wrapped-var? :transform-fn (fn [x] (-> x :nextjournal.clerk/wrapped-var deref))}
    {:pred vector? :render-fn 'v/coll-viewer :opening-paren "[" :closing-paren "]" :fetch-opts {:n 20}}
    {:pred set? :render-fn 'v/coll-viewer :opening-paren "#{" :closing-paren "}" :fetch-opts {:n 20}}
    {:pred sequential? :render-fn 'v/coll-viewer :opening-paren "(" :closing-paren ")" :fetch-opts {:n 20}}

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -157,6 +157,9 @@
 
 (defn fetch-all [_ x] x)
 
+(defn- wrapped-var? [x]
+  (get x :nextjournal.clerk/wrapped-var))
+
 (declare !viewers)
 
 ;; keep viewer selection stricly in Clojure
@@ -172,6 +175,7 @@
    {:pred boolean? :render-fn '(fn [x] (v/html [:span.syntax-bool.inspected-value (str x)]))}
    {:pred fn? :name :fn :render-fn '(fn [x] (v/html [:span.inspected-value [:span.syntax-tag "#function"] "[" x "]"]))}
    {:pred map-entry? :name :map-entry :render-fn '(fn [xs opts] (v/html (into [:<>] (comp (v/inspect-children opts) (interpose " ")) xs))) :fetch-opts {:n 2}}
+   {:pred wrapped-var? :transform-fn '(fn [x] (-> x :nextjournal.clerk/wrapped-var deref)) :render-fn '(fn [x] x)}
    {:pred vector? :render-fn 'v/coll-viewer :opening-paren "[" :closing-paren "]" :fetch-opts {:n 20}}
    {:pred set? :render-fn 'v/coll-viewer :opening-paren "#{" :closing-paren "}" :fetch-opts {:n 20}}
    {:pred sequential? :render-fn 'v/coll-viewer :opening-paren "(" :closing-paren ")" :fetch-opts {:n 20}}

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -355,7 +355,8 @@
    (let [{:as opts :keys [viewers path offset]} (merge {:offset 0} opts)
          wrapped-value (try (wrapped-with-viewer xs viewers) ;; TODO: respect `viewers` on `xs`
                             (catch #?(:clj Exception :cljs js/Error) _ex
-                              nil))
+                              (do (println _ex)
+                                  nil)))
          {:as viewer :keys [fetch-opts fetch-fn]} (viewer wrapped-value)
          fetch-opts (merge fetch-opts (select-keys opts [:offset]))
          xs (value wrapped-value)]

--- a/test/nextjournal/clerk/hashing_test.clj
+++ b/test/nextjournal/clerk/hashing_test.clj
@@ -5,11 +5,9 @@
             [nextjournal.clerk.hashing :as h]
             [weavejester.dependency :as dep]))
 
-
 (defmacro with-ns-binding [ns-sym & body]
   `(binding [*ns* (find-ns ~ns-sym)]
      ~@body))
-
 
 (deftest no-cache?
   (testing "are variables set to no-cache?"

--- a/test/nextjournal/clerk_test.clj
+++ b/test/nextjournal/clerk_test.clj
@@ -71,6 +71,6 @@
         (is (= 99 (lookup-var-in-*ns* "some-var"))))
 
       (testing ".. even if we load it from the cache after a fresh start"
-        (is (match? {:nextjournal/value (symbol (str *ns*) "some-var")}
+        (is (match? {:nextjournal/value {::clerk/wrapped-var (symbol (str *ns*) "some-var")}}
                     (clerk/read+eval-cached {blob-id -100} {} #{:show} "(def some-var 99)")))
         (is (= -100 (lookup-var-in-*ns* "some-var")))))))

--- a/test/nextjournal/clerk_test.clj
+++ b/test/nextjournal/clerk_test.clj
@@ -3,7 +3,9 @@
             [clojure.java.browse :as browse]
             [clojure.string :as str]
             [clojure.test :refer :all]
-            [nextjournal.clerk :as clerk])
+            [matcher-combinators.test :refer [match?]]
+            [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.hashing :as hashing])
   (:import (java.io File)))
 
 (deftest url-canonicalize
@@ -22,3 +24,53 @@
             (clerk/build-static-app! {:paths ["notebooks/hello.clj"]
                                       :out-path temp})
             (is (= expected @url*))))))))
+
+(defn- lookup-var-in-*ns* [var-name]
+ @(find-var (symbol (str *ns*) var-name)))
+
+(deftest read+eval-cached
+  (testing "basic eval'ing will give a result with a hash"
+    (let [first-run (clerk/read+eval-cached {} {} #{:show} "{:x (inc 10)}")]
+      (is (match? {:nextjournal/value            {:x 11}
+                   :nextjournal.clerk/visibility #{:show}
+                   :nextjournal/blob-id          any?}
+                  first-run))
+      (testing "the 'previous results' cache takes first precedence"
+        (is (match? {:nextjournal/value :hacked}
+                    (clerk/read+eval-cached {(:nextjournal/blob-id first-run) :hacked}
+                                            {}
+                                            #{:show}
+                                            "{:x (inc 10)}"))))))
+
+  (testing "eval'ing stores results in a cache"
+    ;; ensure "a-var" is a variable in whatever namespace we're running in
+    (intern *ns* 'a-var 0)
+
+    (is (match? {:nextjournal/value 1}
+                (clerk/read+eval-cached {} {} #{:show} "(inc a-var)")))
+
+    ;; sneakily change the var under the hood
+    (with-redefs [hashing/no-cache? (constantly true)]
+      (clerk/read+eval-cached {} {} #{:show} "(alter-var-root #'a-var inc)"))
+
+    (testing "the expression is cached and we don't see the change to `a-var`"
+      (is (match? {:nextjournal/value 1}
+                  (clerk/read+eval-cached {} {} #{:show} "(inc a-var)"))))
+
+    (testing "with caching off, we get the freshly altered result"
+      (with-redefs [hashing/no-cache? (constantly true)]
+        (is (match? {:nextjournal/value 2}
+                    (clerk/read+eval-cached {} {} #{:show} "(inc a-var)"))))))
+
+  (testing "handling binding forms i.e. def, defn"
+    ;; ensure "some-var" is a variable in whatever namespace we're running in
+    (intern *ns* 'some-var 0)
+
+    (let [{:nextjournal/keys [blob-id]} (clerk/read+eval-cached {} {} #{:show} "(def some-var 99)")]
+      (testing "the variable is properly defined"
+        (is (= 99 (lookup-var-in-*ns* "some-var"))))
+
+      (testing ".. even if we load it from the cache after a fresh start"
+        (is (match? {:nextjournal/value (symbol (str *ns*) "some-var")}
+                    (clerk/read+eval-cached {blob-id -100} {} #{:show} "(def some-var 99)")))
+        (is (= -100 (lookup-var-in-*ns* "some-var")))))))

--- a/test/nextjournal/clerk_test.clj
+++ b/test/nextjournal/clerk_test.clj
@@ -71,6 +71,6 @@
         (is (= 99 (lookup-var-in-*ns* "some-var"))))
 
       (testing ".. even if we load it from the cache after a fresh start"
-        (is (match? {:nextjournal/value {::clerk/wrapped-var (symbol (str *ns*) "some-var")}}
+        (is (match? {:nextjournal/value {::clerk/var-from-def (symbol (str *ns*) "some-var")}}
                     (clerk/read+eval-cached {blob-id -100} {} #{:show} "(def some-var 99)")))
         (is (= -100 (lookup-var-in-*ns* "some-var")))))))

--- a/test/nextjournal/clerk_test.clj
+++ b/test/nextjournal/clerk_test.clj
@@ -71,6 +71,7 @@
         (is (= 99 (lookup-var-in-*ns* "some-var"))))
 
       (testing ".. even if we load it from the cache after a fresh start"
-        (is (match? {:nextjournal/value {::clerk/var-from-def (symbol (str *ns*) "some-var")}}
+        (is (match? {:nextjournal/value {::clerk/var-from-def #(= "some-var"
+                                                                  (-> % symbol name))}}
                     (clerk/read+eval-cached {blob-id -100} {} #{:show} "(def some-var 99)")))
         (is (= -100 (lookup-var-in-*ns* "some-var")))))))


### PR DESCRIPTION
We'd like to allow for different ways to run and render tests from within notebooks.
`clojure.test`'s `deftest` defines a variable with a `:test` metadata field present. It would be great to have this at render time, but clerk currently resolves variables returned by `def` and `defn` into what they point to. The changes here defer this resolution to the viewer so that we can add a viewer that checks for test meta-data and either hides or executes and shows results. We still don't want to resolve normal vars (that are the result of non-def/defn expression evaluation), so I introduced a `wrapped-var` to distinguish between the two.

The PR also:
 - adds test coverage for `read+eval-cached`
 - breaks up `read+eval-cached` into smaller functions. Let me if I went too overboard here; many well-named and small functions helps me with code readability but that might be the case for everyone.

open issues to be resolved:
 - rendering definition that returns a different var is broken
 - rendering `deftest` results in a string result when it should be render a function

![20220106_16h18m54s_grim](https://user-images.githubusercontent.com/94817/148405766-1e4813d4-9db0-4de8-b8e9-fbb313fbf70e.png)

