### PR TITLE
Simplify & clean up viewers

### DIFF
--- a/notebooks/dice.clj
+++ b/notebooks/dice.clj
@@ -11,12 +11,12 @@
 
 ;; Here, we define a viewer using hiccup that will the dice as well as a button. Note that this button has an `:on-click` event handler that uses `v/clerk-eval` to tell Clerk to evaluate the argument, in this cases `(roll!)` when clicked.
 ^::clerk/no-cache
-(clerk/with-viewer (fn [side]
-                     (v/html [:div.text-center
-                              (when side
-                                [:div.mt-2 {:style {:font-size "6em"}} side])
-                              [:button.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
-                               {:on-click (fn [e] (v/clerk-eval '(roll!)))} "Roll 🎲!"]]))
+(clerk/with-viewer '(fn [side]
+                      (v/html [:div.text-center
+                               (when side
+                                 [:div.mt-2 {:style {:font-size "6em"}} side])
+                               [:button.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
+                                {:on-click (fn [e] (v/clerk-eval '(roll!)))} "Roll 🎲!"]]))
   @dice)
 
 ;; Our roll! function `resets!` our `dice` with a random side and prints and says the result. Finally it updates the notebook.

--- a/notebooks/rule_30.clj
+++ b/notebooks/rule_30.clj
@@ -4,10 +4,10 @@
   (:require [nextjournal.clerk :as clerk]))
 
 (clerk/set-viewers!
- [{:pred number? :render-fn #(v/html [:div.inline-block {:style {:width 16 :height 16}
-                                                         :class (if (pos? %) "bg-black" "bg-white border-solid border-2 border-black")}])}
-  {:pred list? :render-fn #(v/html (into [:div.flex.flex-col] (v/inspect-children %2) %1))}
-  {:pred #(and (vector? %) (not (map-entry? %))) :render-fn #(v/html (into [:div.flex.inline-flex] (v/inspect-children %2) %1))}])
+ [{:pred number? :render-fn '#(v/html [:div.inline-block {:style {:width 16 :height 16}
+                                                          :class (if (pos? %) "bg-black" "bg-white border-solid border-2 border-black")}])}
+  {:pred list? :render-fn '#(v/html (into [:div.flex.flex-col] (v/inspect-children %2) %1))}
+  {:pred #(and (vector? %) (not (map-entry? %))) :render-fn '#(v/html (into [:div.flex.inline-flex] (v/inspect-children %2) %1))}])
 
 0
 

--- a/notebooks/viewer_api.clj
+++ b/notebooks/viewer_api.clj
@@ -50,7 +50,7 @@
 
 ;; ## 🚀 Extensibility
 (clerk/with-viewer '#(v/html [:div "Greetings to " [:strong %] "!"])
-  "James Maxwell Clerk")
+  "James Clerk Maxwell")
 
 (clerk/with-viewers [{:pred number? :render-fn '#(v/html [:div.inline-block [(keyword (str "h" %)) (str "Heading " %)]])}]
   [1 2 3 4 5])

--- a/notebooks/viewer_api.clj
+++ b/notebooks/viewer_api.clj
@@ -49,15 +49,15 @@
                             expression-2)))
 
 ;; ## 🚀 Extensibility
-(clerk/with-viewer #(v/html [:div "Greetings to " [:strong %] "!"])
+(clerk/with-viewer '#(v/html [:div "Greetings to " [:strong %] "!"])
   "James Maxwell Clerk")
 
-(clerk/with-viewers [{:pred number? :render-fn #(v/html [:div.inline-block [(keyword (str "h" %)) (str "Heading " %)]])}]
+(clerk/with-viewers [{:pred number? :render-fn '#(v/html [:div.inline-block [(keyword (str "h" %)) (str "Heading " %)]])}]
   [1 2 3 4 5])
 
 ^::clerk/no-cache
-(clerk/with-viewers [{:pred number? :render-fn #(v/html [:div.inline-block {:style {:width 16 :height 16}
-                                                                            :class (if (pos? %) "bg-black" "bg-white border-solid border-2 border-black")}])}]
+(clerk/with-viewers [{:pred number? :render-fn '#(v/html [:div.inline-block {:style {:width 16 :height 16}
+                                                                             :class (if (pos? %) "bg-black" "bg-white border-solid border-2 border-black")}])}]
   (take 10 (repeatedly #(rand-int 2))))
 
 (clerk/with-viewers
@@ -67,11 +67,11 @@
                   (str "(?i)"
                        "(#(?:[0-9a-f]{2}){2,4}|(#[0-9a-f]{3})|"
                        "(rgb|hsl)a?\\((-?\\d+%?[,\\s]+){2,3}\\s*[\\d\\.]+%?\\))")) %))
-    :render-fn #(v/html [:div.inline-block.rounded-sm.shadow
-                         {:style {:width 16
-                                  :height 16
-                                  :border "1px solid rgba(0,0,0,.2)"
-                                  :background-color %}}])}]
+    :render-fn '#(v/html [:div.inline-block.rounded-sm.shadow
+                          {:style {:width 16
+                                   :height 16
+                                   :border "1px solid rgba(0,0,0,.2)"
+                                   :background-color %}}])}]
   ["#571845"
    "rgb(144,12,62)"
    "rgba(199,0,57,1.0)"

--- a/notebooks/viewers/image.clj
+++ b/notebooks/viewers/image.clj
@@ -10,7 +10,7 @@
 (clerk/set-viewers! [{:pred bytes?
                       :fetch-fn (fn [_ bytes] {:nextjournal/content-type "image/png"
                                                :nextjournal/value bytes})
-                      :render-fn (fn [blob] (v/html [:img {:src (v/url-for blob)}]))}])
+                      :render-fn '(fn [blob] (v/html [:img {:src (v/url-for blob)}]))}])
 
 (.. (HttpClient/newHttpClient)
     (send (.build (HttpRequest/newBuilder (URI. "https://upload.wikimedia.org/wikipedia/commons/5/57/James_Clerk_Maxwell.png")))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -240,27 +240,9 @@
 (def use-headers    #'v/use-headers)
 (def hide-result    #'v/hide-result)
 (defn doc-url [path] (v/->SCIEval (list 'v/doc-url path)))
-
-(defmacro with-viewer
-  [viewer x]
-  (let [viewer# (v/->Form viewer)]
-    `(v/with-viewer* ~viewer# ~x)))
-
-#_(macroexpand '(with-viewer #(v/html [:div %]) 1))
-
-(defmacro with-viewers
-  [viewers x]
-  (let [viewers# (v/process-fns viewers)]
-    `(v/with-viewers* ~viewers# ~x)))
-
-#_(macroexpand '(with-viewers [{:pred number? :render-fn #(v/html [:div %])}] 1))
-
-
-(defmacro set-viewers!
-  ([viewers] (v/set-viewers!* *ns* viewers))
-  ([scope viewers] (v/set-viewers!* scope viewers)))
-
-#_(set-viewers! [])
+(def with-viewer    #'v/with-viewer)
+(def with-viewers   #'v/with-viewers)
+(def set-viewers!   #'v/set-viewers!)
 
 (defn file->viewer
   "Evaluates the given `file` and returns it's viewer representation."

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -239,7 +239,7 @@
 (def table          #'v/table)
 (def use-headers    #'v/use-headers)
 (def hide-result    #'v/hide-result)
-(defn doc-url [path] (v/->SCIEval (list 'v/doc-url path)))
+(def doc-url        #'v/doc-url)
 (def with-viewer    #'v/with-viewer)
 (def with-viewers   #'v/with-viewers)
 (def set-viewers!   #'v/set-viewers!)

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -434,14 +434,12 @@
 (defn inspect
   ([x]
    (r/with-let [!expanded-at (r/atom {})]
-     [inspect {:!expanded-at !expanded-at :recursion 0} x]))
-  ([{:as opts :keys [viewers recursion]} x]
+     [inspect {:!expanded-at !expanded-at} x]))
+  ([{:as opts :keys [viewers]} x]
    (let [value (viewer/value x)
          {:as opts :keys [viewers]} (assoc opts :viewers (vec (concat (viewer/viewers x) viewers)))
-         all-viewers (viewer/get-viewers (:scope @!doc) viewers)
-         opts (update opts :recursion inc)]
-     (or (when (< 20 recursion) [:span "reached recursion limit"])
-         (when (react/isValidElement value) value)
+         all-viewers (viewer/get-viewers (:scope @!doc) viewers)]
+     (or (when (react/isValidElement value) value)
          ;; TODO find option to disable client-side viewer selection
          (when-let [viewer (or (viewer/viewer x)
                                (viewer/viewer (viewer/wrapped-with-viewer value all-viewers)))]

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -96,7 +96,7 @@
          :readers {'file (partial with-viewer :file)
                    'object (partial with-viewer :object)
                    'viewer-fn viewer/->viewer-fn
-                   'sci-eval *eval*}
+                   'viewer-eval *eval*}
          :features #{:clj}}))
 
 (defn ^:export read-string [s]
@@ -391,8 +391,7 @@
   [:span.inspected-value.whitespace-nowrap
    [:span.syntax-tag tag] value])
 
-(defn normalize-viewer
-  [x]
+(defn normalize-viewer [x]
   (if-let [viewer (-> x meta :nextjournal/viewer)]
     (with-viewer viewer x)
     x))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -510,9 +510,12 @@
   [viewer x]
   (-> x
       wrap-value
-      (assoc :nextjournal/viewer viewer)))
+      (assoc :nextjournal/viewer (cond-> viewer
+                                   (or (list? viewer) (symbol? viewer))
+                                   ->viewer-fn))))
 
-#_(with-viewer- :latex "x^2")
+#_(with-viewer :latex "x^2")
+#_(with-viewer '#(v/html [:h3 "Hello " % "!"]) "x^2")
 
 (defn with-viewers
   "Binds viewers to types, eg {:boolean view-fn}"

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -327,7 +327,7 @@
     viewer
     (cond-> (dissoc viewer :pred :transform-fn :fetch-fn)
       (:render-fn viewer)
-      (update :render-fn ->Form))))
+      (update :render-fn #?(:clj ->Form :cljs *eval*)))))
 
 #_(process-viewer {:render-fn '(v/html [:h1]) :fetch-fn fetch-all})
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -4,8 +4,7 @@
             [clojure.datafy :as datafy]
             #?@(:clj [[clojure.repl :refer [demunge]]
                       [nextjournal.clerk.config :as config]]
-                :cljs [[reagent.ratom :as ratom]])
-            [nextjournal.clerk.viewer :as v])
+                :cljs [[reagent.ratom :as ratom]]))
   #?(:clj (:import [java.lang Throwable])))
 
 (defrecord ViewerEval [form])

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -145,14 +145,10 @@
 
 (def elide-string-length 100)
 
-(declare with-viewer)
-
 (defn fetch-all [_ x] x)
 
 (defn- var-from-def? [x]
   (get x :nextjournal.clerk/var-from-def))
-
-(declare !viewers)
 
 ;; keep viewer selection stricly in Clojure
 (def default-viewers

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -153,7 +153,7 @@
 
 (def elide-string-length 100)
 
-(declare with-viewer*)
+(declare with-viewer)
 
 (defn fetch-all [_ x] x)
 
@@ -219,42 +219,16 @@
    {:pred string? :render-fn (quote v/string-viewer) :fetch-opts {:n 100}}
    {:pred number? :render-fn '(fn [x] (v/html [:span.tabular-nums (if (js/Number.isNaN x) "NaN" (str x))]))}])
 
-(defn process-fns [viewers]
-  (into []
-        (map (fn [{:as viewer :keys [pred fetch-fn render-fn transform-fn]}]
-               ;; TODO: simplify with own type for things that should not be transmitted to the
-               ;; browser (`pred`, `fetch-fn` & `transform-fn`)
-               ;; also remove `symbol?` checks and let viewers use `(quote my-sym)` instead of `'my-sym`
-               (cond-> viewer
-                 (and pred (or (symbol? pred) (not (ifn? pred))))
-                 (update :pred #?(:cljs *eval* :clj #(->Fn+Form '(constantly false) (eval %))))
-
-                 (and transform-fn (or (symbol? transform-fn) (not (ifn? transform-fn))))
-                 (update :transform-fn #?(:cljs *eval* :clj #(->Fn+Form '(constantly false) (eval %))))
-
-                 (and fetch-fn (not (ifn? fetch-fn)))
-                 (update :fetch-fn #?(:cljs *eval* :clj #(->Fn+Form '(constantly false) (eval %))))
-
-                 #?@(:clj [(and render-fn (not (instance? Form render-fn)))
-                           (update :render-fn ->Form)]
-                     :cljs [(and render-fn (not (instance? Fn+Form render-fn)))
-                            (update :render-fn form->fn+form)]))))
-        viewers))
-
-(defn process-viewers [viewers]
-  #?(:clj (process-fns viewers)
-     :cljs viewers))
-
-(defn processed-default-viewers []
-  {:root (process-viewers default-viewers)
-   :table (process-viewers default-table-cell-viewers)})
+(def all-viewers
+  {:root default-viewers
+   :table default-table-cell-viewers})
 
 (defonce
   ^{:doc "atom containing a map of `:root` and per-namespace viewers."}
   !viewers
-  (#?(:clj atom :cljs ratom/atom) (processed-default-viewers)))
+  (#?(:clj atom :cljs ratom/atom) all-viewers))
 
-#_(reset! !viewers (processed-default-viewers))
+#_(reset! !viewers all-viewers)
 
 ;; heavily inspired by code from Thomas Heller in shadow-cljs, see
 ;; https://github.com/thheller/shadow-cljs/blob/1708acb21bcdae244b50293d17633ce35a78a467/src/main/shadow/remote/runtime/obj_support.cljc#L118-L144
@@ -278,7 +252,7 @@
     (set? xs) (sort resilient-compare xs)
     :else xs))
 
-(declare with-viewer*)
+(declare with-viewer)
 
 (defn find-named-viewer [viewers viewer-name]
   (first (filter (comp #{viewer-name} :name) viewers)))
@@ -311,8 +285,8 @@
 #_(wrapped-with-viewer (clojure.java.io/file "notebooks"))
 #_(wrapped-with-viewer (md "# Hello"))
 #_(wrapped-with-viewer (html [:h1 "hi"]))
-#_(wrapped-with-viewer (with-viewer* :elision {:remaining 10 :count 30 :offset 19}))
-#_(wrapped-with-viewer (with-viewer* (->Form '(fn [name] (html [:<> "Hello " name]))) "James"))
+#_(wrapped-with-viewer (with-viewer :elision {:remaining 10 :count 30 :offset 19}))
+#_(wrapped-with-viewer (with-viewer (->Form '(fn [name] (html [:<> "Hello " name]))) "James"))
 
 (defn get-viewers
   "Returns all the viewers that apply in precendence of: optional local `viewers`, viewers set per `ns`, as well on the `:root`."
@@ -346,7 +320,16 @@
 #_(sequence (drop+take-xf {}) (range 9))
 
 
-(declare with-viewer* assign-closing-parens)
+(declare with-viewer assign-closing-parens)
+
+(defn process-viewer [viewer]
+  (if-not (map? viewer)
+    viewer
+    (cond-> (dissoc viewer :pred :transform-fn :fetch-fn)
+      (:render-fn viewer)
+      (update :render-fn ->Form))))
+
+#_(process-viewer {:render-fn '(v/html [:h1]) :fetch-fn fetch-all})
 
 (defn describe
   "Returns a subset of a given `value`."
@@ -354,7 +337,7 @@
    (describe xs {}))
   ([xs opts]
    (assign-closing-parens
-    (describe xs (merge {:!budget (atom (:budget opts 200)) :path [] :viewers (process-fns (get-viewers *ns* (viewers xs)))} opts) [])))
+    (describe xs (merge {:!budget (atom (:budget opts 200)) :path [] :viewers (get-viewers *ns* (viewers xs))} opts) [])))
   ([xs opts current-path]
    (let [{:as opts :keys [!budget viewers path offset]} (merge {:offset 0} opts)
          wrapped-value (try (wrapped-with-viewer xs viewers) ;; TODO: respect `viewers` on `xs`
@@ -371,7 +354,7 @@
        (swap! !budget #(max (dec %) 0)))
      (merge {:path path}
             (dissoc wrapped-value [:nextjournal/value :nextjournal/viewer])
-            (with-viewer* (cond-> viewer (map? viewer) (dissoc viewer :pred :transform-fn))
+            (with-viewer (process-viewer viewer)
               (cond descend?
                     (let [idx (first (drop (count current-path) path))]
                       (describe (cond (or (map? xs) (set? xs)) (nth (seq (ensure-sorted xs)) idx)
@@ -389,7 +372,7 @@
                                 new-offset (min (+ offset (:n fetch-opts)) total)
                                 remaining (- total new-offset)]
                             (cond-> [(subs xs offset new-offset)]
-                              (pos? remaining) (conj (with-viewer* :elision {:path path :count total :offset new-offset :remaining remaining}))
+                              (pos? remaining) (conj (with-viewer :elision {:path path :count total :offset new-offset :remaining remaining}))
                               true wrap-value
                               true (assoc :replace-path (conj path offset))))
                           xs))
@@ -413,7 +396,7 @@
                       (cond-> children
                         (or (not count) (< (inc offset) count))
 
-                        (conj (with-viewer* :elision
+                        (conj (with-viewer :elision
                                 (cond-> (assoc count-opts :offset (inc offset) :path path)
                                   count (assoc :remaining (- count (inc offset))))))))
 
@@ -431,11 +414,11 @@
   (describe (map vector (range)))
   (describe (subs (slurp "/usr/share/dict/words") 0 1000))
   (describe (plotly {:data [{:z [[1 2 3] [3 2 1]] :type "surface"}]}))
-  (describe (with-viewer* :html [:h1 "hi"]))
-  (describe (with-viewer* :html [:ul (for [x (range 3)] [:li x])]))
+  (describe (with-viewer :html [:h1 "hi"]))
+  (describe (with-viewer :html [:ul (for [x (range 3)] [:li x])]))
   (describe (range))
   (describe {1 [2]})
-  (describe (with-viewer* (->Form '(fn [name] (html [:<> "Hello " name]))) "James")))
+  (describe (with-viewer (->Form '(fn [name] (html [:<> "Hello " name]))) "James")))
 
 (defn desc->values
   "Takes a `description` and returns its value. Inverse of `describe`. Mostly useful for debugging."
@@ -450,7 +433,7 @@
               (map desc->values))))))
 
 #_(desc->values (describe [1 [2 {:a :b} 2] 3 (range 100)]))
-#_(desc->values (describe (with-viewer* :table (normalize-table-data (repeat 60 ["Adelie" "Biscoe" 50 30 200 5000 :female])))))
+#_(desc->values (describe (with-viewer :table (normalize-table-data (repeat 60 ["Adelie" "Biscoe" 50 30 200 5000 :female])))))
 
 (defn path-to-value [path]
   (conj (interleave path (repeat :nextjournal/value)) :nextjournal/value))
@@ -503,16 +486,17 @@
 #_(datafy-scope *ns*)
 #_(datafy-scope #'datafy-scope)
 
-(declare with-viewer*)
+(declare with-viewer)
 
 #?(:clj
-   (defn set-viewers!* [scope viewers]
-     (assert (or (#{:root} scope)
-                 (instance? clojure.lang.Namespace scope)
-                 (var? scope)))
-     (let [viewers (process-fns viewers)]
-       (swap! !viewers assoc scope viewers)
-       (with-viewer* :eval! `'(v/set-viewers! ~(datafy-scope scope) ~viewers)))))
+   (defn set-viewers!
+     ([viewers] (set-viewers! *ns* viewers))
+     ([scope viewers]
+      (assert (or (#{:root} scope)
+                  (instance? clojure.lang.Namespace scope)
+                  (var? scope)))
+      (swap! !viewers assoc scope viewers)
+      (with-viewer :eval! `'(v/set-viewers! ~(datafy-scope scope) ~viewers)))))
 
 
 (defn registration? [x]
@@ -524,7 +508,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; public api
 
-(defn with-viewer*
+(defn with-viewer
   "Wraps given "
   [viewer x]
   (-> x
@@ -533,25 +517,25 @@
 
 #_(with-viewer- :latex "x^2")
 
-(defn with-viewers*
+(defn with-viewers
   "Binds viewers to types, eg {:boolean view-fn}"
   [viewers x]
   (-> x
       wrap-value
       (assoc :nextjournal/viewers viewers)))
 
-#_(->> "x^2" (with-viewer* :latex) (with-viewers* [{:name :latex :render-fn :mathjax}]))
+#_(->> "x^2" (with-viewer :latex) (with-viewers [{:name :latex :render-fn :mathjax}]))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; public convience api
-(def html         (partial with-viewer* :html))
-(def md           (partial with-viewer* :markdown))
-(def plotly       (partial with-viewer* :plotly))
-(def vl           (partial with-viewer* :vega-lite))
-(def tex          (partial with-viewer* :latex))
-(def hide-result  (partial with-viewer* :hide-result))
-(def notebook     (partial with-viewer* :clerk/notebook))
+(def html         (partial with-viewer :html))
+(def md           (partial with-viewer :markdown))
+(def plotly       (partial with-viewer :plotly))
+(def vl           (partial with-viewer :vega-lite))
+(def tex          (partial with-viewer :latex))
+(def hide-result  (partial with-viewer :hide-result))
+(def notebook     (partial with-viewer :clerk/notebook))
 
 (defn table
   "Displays `xs` in a table.
@@ -566,8 +550,8 @@
    (table {:nextjournal/width :wide} xs))
   ([opts xs]
    (-> (if-let [normalized (normalize-table-data xs)]
-         (with-viewer* :table normalized)
-         (with-viewer* :table-error [xs]))
+         (with-viewer :table normalized)
+         (with-viewer :table-error [xs]))
        (merge opts)
        (update :nextjournal/viewers concat (:table @!viewers)))))
 
@@ -576,6 +560,6 @@
 #_(describe (table (set (range 10))))
 
 (defn code [x]
-  (with-viewer* :code (if (string? x) x (with-out-str (pprint/pprint x)))))
+  (with-viewer :code (if (string? x) x (with-out-str (pprint/pprint x)))))
 
 #_(code '(+ 1 2))


### PR DESCRIPTION
Simplify the viewer api by dropping the macros and requiring users to quote the `:render-fn`. This should make it explicit and less magic as to what part of the viewers is evaluated on the JVM and what is sent over the wire to run in the browser.