### PR TITLE
📇 Title & Table of Contents

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,12 @@
         weavejester/dependency {:mvn/version "0.2.1"}
 
         com.nextjournal/beholder {:mvn/version "1.0.0"}
+
+        #_#_  ;; TODO: release md
         io.github.nextjournal/markdown {:mvn/version "0.1.39"}
+        io.github.nextjournal/markdown {:git/url "https://github.com/nextjournal/viewers"
+                                        :git/sha "c51cfb31f0a219e1c01612077a1cd6eefbcf2a43"
+                                        :deps/root "modules/markdown"}
 
         com.taoensso/nippy {:mvn/version "3.1.1"}
         mvxcvi/multihash {:mvn/version "2.0.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -9,11 +9,7 @@
 
         com.nextjournal/beholder {:mvn/version "1.0.0"}
 
-        #_#_  ;; TODO: release md
-        io.github.nextjournal/markdown {:mvn/version "0.1.39"}
-        io.github.nextjournal/markdown {:git/url "https://github.com/nextjournal/viewers"
-                                        :git/sha "c51cfb31f0a219e1c01612077a1cd6eefbcf2a43"
-                                        :deps/root "modules/markdown"}
+        io.github.nextjournal/markdown {:mvn/version "0.2.44"}
 
         com.taoensso/nippy {:mvn/version "3.1.1"}
         mvxcvi/multihash {:mvn/version "2.0.3"}

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -10,7 +10,7 @@
     (not= "false" prop)))
 
 (def default-resource-manifest
-  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VxkmQxqoz9PBnHzUwkS3p6oUpCRVuWKqCNhAWYhyNeT8EBmqJeNiLrEky6VLueY3kwev8JVCHKfbnpGVW23a57YPo"})
+  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VuCTztSMpsX4d9skM1VdchZUDV2WJEgADDrbbQPQzdJpFygjkYcpeFExZcvct4LNZ477a5ts42RQKoLShu4QQfi9h"})
 
 (def resource-manifest-from-props
   (when-let [prop (System/getProperty "clerk.resource_manifest")]

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -10,7 +10,7 @@
     (not= "false" prop)))
 
 (def default-resource-manifest
-  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvcE4ChecnAcKwoPmDaiGw9MsDErSyHcdtXuM8vCJVX2R8YoG6VxcMGxQndF7v3ygqPbmSEPFKeaKeuFd6HGgT3d6"})
+  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VxkmQxqoz9PBnHzUwkS3p6oUpCRVuWKqCNhAWYhyNeT8EBmqJeNiLrEky6VLueY3kwev8JVCHKfbnpGVW23a57YPo"})
 
 (def resource-manifest-from-props
   (when-let [prop (System/getProperty "clerk.resource_manifest")]

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -10,7 +10,7 @@
     (not= "false" prop)))
 
 (def default-resource-manifest
-  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvhXn3d1HeG9cCEfVqQYqRtRVgRBJBi89ao2cGWb7gg4YtYvKGzCeSamMk85AEye6FkUvHAGgYVUnroEmmEByzQ1F"})
+  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvcE4ChecnAcKwoPmDaiGw9MsDErSyHcdtXuM8vCJVX2R8YoG6VxcMGxQndF7v3ygqPbmSEPFKeaKeuFd6HGgT3d6"})
 
 (def resource-manifest-from-props
   (when-let [prop (System/getProperty "clerk.resource_manifest")]

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -10,7 +10,7 @@
     (not= "false" prop)))
 
 (def default-resource-manifest
-  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VuCTztSMpsX4d9skM1VdchZUDV2WJEgADDrbbQPQzdJpFygjkYcpeFExZcvct4LNZ477a5ts42RQKoLShu4QQfi9h"})
+  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8Vtidiyr1qZj6xz62R9MwUkz5DrSVxxGRkUq1eRGe7GYc5j765hEntzQwytpPaK5inAvh7sbqSPF8VNQV6vBGu1m7b"})
 
 (def resource-manifest-from-props
   (when-let [prop (System/getProperty "clerk.resource_manifest")]

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -10,7 +10,7 @@
     (not= "false" prop)))
 
 (def default-resource-manifest
-  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VufNXFDYymQD5T5zdSrX4tPbAHKpGQ3wCeTffp5Tot9yuYfLz98AU3DHW3QFWPNyteKUqHFPieLVR1fojL1hLrW8e"})
+  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvhXn3d1HeG9cCEfVqQYqRtRVgRBJBi89ao2cGWb7gg4YtYvKGzCeSamMk85AEye6FkUvHAGgYVUnroEmmEByzQ1F"})
 
 (def resource-manifest-from-props
   (when-let [prop (System/getProperty "clerk.resource_manifest")]

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -639,7 +639,7 @@
       [inspect @!error]])])
 
 (defn ^:export set-state [{:as state :keys [doc error]}]
-  (doseq [cell (viewer/value doc)
+  (doseq [cell (-> doc viewer/value :blocks)
           :when (viewer/registration? cell)
           :let [form (viewer/value cell)]]
     (*eval* form))

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -80,10 +80,7 @@
      (when-not @collapsed?
        (md.transform/->hiccup markdown/default-renderers toc))]))
 
-(defn notebook [{:as doc xs :blocks :keys [toc title]}]
-  ;; TODO: avoid side effects - as e.g. inline in app layout but
-  ;; this has the advantage to work both in un/bundled static apps as well
-  (set! (.-title js/document) title)
+(defn notebook [{:as doc xs :blocks :keys [toc]}]
   (html
    (into [:div.flex.flex-col.items-center.viewer-notebook
           (when toc (render-toc doc))]
@@ -645,7 +642,9 @@
     (*eval* form))
   (when (contains? state :doc)
     (reset! !doc doc))
-  (reset! !error error))
+  (reset! !error error)
+  (when-some [title (-> doc viewer/value :title)]
+    (set! (.-title js/document) title)))
 
 (dc/defcard eval-viewer
   "Viewers that are lists are evaluated using sci."

--- a/src/nextjournal/clerk/static_app.cljs
+++ b/src/nextjournal/clerk/static_app.cljs
@@ -52,8 +52,8 @@
          :path->url {"notebooks/hello.clj" "notebooks/hello.clj"}
          :url->path {"notebooks/hello.clj" "notebooks/hello.clj"}}])
 
-
 (defn index [{:as view-data :keys [paths]}]
+  (set! (.-title js/document) "Clerk")
   [:div.bg-gray-100.flex.justify-center.overflow-y-auto.w-screen.h-screen.p-4.md:p-0
    [:div.md:my-12.w-full.md:max-w-lg
     [:div.bg-white.shadow-lg.rounded-lg.border

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -141,28 +141,30 @@
 #_(->display {:result {:nextjournal.clerk/visibility #{:hide} :nextjournal/value {:nextjournal/viewer :hide-result}} :ns? false})
 #_(->display {:result {:nextjournal.clerk/visibility #{:hide}} :ns? true})
 
+(defn format-block [{:keys [inline-results?] :or {inline-results? false}} {:keys [ns]} {:as cell :keys [type text result doc]}]
+  (case type
+    :markdown [(v/md (or doc text))]
+    :code (let [{:keys [code? fold? result?]} (->display cell)]
+            (cond-> []
+              code?
+              (conj (cond-> (v/code text) fold? (assoc :nextjournal/viewer :code-folded)))
+              result?
+              (conj (cond
+                      (v/registration? (v/value result))
+                      (v/value result)
+                      :else
+                      (->result ns result (and (not inline-results?)
+                                               (contains? result :nextjournal/blob-id)))))))))
+
 (defn doc->viewer
   ([doc] (doc->viewer {} doc))
-  ([{:keys [inline-results?] :or {inline-results? false}} {:keys [ns blocks]}]
-   (cond-> (into []
-                 (mapcat (fn [{:as cell :keys [type text result doc]}]
-                           (case type
-                             :markdown [(v/md (or doc text))]
-                             :code (let [{:keys [code? fold? result?]} (->display cell)]
-                                     (cond-> []
-                                       code?
-                                       (conj (cond-> (v/code text) fold? (assoc :nextjournal/viewer :code-folded)))
-                                       result?
-                                       (conj (cond
-                                               (v/registration? (v/value result))
-                                               (v/value result)
-
-                                               :else
-                                               (->result ns result (and (not inline-results?)
-                                                                        (contains? result :nextjournal/blob-id))))))))))
-                 blocks)
-     true v/notebook
-     ns (assoc :scope (v/datafy-scope ns)))))
+  ([{:as opts :keys [toc?] :or {toc? true}} {:as doc :keys [ns]}]
+   (-> doc
+       (update :blocks #(into [] (mapcat (partial format-block opts doc)) %))
+       (select-keys [:blocks :toc :title])
+       (cond-> (not toc?) (dissoc :toc))
+       v/notebook
+       (cond-> ns (assoc :scope (v/datafy-scope ns))))))
 
 #_(meta (doc->viewer (nextjournal.clerk/eval-file "notebooks/hello.clj")))
 #_(nextjournal.clerk/show! "notebooks/test.clj")

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -204,8 +204,7 @@ window.ws_send = msg => ws.send(msg)")]]))
 (defn ->static-app [{:as state :keys [current-path]}]
   (hiccup/html5
    [:head
-    (when-let [title (and current-path (-> state :path->doc (get current-path) v/value :title))]
-      [:title title])
+    [:title (or (and current-path (-> state :path->doc (get current-path) v/value :title)) "Clerk")]
     [:meta {:charset "UTF-8"}]
     [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
     (include-tailwind-cdn)

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -141,7 +141,7 @@
 #_(->display {:result {:nextjournal.clerk/visibility #{:hide} :nextjournal/value {:nextjournal/viewer :hide-result}} :ns? false})
 #_(->display {:result {:nextjournal.clerk/visibility #{:hide}} :ns? true})
 
-(defn format-block [{:keys [inline-results?] :or {inline-results? false}} {:keys [ns]} {:as cell :keys [type text result doc]}]
+(defn describe-block [{:keys [inline-results?] :or {inline-results? false}} {:keys [ns]} {:as cell :keys [type text result doc]}]
   (case type
     :markdown [(v/md (or doc text))]
     :code (let [{:keys [code? fold? result?]} (->display cell)]
@@ -160,7 +160,7 @@
   ([doc] (doc->viewer {} doc))
   ([{:as opts :keys [toc?] :or {toc? true}} {:as doc :keys [ns]}]
    (-> doc
-       (update :blocks #(into [] (mapcat (partial format-block opts doc)) %))
+       (update :blocks #(into [] (mapcat (partial describe-block opts doc)) %))
        (select-keys [:blocks :toc :title])
        (cond-> (not toc?) (dissoc :toc))
        v/notebook

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -201,9 +201,11 @@ viewer.mount(document.getElementById('clerk'))\n"
 ws.onmessage = msg => viewer.set_state(viewer.read_string(msg.data))
 window.ws_send = msg => ws.send(msg)")]]))
 
-(defn ->static-app [state]
+(defn ->static-app [{:as state :keys [current-path]}]
   (hiccup/html5
    [:head
+    (when-let [title (and current-path (-> state :path->doc (get current-path) v/value :title))]
+      [:title title])
     [:meta {:charset "UTF-8"}]
     [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
     (include-tailwind-cdn)

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -158,7 +158,7 @@
 
 (defn doc->viewer
   ([doc] (doc->viewer {} doc))
-  ([{:as opts :keys [toc?] :or {toc? true}} {:as doc :keys [ns]}]
+  ([{:as opts :keys [toc?] :or {toc? false}} {:as doc :keys [ns]}]
    (-> doc
        (update :blocks #(into [] (mapcat (partial describe-block opts doc)) %))
        (select-keys [:blocks :toc :title])

--- a/test/nextjournal/clerk/hashing_test.clj
+++ b/test/nextjournal/clerk/hashing_test.clj
@@ -9,6 +9,38 @@
   `(binding [*ns* (find-ns ~ns-sym)]
      ~@body))
 
+(def notebook "^:nextjournal.clerk/no-cache (ns example-notebook)
+
+;; # 📶 Sorting
+
+;; ## Sorting Sets
+;; The following set should be sorted upon description
+
+#{3 1 2}
+
+;; ## Sorting Maps
+
+{2 \"bar\" 1 \"foo\"}
+")
+
+(deftest parse-clojure-string
+  (testing "is returning blocks with types and markdown structure attached"
+    (is (match? (m/equals {:blocks [{:type :code, :text "^:nextjournal.clerk/no-cache (ns example-notebook)", :ns? true}
+                                    {:type :markdown, :text " # 📶 Sorting\n"}
+                                    {:type :markdown, :text " ## Sorting Sets\n The following set should be sorted upon description\n"}
+                                    {:type :code, :text "#{3 1 2}"}
+                                    {:type :markdown, :text " ## Sorting Maps\n"}
+                                    {:type :code, :text "{2 \"bar\" 1 \"foo\"}"}],
+                           :visibility #{:show},
+                           :title "📶 Sorting",
+                           :toc {:type :toc,
+                                 :children [{:type :toc,
+                                             :content [{:type :text, :text "📶 Sorting"}],
+                                             :heading-level 1,
+                                             :children [{:type :toc, :content [{:type :text, :text "Sorting Sets"}], :heading-level 2}
+                                                        {:type :toc, :content [{:type :text, :text "Sorting Maps"}], :heading-level 2}]}]}})
+                (h/parse-clojure-string {:doc? true} notebook)))))
+
 (deftest no-cache?
   (testing "are variables set to no-cache?"
     (is (not (h/no-cache? '(rand-int 10))))

--- a/test/nextjournal/clerk/webserver_test.clj
+++ b/test/nextjournal/clerk/webserver_test.clj
@@ -11,7 +11,7 @@
 (deftest serve-blob
   (testing "lazy loading of simple range"
     (let [doc (clerk/eval-string "(range 100)")
-          {:nextjournal/keys [edn fetch-opts]} (-> doc view/doc->viewer :nextjournal/value second :nextjournal/value)
+          {:nextjournal/keys [edn fetch-opts]} (-> doc view/doc->viewer :nextjournal/value :blocks second :nextjournal/value)
           {:nextjournal/keys [value]} (read-result edn)
           {elision-viewer :nextjournal/viewer elision-fetch-opts :nextjournal/value} (peek value)
           {:keys [body]} (webserver/serve-blob doc (merge fetch-opts {:fetch-opts elision-fetch-opts}))]


### PR DESCRIPTION
This is a first step towards letting Clerk render a table of contents for a given document. We expose `:title` and `:toc` attributes as the result of parse for library consumers but do not yet render the table of contents in the dom. The only user facing change derived from this is using the document title in the browser.

![CleanShot 2022-01-17 at 18 22 01](https://user-images.githubusercontent.com/1078464/149813846-6746df4c-684b-44b4-88ef-f54da68865c4.gif)
