### PR TITLE
Allow to bring your own css and js

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -31,7 +31,7 @@
                               cider/cider-nrepl {:mvn/version "0.26.0"}
                               thheller/shadow-cljs {:mvn/version "2.16.7"}}
                  :extra-paths ["dev"]
-                 :jvm-opts ["-Dclerk.resource_manifest=#{\"/js/viewer.js\"}" "-Dpolyglot.engine.WarnInterpreterOnly=false" "-XX:-OmitStackTraceInFastThrow"]
+                 :jvm-opts ["-Dclerk.resource_manifest={\"/js/viewer.js\" \"http://localhost:7778/js/viewer.js\"}" "-Dpolyglot.engine.WarnInterpreterOnly=false" "-XX:-OmitStackTraceInFastThrow"]
                  :main-opts ["-m" "shadow.cljs.devtools.cli"]}
 
            :test {:extra-deps {nubank/matcher-combinators {:mvn/version "3.3.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -31,7 +31,7 @@
                               cider/cider-nrepl {:mvn/version "0.26.0"}
                               thheller/shadow-cljs {:mvn/version "2.16.7"}}
                  :extra-paths ["dev"]
-                 :jvm-opts ["-Dclerk.live_js=true" "-Dpolyglot.engine.WarnInterpreterOnly=false" "-XX:-OmitStackTraceInFastThrow"]
+                 :jvm-opts ["-Dclerk.resource_manifest=#{\"/js/viewer.js\"}" "-Dpolyglot.engine.WarnInterpreterOnly=false" "-XX:-OmitStackTraceInFastThrow"]
                  :main-opts ["-m" "shadow.cljs.devtools.cli"]}
 
            :test {:extra-deps {nubank/matcher-combinators {:mvn/version "3.3.1"}

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -4,11 +4,6 @@
 (comment
   (clerk/serve! {:browse? true}))
 
-(defn set-dev!
-  "Set this to `true` to load the css + js from a running instance for css + viewer dev. "
-  [enabled?]
-  (alter-var-root #'nextjournal.clerk.view/live-js? (constantly enabled?)))
-
 (comment
   ;; start without file watcher
   (clerk/serve! {})
@@ -18,11 +13,6 @@
 
   ;; start with file watcher and show filter function to enable notebook pinning
   (clerk/serve! {:watch-paths ["notebooks" "src"] :show-filter-fn #(clojure.string/starts-with? % "notebooks")})
-
-  nextjournal.clerk.view/live-js?
-
-  (set-dev! false)
-  (set-dev! true)
 
   (clerk/show! "notebooks/onwards.md")
   (clerk/show! "notebooks/rule_30.clj")

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "d3-require": "^1.2.4",
     "katex": "^0.12.0",
     "lezer-clojure": "0.1.10",
-    "markdown-it": "12.2.0",
+    "markdown-it": "12.3.2",
     "markdown-it-block-image": "0.0.3",
     "markdown-it-sidenote": "git+https://github.com/gerwitz/markdown-it-sidenote.git",
     "markdown-it-texmath": "0.9.1",

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&family=Fira+Mono:wght@400;700&family=Fira+Sans+Condensed:ital,wght@0,700;1,700&family=Fira+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&family=PT+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.css" integrity="sha384-RZU/ijkSsFbcmivfdRBQDtwuwVqK7GMOw6IMvKyeWL2K5UAlyp6WonmB8m7Jd0Hn" crossorigin="anonymous">
-    <-- TODO: switch to programmatic generation via `view.clj` -->
+    <!-- TODO: switch to programmatic generation via `view.clj` -->
     <link rel="stylesheet" href="https://storage.googleapis.com/nextjournal-cas-eu/data/8VvAV62HzsvhcsXEkHP33uj4cV9UvdDz7DU9qLeVRCfEP9kWLFAzaMKL77trdx898DzcVyDVejdfxvxj5XB84UpWvQ">
   </head>
   <body>

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -345,18 +345,16 @@
   - `:bundle?` builds a single page app versus a folder with an html page for each notebook (defaults to `true`)
   - `:path-prefix` a prefix to urls
   - `:out-path` a relative path to a folder to contain the static pages (defaults to `\"public/build\"`)
-  - `:live-js?` in local development, uses shadow current build and http server
   - `:git/sha`, `:git/url` when both present, each page displays a link to `(str url \"blob\" sha path-to-notebook)`
   "
-  [{:as opts :keys [paths out-path live-js? bundle? browse?]
+  [{:as opts :keys [paths out-path bundle? browse?]
     :or {paths clerk-docs
          out-path (str "public" fs/file-separator "build")
-         live-js? view/live-js?
          bundle? true
          browse? true}}]
   (let [path->doc (into {} (map (juxt identity file->viewer)) paths)
         path->url (into {} (map (juxt identity #(cond-> (strip-index %) (not bundle?) ->html-extension))) paths)
-        static-app-opts (assoc opts :live-js? live-js? :bundle? bundle? :path->doc path->doc :paths (vec (keys path->doc)) :path->url path->url)
+        static-app-opts (assoc opts :bundle? bundle? :path->doc path->doc :paths (vec (keys path->doc)) :path->url path->url)
         index-html (str out-path fs/file-separator "index.html")]
     (when-not (fs/exists? (fs/parent index-html))
       (fs/create-dirs (fs/parent index-html)))
@@ -369,14 +367,13 @@
               (fs/create-dirs (fs/parent out-html))
               (spit out-html (view/->static-app (assoc static-app-opts :path->doc (hash-map path doc) :current-path path)))))))
     (when browse?
-      (if (and live-js? (str/starts-with? out-path "public/"))
+      (if (str/starts-with? out-path "public/")
         (browse/browse-url (str "http://localhost:7778/" (str/replace out-path "public/" "")))
         (browse/browse-url (-> index-html fs/absolutize .toString path-to-url-canonicalize))))))
 
 #_(build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true})
 #_(build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? false :path-prefix "build/"})
 #_(build-static-app! {})
-#_(build-static-app! {:live-js? false})
 #_(build-static-app! {:paths ["notebooks/viewer_api.clj" "notebooks/rule_30.clj"]})
 
 ;; And, as is the culture of our people, a commend block containing

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -12,11 +12,19 @@
 (def default-resource-manifest
   {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VwLM2wq7ZJ8xd2zmqCWVgdmU9xrVYt6YDYryMVeJHbNUDarrbLScR4LKvtsQjNax2h99EYeU8qWnF4ryQSjN1z4Pq"})
 
-(defonce resource-manifest
-  (or (when-let [prop (System/getProperty "clerk.resource_manifest")]
-        (when-not (str/blank? prop)
-          (read-string prop)))
-      default-resource-manifest))
+(def resource-manifest-from-props
+  (when-let [prop (System/getProperty "clerk.resource_manifest")]
+    (when-not (str/blank? prop)
+      (read-string prop))))
+
+(defonce !resource->url
+  (atom (or resource-manifest-from-props
+            default-resource-manifest)))
+
+#_(swap! !resource->url assoc "/css/viewer.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvAV62HzsvhcsXEkHP33uj4cV9UvdDz7DU9qLeVRCfEP9kWLFAzaMKL77trdx898DzcVyDVejdfxvxj5XB84UpWvQ")
+#_(swap! !resource->url dissoc "/css/viewer.css")
+#_(reset! !resource->url identity)
+#_(reset! !resource->url default-resource-manifest)
 
 
 (def ^:dynamic *in-clerk* false)

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -1,4 +1,5 @@
-(ns nextjournal.clerk.config)
+(ns nextjournal.clerk.config
+  (:require [clojure.string :as str]))
 
 (defn cache-dir []
   (or (System/getProperty "clerk.cache_dir")
@@ -7,6 +8,20 @@
 (defn cache-disabled? []
   (when-let [prop (System/getProperty "clerk.disable_cache")]
     (not= "false" prop)))
+
+(defn cache-disabled? []
+  (when-let [prop (System/getProperty "clerk.disable_cache")]
+    (not= "false" prop)))
+
+(def default-resource-manifest
+  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VwLM2wq7ZJ8xd2zmqCWVgdmU9xrVYt6YDYryMVeJHbNUDarrbLScR4LKvtsQjNax2h99EYeU8qWnF4ryQSjN1z4Pq"})
+
+(defonce resource-manifest
+  (or (when-let [prop (System/getProperty "clerk.resource_manifest")]
+        (when-not (str/blank? prop)
+          (read-string prop)))
+      default-resource-manifest))
+
 
 (def ^:dynamic *in-clerk* false)
 

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -10,7 +10,7 @@
     (not= "false" prop)))
 
 (def default-resource-manifest
-  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VwLM2wq7ZJ8xd2zmqCWVgdmU9xrVYt6YDYryMVeJHbNUDarrbLScR4LKvtsQjNax2h99EYeU8qWnF4ryQSjN1z4Pq"})
+  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VufNXFDYymQD5T5zdSrX4tPbAHKpGQ3wCeTffp5Tot9yuYfLz98AU3DHW3QFWPNyteKUqHFPieLVR1fojL1hLrW8e"})
 
 (def resource-manifest-from-props
   (when-let [prop (System/getProperty "clerk.resource_manifest")]

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -9,10 +9,6 @@
   (when-let [prop (System/getProperty "clerk.disable_cache")]
     (not= "false" prop)))
 
-(defn cache-disabled? []
-  (when-let [prop (System/getProperty "clerk.disable_cache")]
-    (not= "false" prop)))
-
 (def default-resource-manifest
   {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VwLM2wq7ZJ8xd2zmqCWVgdmU9xrVYt6YDYryMVeJHbNUDarrbLScR4LKvtsQjNax2h99EYeU8qWnF4ryQSjN1z4Pq"})
 

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -154,15 +154,6 @@
 #_(nextjournal.clerk/show! "notebooks/test.clj")
 #_(nextjournal.clerk/show! "notebooks/visibility.clj")
 
-
-(defonce !resource->url
-  (atom config/resource-manifest))
-
-#_(swap! !resource->url assoc "/css/viewer.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvAV62HzsvhcsXEkHP33uj4cV9UvdDz7DU9qLeVRCfEP9kWLFAzaMKL77trdx898DzcVyDVejdfxvxj5XB84UpWvQ")
-#_(swap! !resource->url dissoc "/css/viewer.css")
-#_(reset! !resource->url identity)
-#_(reset! !resource->url config/resource-manifest)
-
 (defn include-tailwind-cdn []
   (list
    (hiccup/include-js "https://cdn.tailwindcss.com?plugins=typography")
@@ -176,11 +167,11 @@
    [:head
     [:meta {:charset "UTF-8"}]
     [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
-    (if-let [css-url (@!resource->url "/css/viewer.css")]
+    (if-let [css-url (@config/!resource->url "/css/viewer.css")]
       (hiccup/include-css css-url)
       (include-tailwind-cdn))
     (hiccup/include-css "https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.css")
-    (hiccup/include-js (@!resource->url "/js/viewer.js"))
+    (hiccup/include-js (@config/!resource->url "/js/viewer.js"))
     (hiccup/include-css "https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.css")
     (hiccup/include-css "https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&family=Fira+Mono:wght@400;700&family=Fira+Sans+Condensed:ital,wght@0,700;1,700&family=Fira+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&family=PT+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap")]
    [:body
@@ -200,7 +191,7 @@ window.ws_send = msg => ws.send(msg)")]]))
     [:meta {:charset "UTF-8"}]
     [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
     (include-tailwind-cdn)
-    (hiccup/include-js (@!resource->url "/js/viewer.js"))
+    (hiccup/include-js (@config/!resource->url "/js/viewer.js"))
     (hiccup/include-css "https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.css")
     (hiccup/include-css "https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&family=Fira+Mono:wght@400;700&family=Fira+Sans+Condensed:ital,wght@0,700;1,700&family=Fira+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&family=PT+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap")]
    [:body

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -69,8 +69,6 @@
                                                          (eval (read-string msg))))})
     (try
       (case (get (re-matches #"/([^/]*).*" uri) 1)
-        ("css" "js") {:status 302
-                      :headers {"Location" (str "http://localhost:7778" uri)}}
         "_blob" (serve-blob req)
         "_ws" {:status 200 :body "upgrading..."}
         {:status  200


### PR DESCRIPTION
This lets consumers opt into providing their own js and js by setting values in `nextjournal.clerk.config/ !resource->url`. Also drop `live-js?` the config but introduce a `clerk.resource_manifest` JVM system property and use it to get live js in dev instead.