### PR TITLE
First cut of image viewer

### DIFF
--- a/notebooks/viewers/image.clj
+++ b/notebooks/viewers/image.clj
@@ -1,12 +1,17 @@
 ;; # 🏞 Image Viewer
-(ns ^:nextjournal.clerk/no-cache image
+(ns image
   (:import (java.net URL)
            (javax.imageio ImageIO)))
 
-;; Clerk now comes with a default viewer for `java.awt.image.BufferedImage`.
-
+;; Clerk now comes with a default viewer for `java.awt.image.BufferedImage`. It looks at the dimensions of the image, and tries to do the right thing. For an image larger than 900px wide with an aspect ratio larger 2, it uses full width.
 (ImageIO/read (URL. "https://images.unsplash.com/photo-1532879311112-62b7188d28ce?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8"))
 
+;; A large image with an aspect ratio smaller 2 is shown wider.
 (ImageIO/read (URL. "https://images.freeimages.com/images/large-previews/773/koldalen-4-1384902.jpg"))
 
-#_(nextjournal.clerk/show! "notebooks/viewers/image.clj")
+;; Smaller images are centered and shown using thier intrinsic dimensions.
+(ImageIO/read (URL. "https://etc.usf.edu/clipart/36600/36667/thermos_36667_sm.gif"))
+
+(ImageIO/read (URL. "https://etc.usf.edu/clipart/186600/186669/186669-trees-in-the-winter_sm.gif"))
+
+(ImageIO/read (URL. "https://nextjournal.com/data/QmUyFWw9L8nZ6wvFTfJvtyqxtDyJiAr7EDZQxLVn64HASX?filename=Requiem-Ornaments-Byline.png&content-type=image/png"))

--- a/notebooks/viewers/image.clj
+++ b/notebooks/viewers/image.clj
@@ -4,6 +4,9 @@
            (javax.imageio ImageIO)))
 
 ;; Clerk now comes with a default viewer for `java.awt.image.BufferedImage`.
+
 (ImageIO/read (URL. "https://images.unsplash.com/photo-1532879311112-62b7188d28ce?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8"))
+
+(ImageIO/read (URL. "https://images.freeimages.com/images/large-previews/773/koldalen-4-1384902.jpg"))
 
 #_(nextjournal.clerk/show! "notebooks/viewers/image.clj")

--- a/notebooks/viewers/image.clj
+++ b/notebooks/viewers/image.clj
@@ -1,19 +1,9 @@
-;; # 🏞 Customizing Fetch
-;; Showing how to use a custom `fetch-fn` with a `content-type` to let Clerk serve arbitrary things, in this case a PNG image.
+;; # 🏞 Image Viewer
 (ns ^:nextjournal.clerk/no-cache image
-  (:require [nextjournal.clerk :as clerk]
-            [nextjournal.clerk.viewer :as v])
-  (:import (java.net.http HttpRequest HttpClient HttpResponse$BodyHandlers)
-           (java.net URI)))
+  (:import (java.net URL)
+           (javax.imageio ImageIO)))
 
-;; We set a custom viewer for `bytes?` that includes a `:fetch-fn`, returning a wrapped value with a `:nextjournal/content-type` key set.
-(clerk/set-viewers! [{:pred bytes?
-                      :fetch-fn (fn [_ bytes] {:nextjournal/content-type "image/png"
-                                               :nextjournal/value bytes})
-                      :render-fn '(fn [blob] (v/html [:img {:src (v/url-for blob)}]))}])
-
-(.. (HttpClient/newHttpClient)
-    (send (.build (HttpRequest/newBuilder (URI. "https://upload.wikimedia.org/wikipedia/commons/5/57/James_Clerk_Maxwell.png")))
-          (HttpResponse$BodyHandlers/ofByteArray)) body)
+;; Clerk now comes with a default viewer for `java.awt.image.BufferedImage`.
+(ImageIO/read (URL. "https://images.unsplash.com/photo-1532879311112-62b7188d28ce?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8"))
 
 #_(nextjournal.clerk/show! "notebooks/viewers/image.clj")

--- a/notebooks/viewers/image_layouts.clj
+++ b/notebooks/viewers/image_layouts.clj
@@ -1,0 +1,154 @@
+;; # Image Layouts 🎑 🌁 🏞
+;;
+;; A list of image samples in different layouts that best suit the images
+;; aspect ratio.
+
+(ns ^:nextjournal.clerk/no-cache image-layouts
+  (:require [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.viewer :as v]))
+
+;; ## Viewport width, height based on aspect ratio (or fixed)
+;; * Examples: `3:1`, `4:1`
+;; * Default for `2 < ratio` and `content width < intrinsic width`
+
+(merge
+  {:nextjournal/width :full}
+  (clerk/html
+    [:figure
+     [:img
+      {:class "w-full"
+       :src "https://images.unsplash.com/photo-1532879311112-62b7188d28ce?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8"}]
+     [:figcaption.max-w-prose.mx-auto.px-8.text-sm.text-slate-500.sans-serif.mt-2
+      "Viewport width, height based on aspect ratio"]]))
+
+(merge
+  {:nextjournal/width :full}
+  (clerk/html
+    [:figure
+     [:img
+      {:class "w-full object-cover h-[300px]"
+       :src "https://images.unsplash.com/photo-1532879311112-62b7188d28ce?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8"}]
+     [:figcaption.max-w-prose.mx-auto.px-8.text-sm.text-slate-500.sans-serif.mt-2
+      "Viewport width, fixed height"]]))
+
+;; ## Content width, height based on aspect ratio (or fixed)
+;; * Examples: `1.91:1`, `2:1`, `3:2`, `4:3`, `16:9`
+;; * Default for `1 < ratio < 2` and `content width <= intrinsic width`
+
+(clerk/html
+  [:figure.not-prose
+   [:img
+    {:class "w-full"
+     :src "https://images.freeimages.com/images/large-previews/773/koldalen-4-1384902.jpg"}]
+   [:figcaption.max-w-prose.px-8.text-sm.text-slate-500.sans-serif.mt-2
+    "Content width, height based on aspect ratio"]])
+
+(clerk/html
+  [:figure.not-prose
+   [:img
+    {:class "w-full object-cover h-[300px]"
+     :src "https://images.freeimages.com/images/large-previews/773/koldalen-4-1384902.jpg"}]
+   [:figcaption.text-sm.text-slate-500.sans-serif.mt-2
+    "Content width, fixed height"]])
+
+;; ## Intrinsic dimensions (or fixed dimensions)
+;; * Examples: `1:1`, `2:3`, `9:16`
+;; * Default for `ratio <= 1` and `intrinsic width <= content width`
+
+(clerk/html
+  [:figure.not-prose.flex.flex-col.items-center
+   [:img
+    {:src "https://etc.usf.edu/clipart/36600/36667/thermos_36667_sm.gif"}]
+   [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
+    "Intrinsic width, height based on aspect ratio"]])
+
+(clerk/html
+  [:figure.not-prose.flex.flex-col.items-center
+   [:img.object-contain
+    {:class "object-contain w-[300px] h-[300px]"
+     :src "https://etc.usf.edu/clipart/186600/186669/186669-trees-in-the-winter_sm.gif"}]
+   [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
+    "Fixed width and height"]])
+
+;; ## Bonus Mission: Grids!
+;; * auto-sizes based on content width
+;; * or uses fixed cell dimensions
+;; * Default layouts: single row for `image count < 4`, then adds rows based on count
+
+;; ### Single row, auto-sizing cells
+
+(clerk/html
+  [:div.not-prose.grid.grid-cols-3.gap-6
+   [:figure.not-prose.flex.flex-col.items-center.justify-end
+    [:img
+     {:class "object-contain"
+      :src "https://etc.usf.edu/clipart/16200/16224/snowflake3_16224_sm.gif"}]
+    [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
+     "1-1"]]
+   [:figure.not-prose.flex.flex-col.items-center.justify-end
+    [:img
+     {:class "object-contain"
+      :src "https://etc.usf.edu/clipart/16200/16226/snowflake5_16226_sm.gif"}]
+    [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
+     "1-2"]]
+   [:figure.not-prose.flex.flex-col.items-center.justify-end
+    [:img
+     {:class "object-contain"
+      :src "https://etc.usf.edu/clipart/16200/16228/snowflake6_16228_sm.gif"}]
+    [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
+     "1-3"]]])
+
+;; ### Multiple rows, fixed layout (4 columns), fixed cell size
+
+(clerk/html
+  [:div.not-prose.grid.grid-cols-4.gap-6
+   [:figure.not-prose.flex.flex-col.items-center.justify-end
+    [:img
+     {:class "object-contain w-[100px] h-[100px]"
+      :src "https://etc.usf.edu/clipart/16200/16224/snowflake3_16224_sm.gif"}]
+    [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
+     "1-1"]]
+   [:figure.not-prose.flex.flex-col.items-center.justify-end
+    [:img
+     {:class "object-contain w-[100px] h-[100px]"
+      :src "https://etc.usf.edu/clipart/16200/16226/snowflake5_16226_sm.gif"}]
+    [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
+     "1-2"]]
+   [:figure.not-prose.flex.flex-col.items-center.justify-end
+    [:img
+     {:class "object-contain w-[100px] h-[100px]"
+      :src "https://etc.usf.edu/clipart/16200/16228/snowflake6_16228_sm.gif"}]
+    [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
+     "1-3"]]
+   [:figure.not-prose.flex.flex-col.items-center.justify-end
+    [:img
+     {:class "object-contain w-[100px] h-[100px]"
+      :src "https://etc.usf.edu/clipart/16200/16215/snowflake1_16215_sm.gif"}]
+    [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
+     "1-4"]]
+   [:figure.not-prose.flex.flex-col.items-center.justify-end
+    [:img
+     {:class "object-contain w-[100px] h-[100px]"
+      :src "https://etc.usf.edu/clipart/16200/16223/snowflake2_16223_sm.gif"}]
+    [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
+     "2-1"]]
+   [:figure.not-prose.flex.flex-col.items-center.justify-end
+    [:img
+     {:class "object-contain w-[100px] h-[100px]"
+      :src "https://etc.usf.edu/clipart/16200/16229/snowflake7_16229_sm.gif"}]
+    [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
+     "2-2"]]
+   [:figure.not-prose.flex.flex-col.items-center.justify-end
+    [:img
+     {:class "object-contain w-[100px] h-[100px]"
+      :src "https://etc.usf.edu/clipart/16200/16236/snowflake13_16236_sm.gif"}]
+    [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
+     "2-3"]]
+   [:figure.not-prose.flex.flex-col.items-center.justify-end
+    [:img
+     {:class "object-contain w-[100px] h-[100px]"
+      :src "https://etc.usf.edu/clipart/16200/16237/snowflake14_16237_sm.gif"}]
+    [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
+     "2-4"]]])
+
+#_(nextjournal.clerk/show! "notebooks/viewers/image_layouts.clj")

--- a/notebooks/viewers/image_layouts.clj
+++ b/notebooks/viewers/image_layouts.clj
@@ -36,15 +36,15 @@
 ;; * Default for `1 < ratio < 2` and `content width <= intrinsic width`
 
 (clerk/html
-  [:figure.not-prose
+  [:figure
    [:img
     {:class "w-full"
      :src "https://images.freeimages.com/images/large-previews/773/koldalen-4-1384902.jpg"}]
-   [:figcaption.max-w-prose.px-8.text-sm.text-slate-500.sans-serif.mt-2
+   [:figcaption.max-w-prose.text-sm.text-slate-500.sans-serif.mt-2
     "Content width, height based on aspect ratio"]])
 
 (clerk/html
-  [:figure.not-prose
+  [:figure
    [:img
     {:class "w-full object-cover h-[300px]"
      :src "https://images.freeimages.com/images/large-previews/773/koldalen-4-1384902.jpg"}]
@@ -56,14 +56,14 @@
 ;; * Default for `ratio <= 1` and `intrinsic width <= content width`
 
 (clerk/html
-  [:figure.not-prose.flex.flex-col.items-center
+  [:figure.flex.flex-col.items-center
    [:img
     {:src "https://etc.usf.edu/clipart/36600/36667/thermos_36667_sm.gif"}]
    [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
     "Intrinsic width, height based on aspect ratio"]])
 
 (clerk/html
-  [:figure.not-prose.flex.flex-col.items-center
+  [:figure.flex.flex-col.items-center
    [:img.object-contain
     {:class "object-contain w-[300px] h-[300px]"
      :src "https://etc.usf.edu/clipart/186600/186669/186669-trees-in-the-winter_sm.gif"}]
@@ -78,20 +78,20 @@
 ;; ### Single row, auto-sizing cells
 
 (clerk/html
-  [:div.not-prose.grid.grid-cols-3.gap-6
-   [:figure.not-prose.flex.flex-col.items-center.justify-end
+  [:div.grid.grid-cols-3.gap-6
+   [:figure.flex.flex-col.items-center.justify-end
     [:img
      {:class "object-contain"
       :src "https://etc.usf.edu/clipart/16200/16224/snowflake3_16224_sm.gif"}]
     [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
      "1-1"]]
-   [:figure.not-prose.flex.flex-col.items-center.justify-end
+   [:figure.flex.flex-col.items-center.justify-end
     [:img
      {:class "object-contain"
       :src "https://etc.usf.edu/clipart/16200/16226/snowflake5_16226_sm.gif"}]
     [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
      "1-2"]]
-   [:figure.not-prose.flex.flex-col.items-center.justify-end
+   [:figure.flex.flex-col.items-center.justify-end
     [:img
      {:class "object-contain"
       :src "https://etc.usf.edu/clipart/16200/16228/snowflake6_16228_sm.gif"}]
@@ -101,50 +101,50 @@
 ;; ### Multiple rows, fixed layout (4 columns), fixed cell size
 
 (clerk/html
-  [:div.not-prose.grid.grid-cols-4.gap-6
-   [:figure.not-prose.flex.flex-col.items-center.justify-end
+  [:div.grid.grid-cols-4.gap-6
+   [:figure.flex.flex-col.items-center.justify-end
     [:img
      {:class "object-contain w-[100px] h-[100px]"
       :src "https://etc.usf.edu/clipart/16200/16224/snowflake3_16224_sm.gif"}]
     [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
      "1-1"]]
-   [:figure.not-prose.flex.flex-col.items-center.justify-end
+   [:figure.flex.flex-col.items-center.justify-end
     [:img
      {:class "object-contain w-[100px] h-[100px]"
       :src "https://etc.usf.edu/clipart/16200/16226/snowflake5_16226_sm.gif"}]
     [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
      "1-2"]]
-   [:figure.not-prose.flex.flex-col.items-center.justify-end
+   [:figure.flex.flex-col.items-center.justify-end
     [:img
      {:class "object-contain w-[100px] h-[100px]"
       :src "https://etc.usf.edu/clipart/16200/16228/snowflake6_16228_sm.gif"}]
     [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
      "1-3"]]
-   [:figure.not-prose.flex.flex-col.items-center.justify-end
+   [:figure.flex.flex-col.items-center.justify-end
     [:img
      {:class "object-contain w-[100px] h-[100px]"
       :src "https://etc.usf.edu/clipart/16200/16215/snowflake1_16215_sm.gif"}]
     [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
      "1-4"]]
-   [:figure.not-prose.flex.flex-col.items-center.justify-end
+   [:figure.flex.flex-col.items-center.justify-end
     [:img
      {:class "object-contain w-[100px] h-[100px]"
       :src "https://etc.usf.edu/clipart/16200/16223/snowflake2_16223_sm.gif"}]
     [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
      "2-1"]]
-   [:figure.not-prose.flex.flex-col.items-center.justify-end
+   [:figure.flex.flex-col.items-center.justify-end
     [:img
      {:class "object-contain w-[100px] h-[100px]"
       :src "https://etc.usf.edu/clipart/16200/16229/snowflake7_16229_sm.gif"}]
     [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
      "2-2"]]
-   [:figure.not-prose.flex.flex-col.items-center.justify-end
+   [:figure.flex.flex-col.items-center.justify-end
     [:img
      {:class "object-contain w-[100px] h-[100px]"
       :src "https://etc.usf.edu/clipart/16200/16236/snowflake13_16236_sm.gif"}]
     [:figcaption.text-sm.text-slate-500.sans-serif.mt-2.text-center
      "2-3"]]
-   [:figure.not-prose.flex.flex-col.items-center.justify-end
+   [:figure.flex.flex-col.items-center.justify-end
     [:img
      {:class "object-contain w-[100px] h-[100px]"
       :src "https://etc.usf.edu/clipart/16200/16237/snowflake14_16237_sm.gif"}]

--- a/notebooks/viewers/image_layouts.clj
+++ b/notebooks/viewers/image_layouts.clj
@@ -2,10 +2,9 @@
 ;;
 ;; A list of image samples in different layouts that best suit the images
 ;; aspect ratio.
-
-(ns ^:nextjournal.clerk/no-cache image-layouts
-  (:require [nextjournal.clerk :as clerk]
-            [nextjournal.clerk.viewer :as v]))
+^{:nextjournal.clerk/visibility #{:fold}}
+(ns image-layouts
+  (:require [nextjournal.clerk :as clerk]))
 
 ;; ## Viewport width, height based on aspect ratio (or fixed)
 ;; * Examples: `3:1`, `4:1`

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -318,6 +318,7 @@
          "viewer_api_meta"
          "viewers/html"
          "viewers/image"
+         "viewers/image_layouts"
          "viewers/markdown"
          "viewers/plotly"
          "viewers/table"

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -12,14 +12,20 @@
             [nextjournal.clerk.view :as view]
             [nextjournal.clerk.viewer :as v]
             [nextjournal.clerk.webserver :as webserver]
-            [taoensso.nippy :as nippy]))
+            [taoensso.nippy :as nippy])
+  (:import (java.awt.image BufferedImage)
+           (javax.imageio ImageIO)))
 
 (comment
   (alter-var-root #'nippy/*freeze-serializable-allowlist* (fn [_] "allow-and-record"))
   (alter-var-root   #'nippy/*thaw-serializable-allowlist* (fn [_] "allow-and-record"))
   (nippy/get-recorded-serializable-classes))
 
+;; nippy tweaks
 (alter-var-root #'nippy/*thaw-serializable-allowlist* (fn [_] (conj nippy/default-thaw-serializable-allowlist "java.io.File" "clojure.lang.Var" "clojure.lang.Namespace")))
+(nippy/extend-freeze BufferedImage :java.awt.image.BufferedImage [x out] (ImageIO/write x "png" (ImageIO/createImageOutputStream out)))
+(nippy/extend-thaw :java.awt.image.BufferedImage [in] (ImageIO/read in))
+
 #_(-> [(clojure.java.io/file "notebooks") (find-ns 'user)] nippy/freeze nippy/thaw)
 
 
@@ -90,8 +96,8 @@
 (defn- cache! [digest-file var-value]
   (try
     (spit digest-file (hash+store-in-cas! var-value))
-    (catch Exception _e
-      #_(prn :freeze-error e)
+    (catch Exception e
+      (prn :freeze-error e)
       nil)))
 
 (defn- eval+cache! [form hash digest-file introduced-var no-cache? visibility]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -182,9 +182,9 @@
                                           r (float (/ w h))]
                                       (ImageIO/write image "png" stream)
                                       (cond-> {:nextjournal/value (.toByteArray stream)
-                                               :nextjournal/content-type "image/png"}
-                                        (< 2 r) (assoc :nextjournal/width :full))))
-            :render-fn '(fn [blob] (v/html [:img {:src (v/url-for blob)}]))})
+                                               :nextjournal/content-type "image/png"
+                                               :nextjournal/width (if (and (< 2 r) (< 900 w)) :full :wide)})))
+            :render-fn '(fn [blob] (v/html [:figure.flex.flex-col.items-center [:img {:src (v/url-for blob)}]]))})
    {:pred (fn [_] true) :transform-fn pr-str :render-fn '(fn [x] (v/html [:span.inspected-value.whitespace-nowrap.text-gray-700 x]))}
    {:name :elision :render-fn (quote v/elision-viewer)}
    {:name :latex :render-fn (quote v/katex-viewer) :fetch-fn fetch-all}
@@ -219,16 +219,16 @@
    {:pred string? :render-fn (quote v/string-viewer) :fetch-opts {:n 100}}
    {:pred number? :render-fn '(fn [x] (v/html [:span.tabular-nums (if (js/Number.isNaN x) "NaN" (str x))]))}])
 
-(def all-viewers
+(defn get-all-viewers []
   {:root  default-viewers
    :table default-table-cell-viewers})
 
 (defonce
   ^{:doc "atom containing a map of `:root` and per-namespace viewers."}
   !viewers
-  (#?(:clj atom :cljs ratom/atom) all-viewers))
+  (#?(:clj atom :cljs ratom/atom) (get-all-viewers)))
 
-#_(reset! !viewers all-viewers)
+#_(reset! !viewers (get-all-viewers))
 
 ;; heavily inspired by code from Thomas Heller in shadow-cljs, see
 ;; https://github.com/thheller/shadow-cljs/blob/1708acb21bcdae244b50293d17633ce35a78a467/src/main/shadow/remote/runtime/obj_support.cljc#L118-L144


### PR DESCRIPTION
This adds a default viewer for `java.awt.image.BufferedImage` that can be easily constructed in the JVM using `java.imageio.ImageIO/read`. In this iteration, the viewer will look at the dimensions of the image and pick a suitable layout depending on the size and aspect ratio of the image. Customization and captions will be supported in a follow-up.

See https://snapshots.nextjournal.com/clerk/build/7fc947c54f179d266ad7a97228c75b31f99b89e4/index.html#/notebooks/viewers/image.clj about what this first version supports.

<img width="1221" alt="CleanShot 2022-01-11 at 14 02 56@2x" src="https://user-images.githubusercontent.com/1944/148947522-acf8d4eb-ff95-42b7-b8e4-649f4a3fcf5b.png">

<img width="1221" alt="CleanShot 2022-01-11 at 14 03 08@2x" src="https://user-images.githubusercontent.com/1944/148947506-31d0de47-5536-4fcc-b565-8bd501a6f3ed.png">

<img width="1221" alt="CleanShot 2022-01-11 at 14 03 13@2x" src="https://user-images.githubusercontent.com/1944/148947484-41a42fab-6148-431f-b5d9-f6d258ce1c70.png">

<img width="1221" alt="CleanShot 2022-01-11 at 14 03 20@2x" src="https://user-images.githubusercontent.com/1944/148947466-8279e64e-e1e0-4383-a164-d6b2d9916311.png">

<img width="1221" alt="CleanShot 2022-01-11 at 14 03 23@2x" src="https://user-images.githubusercontent.com/1944/148947432-fb507367-ce1c-4596-9fa0-dc249e715c44.png">
