### PR TITLE
Introduce print budget to elide deeply nested structures

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -42,6 +42,7 @@
            :demo {:extra-deps {com.github.seancorfield/next.jdbc {:mvn/version "1.2.659"}
                                org.xerial/sqlite-jdbc {:mvn/version "3.34.0"}
                                org.clojure/data.csv {:mvn/version "1.0.0"}
+                               hickory/hickory {:mvn/version "0.7.1"}
                                sicmutils/sicmutils {:mvn/version "0.20.0"}}}
 
            :build {:deps {io.github.clojure/tools.build {:git/tag "v0.6.1" :git/sha "515b334"}

--- a/notebooks/deep.clj
+++ b/notebooks/deep.clj
@@ -3,6 +3,8 @@
 
 (reduce (fn [acc i] (vector acc)) :fin (range 30 0 -1))
 
+(reduce (fn [acc i] (vector acc)) :fin (range 300 0 -1))
+
 (reduce (fn [acc i] (vector i acc)) (range 30 0 -1))
 
 (reduce (fn [acc i] (vector acc i)) (range 30 0 -1))
@@ -13,7 +15,4 @@
 
 (reduce (fn [acc i] (vector #{i} i acc (inc i) #{(inc i)})) :fin (range 30 0 -1))
 
-(-> "https://github.com/davidsantiago/hickory"
-    slurp
-    hick/parse
-    hick/as-hickory)
+(-> "https://github.com/davidsantiago/hickory" slurp hick/parse hick/as-hickory)

--- a/notebooks/deep.clj
+++ b/notebooks/deep.clj
@@ -1,0 +1,13 @@
+(ns ^:nextjournal.clerk/no-cache deep)
+
+(reduce (fn [acc i] (vector acc)) :fin (range 30 0 -1))
+
+(reduce (fn [acc i] (vector i acc)) (range 30 0 -1))
+
+(reduce (fn [acc i] (vector acc i)) (range 30 0 -1))
+
+(reduce (fn [acc i] (vector i [i (inc i)] acc)) (range 30 0 -1))
+
+(reduce (fn [acc i] (vector i acc (inc i))) :fin (range 30 0 -1))
+
+(reduce (fn [acc i] (vector #{i} i acc (inc i) #{(inc i)})) :fin (range 30 0 -1))

--- a/notebooks/deep.clj
+++ b/notebooks/deep.clj
@@ -1,4 +1,5 @@
-(ns ^:nextjournal.clerk/no-cache deep)
+(ns ^:nextjournal.clerk/no-cache deep
+  (:require [hickory.core :as hick]))
 
 (reduce (fn [acc i] (vector acc)) :fin (range 30 0 -1))
 
@@ -11,3 +12,8 @@
 (reduce (fn [acc i] (vector i acc (inc i))) :fin (range 30 0 -1))
 
 (reduce (fn [acc i] (vector #{i} i acc (inc i) #{(inc i)})) :fin (range 30 0 -1))
+
+(-> "https://github.com/davidsantiago/hickory"
+    slurp
+    hick/parse
+    hick/as-hickory)

--- a/notebooks/deep.clj
+++ b/notebooks/deep.clj
@@ -1,18 +1,34 @@
+;; # 🕳 Deep Data
+^{:nextjournal.clerk/visibility :hide-ns}
 (ns ^:nextjournal.clerk/no-cache deep
-  (:require [hickory.core :as hick]))
-
-(reduce (fn [acc i] (vector acc)) :fin (range 30 0 -1))
+  (:require [clojure.string :as str]
+            [hickory.core :as hick]
+            [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.viewer :as viewer]))
 
 (reduce (fn [acc i] (vector acc)) :fin (range 300 0 -1))
 
-(reduce (fn [acc i] (vector i acc)) (range 30 0 -1))
+(reduce (fn [acc i] (vector acc)) :fin (range 300 0 -1))
 
-(reduce (fn [acc i] (vector acc i)) (range 30 0 -1))
+(reduce (fn [acc i] (vector i acc)) (range 300 0 -1))
 
-(reduce (fn [acc i] (vector i [i (inc i)] acc)) (range 30 0 -1))
+(reduce (fn [acc i] (vector acc i)) (range 300 0 -1))
 
-(reduce (fn [acc i] (vector i acc (inc i))) :fin (range 30 0 -1))
+(reduce (fn [acc i] (vector i [i (inc i)] acc)) (range 300 0 -1))
 
-(reduce (fn [acc i] (vector #{i} i acc (inc i) #{(inc i)})) :fin (range 30 0 -1))
+(reduce (fn [acc i] (vector i acc (inc i))) :fin (range 300 0 -1))
+
+(reduce (fn [acc i] (vector #{i} i acc (inc i) #{(inc i)})) :fin (range 300 0 -1))
 
 (-> "https://github.com/davidsantiago/hickory" slurp hick/parse hick/as-hickory)
+
+(def letters->words
+  (->> "/usr/share/dict/words"
+       slurp
+       str/split-lines
+       (group-by (comp keyword str/lower-case first))
+       (into (sorted-map))))
+
+(clerk/table {:nextjournal/width :full} letters->words)
+
+(clerk/table (repeat 100 (range 100)))

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -161,7 +161,7 @@
 (def resource->static-url
   {"/css/app.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VxQBDwk3cvr1bt8YVL5m6bJGrFEmzrSbCrH1roypLjJr4AbbteCKh9Y6gQVYexdY85QA2HG5nQFLWpRp69zFSPDJ9"
    "/css/viewer.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvykE47cdahchdt8fxwHyYwJ7YSmEFcMSyqf4UNs61izpuF1xXpKA4HeZQctDkkU11B5iLVSBjpCQrk5f5mWXS9xv"
-   "/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VwZ1EdFVyCUZE8PXjByuKqwAtpvRWGZr1pJYFceiTFHVCs6tFr8Xfc2REHtiwXhwB4XrWzud77FTMXoBAxvr5URcb"})
+   "/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8Vw5gbdRsRKfPVC3GCyLhvHvgZj8hiwVPW86DYnSKCQ621xYr4odJc7rvUbpSDh1Hm3TbtLWbMp5pYFCqcLzAtGZjF"})
 
 (defn ->html [{:keys [conn-ws? live-js?] :or {conn-ws? true live-js? live-js?}} state]
   (hiccup/html5

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -446,9 +446,10 @@
                       (cond-> children
                         (or (not count) (< (inc offset) count))
 
-                        (conj (with-viewer* :elision
-                                (cond-> (assoc count-opts :offset (inc offset) :path path :source {:count count :offset offset :< (< (inc offset) count)})
-                                  count (assoc :remaining (- count (inc offset))))))))
+                        (conj (do (when graph ((:insert-edge! opts) opts (conj path (inc offset)) xs '...))
+                                  (with-viewer* :elision
+                                    (cond-> (assoc count-opts :offset (inc offset) :path path :source {:count count :offset offset :< (< (inc offset) count)})
+                                      count (assoc :remaining (- count (inc offset)))))))))
 
                     :else ;; leaf value
                     xs))))))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -392,7 +392,7 @@
                                         {:count (count xs)}
                                         (bounded-count-opts (:n fetch-opts) xs))
                           fetch-opts (cond-> fetch-opts
-                                       (:n fetch-opts)
+                                       (and (:n fetch-opts) (not (map-entry? xs)))
                                        (update :n min @!budget))
                           children (into []
                                          (comp (if (number? (:n fetch-opts)) (drop+take-xf fetch-opts) identity)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -348,10 +348,9 @@
    (describe xs {}))
   ([xs opts]
    (assign-closing-parens
-    (describe xs (merge #?(:clj (some-> 'setup-arrowic-graph resolve (apply [])))
-                        {:!budget (atom 200) :path [] :viewers (process-fns (get-viewers *ns* (viewers xs)))} opts) [])))
+    (describe xs (merge {:!budget (atom (:budget opts 200)) :path [] :viewers (process-fns (get-viewers *ns* (viewers xs)))} opts) [])))
   ([xs opts current-path]
-   (let [{:as opts :keys [!budget graph viewers path offset]} (merge {:offset 0} opts)
+   (let [{:as opts :keys [!budget viewers path offset]} (merge {:offset 0} opts)
          wrapped-value (try (wrapped-with-viewer xs viewers) ;; TODO: respect `viewers` on `xs`
                             (catch #?(:clj Exception :cljs js/Error) _ex
                               nil))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -367,7 +367,7 @@
    (assign-closing-parens
     (describe xs (merge {#_#_:graph (arrowic/create-graph) :path [] :viewers (process-fns (get-viewers *ns* (viewers xs)))} opts) [])))
   ([xs opts current-path]
-   (let [{:as opts :keys [budget graph viewers path offset]} (merge {:offset 0 :budget 5} opts)
+   (let [{:as opts :keys [depth-budget graph viewers path offset]} (merge {:offset 0 :depth-budget 10} opts)
          wrapped-value (try (wrapped-with-viewer xs viewers) ;; TODO: respect `viewers` on `xs`
                             (catch #?(:clj Exception :cljs js/Error) _ex
                               nil))
@@ -375,7 +375,7 @@
          fetch-opts (merge fetch-opts (select-keys opts [:offset]))
          xs (value wrapped-value)]
      #_(prn :xs xs :type (type xs) :path path :current-path current-path)
-     (if-not (pos? (cond-> budget
+     (if-not (pos? (cond-> depth-budget
                      (and xs (not (string? xs)) (seqable? xs))
                      dec))
        (with-viewer* :elision {:path path :source :root})
@@ -421,7 +421,7 @@
 
                                                                 (describe x (-> opts
                                                                                 (dissoc :offset)
-                                                                                (update :budget dec)
+                                                                                (update :depth-budget dec)
                                                                                 (update :path conj (+ i offset))) (conj current-path i))))
                                                  (remove nil?))
                                            (ensure-sorted xs))
@@ -437,6 +437,8 @@
 
                       :else ;; leaf value
                       xs)))))))
+
+
 
 
 (comment

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -36,13 +36,12 @@
       (is (= value (describe+fetch value)))))
 
   (testing "deep vector with element after"
-    (let [value (reduce (fn [acc i] (vector acc i)) :fin (range 19 0 -1))]
+    (let [value (reduce (fn [acc i] (vector acc i)) :fin (range 20 0 -1))]
       (is (= value (describe+fetch value)))))
 
   (testing "deep vector with elements around"
-    (let [value (reduce (fn [acc i] (vector i acc (inc i))) :fin (range 15 0 -1))]
+    (let [value (reduce (fn [acc i] (vector i acc (inc i))) :fin (range 10 0 -1))]
       (is (= value (describe+fetch value))))))
-
 
 (deftest assign-closing-parens
   (testing "closing parenthesis are moved to right-most children in the tree"

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -26,14 +26,31 @@
       ;; `str/join` is needed here because elided strings get turned into vector of segments
       (is (= value (str/join (v/desc->values (v/merge-descriptions desc more)))))))
 
-  (testing "deeply nested"
-    (let [value (reduce (fn [acc i] (vector i acc)) :fin (range 7 0 -1))
+  (testing "deep vector"
+    (let [value (reduce (fn [acc i] (vector acc)) :fin (range 7 0 -1))
           desc (v/describe value)
           path [0 0 0]
           elision (peek (get-in desc (v/path-to-value path)))
           more (v/describe value (:nextjournal/value elision))]
       (is (= value (v/desc->values (v/merge-descriptions desc more))))))
+
+  (testing "deep vector with element"
+    (let [value (reduce (fn [acc i] (vector i acc)) :fin (range 7 0 -1))
+          desc (v/describe value)
+          path [1 1 1]
+          elision (peek (get-in desc (v/path-to-value path)))
+          more (v/describe value (:nextjournal/value elision))]
+      (is (= value (v/desc->values (v/merge-descriptions desc more))))))
+
+  (testing "deep vector with elements"
+    (let [value (reduce (fn [acc i] (vector i acc (inc i))) :fin (range 7 0 -1))
+          desc (v/describe value)
+          path [1 1 1]
+          elision (get (get-in desc (v/path-to-value path)) 1)
+          more (v/describe value (:nextjournal/value elision))]
+      (is (= value (v/desc->values (v/merge-descriptions desc more))))))
   )
+
 
 (deftest assign-closing-parens
   (testing "closing parenthesis are moved to right-most children in the tree"

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -8,7 +8,7 @@
                  (tree-seq (comp vector? :nextjournal/value) :nextjournal/value desc))))
 
 (defn describe+fetch [value]
-  (let [desc (v/describe value)
+  (let [desc (v/describe value {:depth-budget 5})
         elision (find-elision desc)
         more (v/describe value (:nextjournal/value elision))]
     (v/desc->values (v/merge-descriptions desc more))))
@@ -48,7 +48,7 @@
   (testing "closing parenthesis are moved to right-most children in the tree"
     (let [before (v/describe {:a [1 '(2 3 #{4})]
                               :b '([5 6] 7 8)}
-                             {:viewers (v/get-viewers nil) :budget 10}
+                             {:viewers (v/get-viewers nil)}
                              [])
           after (v/assign-closing-parens before)]
 

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -26,6 +26,13 @@
       ;; `str/join` is needed here because elided strings get turned into vector of segments
       (is (= value (str/join (v/desc->values (v/merge-descriptions desc more)))))))
 
+  (testing "deeply nested"
+    (let [value (reduce (fn [acc i] (vector i acc)) :fin (range 7 0 -1))
+          desc (v/describe value)
+          path [0 0 0]
+          elision (peek (get-in desc (v/path-to-value path)))
+          more (v/describe value (:nextjournal/value elision))]
+      (is (= value (v/desc->values (v/merge-descriptions desc more))))))
   )
 
 (deftest assign-closing-parens

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -51,6 +51,23 @@
       (is (= value (v/desc->values (v/merge-descriptions desc more))))))
   )
 
+(let [value (reduce (fn [acc i] (vector i acc (inc i))) :fin (range 7 0 -1))
+      desc (v/describe value)
+      path [1 1 1]
+      elision (get (get-in desc (v/path-to-value path)) 1)
+      more (v/describe value (:nextjournal/value elision))]
+  (is (= value (v/desc->values (v/merge-descriptions desc more)))))
+
+
+
+(let [value (reduce (fn [acc i] (vector i acc)) :fin (range 7 0 -1))
+      desc (v/describe value)
+      path [1 1 1]
+      elision (peek (get-in desc (v/path-to-value path)))
+      more (v/describe value (:nextjournal/value elision))]
+  (v/desc->values (v/merge-descriptions desc more))
+  elision
+  more)
 
 (deftest assign-closing-parens
   (testing "closing parenthesis are moved to right-most children in the tree"

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -8,7 +8,7 @@
                  (tree-seq (comp vector? :nextjournal/value) :nextjournal/value desc))))
 
 (defn describe+fetch [value]
-  (let [desc (v/describe value {:depth-budget 5})
+  (let [desc (v/describe value {:budget 21})
         elision (find-elision desc)
         more (v/describe value (:nextjournal/value elision))]
     (v/desc->values (v/merge-descriptions desc more))))
@@ -28,19 +28,19 @@
       (is (= value (str/join (describe+fetch value))))))
 
   (testing "deep vector"
-    (let [value (reduce (fn [acc i] (vector acc)) :fin (range 7 0 -1))]
+    (let [value (reduce (fn [acc i] (vector acc)) :fin (range 30 0 -1))]
       (is (= value (describe+fetch value)))))
 
   (testing "deep vector with element before"
-    (let [value (reduce (fn [acc i] (vector i acc)) :fin (range 7 0 -1))]
+    (let [value (reduce (fn [acc i] (vector i acc)) :fin (range 15 0 -1))]
       (is (= value (describe+fetch value)))))
 
   (testing "deep vector with element after"
-    (let [value (reduce (fn [acc i] (vector acc i)) :fin (range 7 0 -1))]
+    (let [value (reduce (fn [acc i] (vector acc i)) :fin (range 19 0 -1))]
       (is (= value (describe+fetch value)))))
 
   (testing "deep vector with elements around"
-    (let [value (reduce (fn [acc i] (vector i acc (inc i))) :fin (range 7 0 -1))]
+    (let [value (reduce (fn [acc i] (vector i acc (inc i))) :fin (range 15 0 -1))]
       (is (= value (describe+fetch value))))))
 
 
@@ -48,7 +48,7 @@
   (testing "closing parenthesis are moved to right-most children in the tree"
     (let [before (v/describe {:a [1 '(2 3 #{4})]
                               :b '([5 6] 7 8)}
-                             {:viewers (v/get-viewers nil)}
+                             {:viewers (v/get-viewers nil) :!budget (atom 20)}
                              [])
           after (v/assign-closing-parens before)]
 

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -1,37 +1,63 @@
 (ns nextjournal.clerk.viewer-test
-  (:require [clojure.test :refer :all]
-            [nextjournal.clerk.viewer :as viewer]))
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
+            [nextjournal.clerk.viewer :as v]))
+
+(deftest merge-descriptions
+  (testing "range"
+    (let [value (range 30)
+          desc (v/describe value)
+          elision (peek (get-in desc (v/path-to-value [])))
+          more (v/describe value (:nextjournal/value elision))]
+      (is (= value (v/desc->values (v/merge-descriptions desc more))))))
+
+  (testing "nested range"
+    (let [value [(range 30)]
+          desc (v/describe value)
+          elision (peek (get-in desc (v/path-to-value [0])))
+          more (v/describe value (:nextjournal/value elision))]
+      (is (= value (v/desc->values (v/merge-descriptions desc more))))))
+
+  (testing "string"
+    (let [value (str/join (map #(str/join (repeat 70 %)) ["a" "b"]))
+          desc (v/describe value)
+          elision (peek (get-in desc (v/path-to-value [])))
+          more (v/describe value (:nextjournal/value elision))]
+      ;; `str/join` is needed here because elided strings get turned into vector of segments
+      (is (= value (str/join (v/desc->values (v/merge-descriptions desc more)))))))
+
+  )
 
 (deftest assign-closing-parens
   (testing "closing parenthesis are moved to right-most children in the tree"
-    (let [before (viewer/describe {:a [1 '(2 3 #{4})]
-                                   :b '([5 6] 7 8)}
-                                  {:viewers (viewer/get-viewers nil)}
-                                  [])
-          after (viewer/assign-closing-parens before)]
+    (let [before (v/describe {:a [1 '(2 3 #{4})]
+                              :b '([5 6] 7 8)}
+                             {:viewers (v/get-viewers nil)}
+                             [])
+          after (v/assign-closing-parens before)]
 
       (is (= "}"
              (-> before
-                 (get-in (viewer/path-to-value [0 1 1]))
+                 (get-in (v/path-to-value [0 1 1]))
                  (get 2)
-                 viewer/viewer
+                 v/viewer
                  :closing-paren)))
       (is (= ")"
              (-> before
-                 (get-in (viewer/path-to-value [1]))
+                 (get-in (v/path-to-value [1]))
                  (get 1)
-                 viewer/viewer
+                 v/viewer
                  :closing-paren)))
 
       (is (= '( "}" ")" "]")
              (-> after
-                 (get-in (viewer/path-to-value [0 1 1]))
+                 (get-in (v/path-to-value [0 1 1]))
                  (get 2)
-                 viewer/viewer
+                 v/viewer
                  :closing-paren)))
       (is (= '(")" "}")
              (-> after
-                 (get-in (viewer/path-to-value [1]))
+                 (get-in (v/path-to-value [1]))
                  (get 1)
-                 viewer/viewer
+                 v/viewer
                  :closing-paren))))))


### PR DESCRIPTION
Limit the amount of data that Clerk would send to the browser by introducing a global print budget per result, defaulting to 200. For now, we opt out of this budget handling for tables and map entries.