### PR TITLE
Refactor to avoid double parsing and make testing easier

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,8 +76,8 @@ jobs:
       - name: 🗝 Clerk Cache
         uses: actions/cache@v2
         with:
-          path: .cache
-          key: ${{ runner.os }}-clerk
+          path: .clerk
+          key: ${{ runner.os }}-clerk-cache
 
       - name: 🏗 Build Clerk Static App with default Notebooks
         run: clojure -X:demo nextjournal.clerk/build-static-app! :git/sha '"${{ github.sha }}"' :git/url '"https://github.com/nextjournal/clerk"'

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,8 @@
 
         rewrite-clj/rewrite-clj {:mvn/version "1.0.699-alpha"}}
 
- :aliases {:sci {:extra-deps  {applied-science/js-interop  {:mvn/version "0.3.0"}
+ :aliases {:nextjournal/clerk {:exec-fn nextjournal.clerk/build-static-app!}
+           :sci {:extra-deps  {applied-science/js-interop  {:mvn/version "0.3.0"}
                                borkdude/sci {:mvn/version "0.2.6"}
                                reagent/reagent {:mvn/version "1.1.0"}
                                io.github.nextjournal/viewers {:git/sha "3e1569a67dbec87bcbd7d1343aa754222aeede77"}

--- a/notebooks/how_clerk_works.clj
+++ b/notebooks/how_clerk_works.clj
@@ -35,6 +35,8 @@
 (let [{:keys [graph]} analyzed]
   (dep/transitive-dependencies graph 'how-clerk-works/analyzed))
 
+(keys analyzed)
+
 ;; ### Step 3: Hashing
 ;; Then we can use this information to hash each expression.
 (def hashes

--- a/notebooks/how_clerk_works.clj
+++ b/notebooks/how_clerk_works.clj
@@ -19,7 +19,7 @@
 ;; Then, each expression is analysed using `tools.analyzer`. A dependency graph, the analyzed form and the originating file is recorded.
 
 (def analyzed
-  (h/analyze-file "notebooks/how_clerk_works.clj"))
+  (h/build-graph parsed))
 
 
 ;; This analysis is done recursively, descending into all dependency symbols.
@@ -32,8 +32,8 @@
 
 (h/find-location 'java.util.UUID)
 
-(let [{:keys [graph]} (h/build-graph parsed)]
-  (dep/transitive-dependencies graph `analyzed))
+(let [{:keys [graph]} analyzed]
+  (dep/transitive-dependencies graph 'how-clerk-works/analyzed))
 
 ;; ### Step 3: Hashing
 ;; Then we can use this information to hash each expression.

--- a/notebooks/how_clerk_works.clj
+++ b/notebooks/how_clerk_works.clj
@@ -1,7 +1,7 @@
 ;; # How Clerk Works 🕵🏻‍♀️
 (ns how-clerk-works
   (:require [next.jdbc :as jdbc]
-            [nextjournal.clerk]
+            [nextjournal.clerk :as clerk]
             [nextjournal.clerk.hashing :as h]
             [weavejester.dependency :as dep]))
 
@@ -13,7 +13,7 @@
 ;; ### Step 1: Parsing
 ;; First, we parse a given Clojure file using `rewrite-clj`.
 (def parsed
-  (nextjournal.clerk/parse-file "notebooks/how_clerk_works.clj"))
+  (clerk/parse-file "notebooks/how_clerk_works.clj"))
 
 ;; ### Step 2: Analysis
 ;; Then, each expression is analysed using `tools.analyzer`. A dependency graph, the analyzed form and the originating file is recorded.
@@ -32,14 +32,14 @@
 
 (h/find-location 'java.util.UUID)
 
-(let [{:keys [graph]} (h/build-graph "notebooks/how_clerk_works.clj")]
+(let [{:keys [graph]} (h/build-graph parsed)]
   (dep/transitive-dependencies graph `analyzed))
 
 
 ;; ### Step 3: Hashing
 ;; Then we can use this information to hash each expression.
 (def hashes
-  (nextjournal.clerk.hashing/hash parsed))
+  (h/hash parsed))
 
 ;; ### Step 4: Evaluation
 ;; Clerk uses the hashes as filenames and only re-evaluates forms that haven't been seen before. The cache is using [nippy](https://github.com/ptaoussanis/nippy).
@@ -50,16 +50,14 @@
 ;; We can look up the cache key using the var name in the hashes map.
 (when-let [form-hash (get hashes `rand-fifteen)]
   (let [hash (slurp (nextjournal.clerk/->cache-file (str "@" form-hash)))]
-    (nextjournal.clerk/thaw-from-cas hash)))
+    (clerk/thaw-from-cas hash)))
 
 ;; As an escape hatch, you can tag a form or var with `::clerk/no-cache` to always re-evaluate it. The following form will never be cached.
-^:nextjournal.clerk/no-cache (shuffle (range 42))
+^::clerk/no-cache (shuffle (range 42))
 
 ;; For side effectful functions that should be cached, like a database query, you can add a value like this `#inst` to control when evaluation should happen.
 (def query-results
   (let [_run-at #_(java.util.Date.) #inst "2021-05-20T08:28:29.445-00:00"
         ds (next.jdbc/get-datasource {:dbtype "sqlite" :dbname "chinook.db"})]
     (with-open [conn (next.jdbc/get-connection ds)]
-      (nextjournal.clerk/table (next.jdbc/execute! conn ["SELECT AlbumId, Bytes, Name, TrackID, UnitPrice FROM tracks"])))))
-
-#_(nextjournal.clerk/show! "notebooks/how_clerk_works.clj")
+      (clerk/table (next.jdbc/execute! conn ["SELECT AlbumId, Bytes, Name, TrackID, UnitPrice FROM tracks"])))))

--- a/notebooks/how_clerk_works.clj
+++ b/notebooks/how_clerk_works.clj
@@ -28,19 +28,20 @@
 
 (h/find-location `dep/depend)
 
-(h/find-location  'io.methvin.watcher.DirectoryChangeEvent)
+(h/find-location 'io.methvin.watcher.DirectoryChangeEvent)
 
 (h/find-location 'java.util.UUID)
 
 (let [{:keys [graph]} analyzed]
   (dep/transitive-dependencies graph 'how-clerk-works/analyzed))
 
-(keys analyzed)
 
 ;; ### Step 3: Hashing
 ;; Then we can use this information to hash each expression.
 (def hashes
   (h/hash parsed))
+
+(keys hashes)
 
 ;; ### Step 4: Evaluation
 ;; Clerk uses the hashes as filenames and only re-evaluates forms that haven't been seen before. The cache is using [nippy](https://github.com/ptaoussanis/nippy).

--- a/notebooks/how_clerk_works.clj
+++ b/notebooks/how_clerk_works.clj
@@ -32,16 +32,14 @@
 
 (h/find-location 'java.util.UUID)
 
+
 (let [{:keys [graph]} analyzed]
   (dep/transitive-dependencies graph 'how-clerk-works/analyzed))
-
 
 ;; ### Step 3: Hashing
 ;; Then we can use this information to hash each expression.
 (def hashes
-  (h/hash parsed))
-
-(keys hashes)
+  (h/hash analyzed))
 
 ;; ### Step 4: Evaluation
 ;; Clerk uses the hashes as filenames and only re-evaluates forms that haven't been seen before. The cache is using [nippy](https://github.com/ptaoussanis/nippy).

--- a/notebooks/how_clerk_works.clj
+++ b/notebooks/how_clerk_works.clj
@@ -35,7 +35,6 @@
 (let [{:keys [graph]} (h/build-graph parsed)]
   (dep/transitive-dependencies graph `analyzed))
 
-
 ;; ### Step 3: Hashing
 ;; Then we can use this information to hash each expression.
 (def hashes
@@ -49,7 +48,7 @@
 
 ;; We can look up the cache key using the var name in the hashes map.
 (when-let [form-hash (get hashes `rand-fifteen)]
-  (let [hash (slurp (nextjournal.clerk/->cache-file (str "@" form-hash)))]
+  (let [hash (slurp (clerk/->cache-file (str "@" form-hash)))]
     (clerk/thaw-from-cas hash)))
 
 ;; As an escape hatch, you can tag a form or var with `::clerk/no-cache` to always re-evaluate it. The following form will never be cached.

--- a/notebooks/how_clerk_works.clj
+++ b/notebooks/how_clerk_works.clj
@@ -39,7 +39,7 @@
 ;; ### Step 3: Hashing
 ;; Then we can use this information to hash each expression.
 (def hashes
-  (nextjournal.clerk.hashing/hash "notebooks/how_clerk_works.clj"))
+  (nextjournal.clerk.hashing/hash (nextjournal.clerk.hashing/parse-file "notebooks/how_clerk_works.clj")))
 
 ;; ### Step 4: Evaluation
 ;; Clerk uses the hashes as filenames and only re-evaluates forms that haven't been seen before. The cache is using [nippy](https://github.com/ptaoussanis/nippy).

--- a/notebooks/how_clerk_works.clj
+++ b/notebooks/how_clerk_works.clj
@@ -39,7 +39,7 @@
 ;; ### Step 3: Hashing
 ;; Then we can use this information to hash each expression.
 (def hashes
-  (nextjournal.clerk.hashing/hash (nextjournal.clerk.hashing/parse-file "notebooks/how_clerk_works.clj")))
+  (nextjournal.clerk.hashing/hash parsed))
 
 ;; ### Step 4: Evaluation
 ;; Clerk uses the hashes as filenames and only re-evaluates forms that haven't been seen before. The cache is using [nippy](https://github.com/ptaoussanis/nippy).

--- a/notebooks/test123.clj
+++ b/notebooks/test123.clj
@@ -1,7 +1,5 @@
-(ns test123)
+(ns ^:nextjournal.clerk/no-cache test123)
 
 (def a 41)
 
 (def answer (inc a))
-
-(defonce !state (atom {}))

--- a/notebooks/test123.clj
+++ b/notebooks/test123.clj
@@ -1,5 +1,8 @@
-(ns ^:nextjournal.clerk/no-cache test123)
+(ns ^:nextjournal.clerk/no-cache test123
+  (:require [clojure.string :as str]))
 
 (def a 41)
 
 (def answer (inc a))
+
+(str/includes? "foo" "bar")

--- a/notebooks/test123.clj
+++ b/notebooks/test123.clj
@@ -1,0 +1,7 @@
+(ns test123)
+
+(def a 41)
+
+(def answer (inc a))
+
+(defonce !state (atom {}))

--- a/resources/tests/circular.clj
+++ b/resources/tests/circular.clj
@@ -1,5 +1,0 @@
-(ns circular)
-
-(declare a)
-(def b (str a " boom"))
-(def a (str "boom " b))

--- a/resources/tests/example_notebook.clj
+++ b/resources/tests/example_notebook.clj
@@ -1,8 +1,0 @@
-^:nextjournal.clerk/no-cache
-(ns example-notebook)
-
-;; # 📶 Sorting
-
-#{3 1 2}
-
-#_(nextjournal.clerk/show! "notebooks/sorting.clj")

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -157,7 +157,6 @@
 (defn +eval-results [results-last-run doc]
   (let [{:as info :keys [doc]} (hashing/build-graph doc) ;; TODO: clarify that this returns an analyzed doc
         ->hash (hashing/hash info)
-        _ (prn :->hash ->hash)
         {:keys [blocks visibility]} doc
         blocks (into [] (map (fn [{:as cell :keys [type]}]
                                (cond-> cell

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -169,6 +169,8 @@
 #_(parse-file "notebooks/elements.clj")
 #_(parse-file "notebooks/visibility.clj")
 
+#_(hashing/build-graph (parse-file "notebooks/test123.clj"))
+
 (defn eval-file
   ([file] (eval-file {} file))
   ([results-last-run file]

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -192,7 +192,7 @@
       (reset! !last-file file)
       (let [doc (parse-file file)
             results-last-run (meta @webserver/!doc)
-            {:keys [result time-ms]} (time-ms (+eval-results results-last-run (hashing/hash file) doc))]
+            {:keys [result time-ms]} (time-ms (+eval-results results-last-run (hashing/hash doc) doc))]
         ;; TODO diff to avoid flickering
         #_(webserver/update-doc! doc)
         (println (str "Clerk evaluated '" file "' in " time-ms "ms."))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -166,7 +166,7 @@
     (+eval-results blob->result {} doc))
 
 (defn parse-file [file]
-  (hashing/parse-file {:markdown? true} file))
+  (hashing/parse-file {:doc? true} file))
 
 #_(parse-file "notebooks/elements.clj")
 #_(parse-file "notebooks/visibility.clj")

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -1,11 +1,11 @@
 (ns nextjournal.clerk.config
   (:require [clojure.string :as str]))
 
-(defn cache-dir []
+(def cache-dir
   (or (System/getProperty "clerk.cache_dir")
-      ".cache"))
+      ".clerk/cache"))
 
-(defn cache-disabled? []
+(def cache-disabled?
   (when-let [prop (System/getProperty "clerk.disable_cache")]
     (not= "false" prop)))
 

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -375,12 +375,10 @@
 #_(dep/transitive-dependencies (:graph (build-graph "src/nextjournal/clerk/hashing.clj"))  #'nextjournal.clerk.hashing/long-thing)
 
 (defn- hash-form [->hash {:keys [hash form deps]}]
-  (prn :hash-form ->hash :hash hash :form form :deps deps)
   (let [hashed-deps (into #{} (map ->hash) deps)]
     (sha1-base58 (pr-str (conj hashed-deps (if form form hash))))))
 
 (defn hash [{:keys [->analysis-info graph]}]
-  (prn :->analysis-info ->analysis-info :graph graph)
   (reduce (fn [->hash k]
             (if-let [info (get ->analysis-info k)]
               (assoc ->hash k (hash-form ->hash info))

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -170,21 +170,21 @@
 (defn parse-markdown-cell [state markdown-code-cell]
   (reduce (fn [{:as state :keys [visibility]} node]
             (-> state
-                (update :doc conj (->codeblock visibility node))
+                (update :blocks conj (->codeblock visibility node))
                 (cond-> (not visibility) (assoc :visibility (-> node n/string read-string ->doc-visibility)))))
           state
           (-> markdown-code-cell markdown.transform/->text str/trim p/parse-string-all :children
               (->> (filter (comp code-tags n/tag))))))
 
 (defn parse-markdown-string [{:keys [doc?]} s]
-  (loop [{:as state :keys [nodes] ::keys [md-slice]} {:doc [] ::md-slice [] :nodes (:content (markdown/parse s))}]
+  (loop [{:as state :keys [nodes] ::keys [md-slice]} {:blocks [] ::md-slice [] :nodes (:content (markdown/parse s))}]
     (if-some [node (first nodes)]
       (recur
        (if (code-cell? node)
          (cond-> state
            (seq md-slice)
            (-> #_state
-               (update :doc conj {:type :markdown :doc {:type :doc :content md-slice}})
+               (update :blocks conj {:type :markdown :doc {:type :doc :content md-slice}})
                (assoc ::md-slice []))
 
            :always
@@ -195,8 +195,8 @@
          (-> state (update :nodes rest) (cond-> doc? (update ::md-slice conj node)))))
 
       (-> state
-          (update :doc #(cond-> % (seq md-slice) (conj {:type :markdown :doc {:type :doc :content md-slice}})))
-          (select-keys [:doc :visibility])))))
+          (update :blocks #(cond-> % (seq md-slice) (conj {:type :markdown :doc {:type :doc :content md-slice}})))
+          (select-keys [:blocks :visibility])))))
 
 (defn parse-file
   ([file] (parse-file {} file))

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -247,19 +247,11 @@
          code-cells (into [] (filter (comp #{:code} :type)) (:doc doc))]
      (reduce (partial analyze-codeblock (:file doc)) state-with-document code-cells))))
 
-
 (defn analyze-file
-  ([file]
-   (analyze-file {:graph (dep/graph)} file))
-  ([state file]
-   (analyze-file {} state file))
-  ([{:as opts :keys [markdown?]} state file]
-   (let [doc                 (parse-file opts file)
-         state-with-document (cond-> state markdown? (assoc :doc doc))
-         code-cells (into [] (filter (comp #{:code} :type)) (:doc doc))]
-     (reduce (partial analyze-codeblock file) state-with-document code-cells))))
+  ([file] (analyze-file {:graph (dep/graph)} file))
+  ([state file] (analyze-doc state (parse-file {} file))))
 
-#_(:graph (analyze-file {:markdown? true} {:graph (dep/graph)} "notebooks/elements.clj"))
+#_(:graph (analyze-file {:graph (dep/graph)} "notebooks/elements.clj"))
 #_(analyze-file {:markdown? true} {:graph (dep/graph)} "notebooks/rule_30.clj")
 #_(analyze-file {:graph (dep/graph)} "notebooks/recursive.clj")
 #_(analyze-file {:graph (dep/graph)} "notebooks/hello.clj")

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -78,7 +78,6 @@
 ;; TODO
 #_(analyze '(defonce !state (atom {})))
 
-
 (defn remove-leading-semicolons [s]
   (str/replace s #"^[;]+" ""))
 

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -193,9 +193,10 @@
 
 (defn parse-file
   ([file] (parse-file {} file))
-  ([opts file] (if (str/ends-with? file ".md")
-                 (parse-markdown-string opts (slurp file))
-                 (parse-clojure-string opts (slurp file)))))
+  ([opts file] (-> (if (str/ends-with? file ".md")
+                     (parse-markdown-string opts (slurp file))
+                     (parse-clojure-string opts (slurp file)))
+                   (assoc :file file))))
 
 #_(parse-file {:markdown? true} "notebooks/visibility.clj")
 #_(parse-file "notebooks/elements.clj")
@@ -244,7 +245,7 @@
   ([state doc]
    (let [state-with-document (assoc state :doc doc)
          code-cells (into [] (filter (comp #{:code} :type)) (:doc doc))]
-     (reduce (partial analyze-codeblock nil) state-with-document code-cells))))
+     (reduce (partial analyze-codeblock (:file doc)) state-with-document code-cells))))
 
 
 (defn analyze-file

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -343,8 +343,8 @@
 
   Recursively decends into dependency vars as well as given they can be found in the classpath.
   "
-  [file]
-  (let [{:as graph :keys [->analysis-info]} (analyze-file file)]
+  [doc]
+  (let [{:as graph :keys [->analysis-info]} (analyze-doc doc)]
     (reduce (fn [g [source symbols]]
               (if (or (nil? source)
                       (str/ends-with? source ".jar"))
@@ -366,8 +366,8 @@
 
 
 (defn hash
-  ([file]
-   (let [{vars :->analysis-info :keys [graph]} (build-graph file)]
+  ([doc]
+   (let [{vars :->analysis-info :keys [graph]} (build-graph doc)]
      (reduce (fn [vars->hash var]
                (if-let [info (get vars var)]
                  (assoc vars->hash var (hash vars->hash (assoc info :var var)))

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -227,9 +227,9 @@
   (let [{:keys [var deps form ns-effect?]} (-> text read-string analyze)
         state-with-var-hash (assoc-in state
                                       [:->analysis-info (if var var form)]
-                                      {:file file
-                                       :form form
-                                       :deps deps})]
+                                      (cond-> {:form form
+                                               :deps deps}
+                                        file (assoc :file file)))]
     (when ns-effect?
       (eval form))
     (if (seq deps)
@@ -244,7 +244,7 @@
   ([state doc]
    (let [state-with-document (assoc state :doc doc)
          code-cells (into [] (filter (comp #{:code} :type)) (:doc doc))]
-     (reduce (partial analyze-codeblock :string) state-with-document code-cells))))
+     (reduce (partial analyze-codeblock nil) state-with-document code-cells))))
 
 
 (defn analyze-file

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -389,12 +389,12 @@
 #_(hash "notebooks/hello.clj")
 #_(hash "notebooks/elements.clj")
 #_(clojure.data/diff (hash "notebooks/how_clerk_works.clj")
-(hash "notebooks/how_clerk_works.clj"))
+                     (hash "notebooks/how_clerk_works.clj"))
 
 (comment
-(require 'clojure.data)
-(let [file "notebooks/cache.clj"
-      g1 (build-graph file)
-      g2 (build-graph file)]
-  [:= (= g1 g2)
-   :diff (clojure.data/diff g1 g2)]))
+  (require 'clojure.data)
+  (let [file "notebooks/cache.clj"
+        g1 (build-graph file)
+        g2 (build-graph file)]
+    [:= (= g1 g2)
+     :diff (clojure.data/diff g1 g2)]))

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -128,27 +128,26 @@
 
 (defn doc->viewer
   ([doc] (doc->viewer {} doc))
-  ([{:keys [inline-results?] :or {inline-results? false}} doc]
-   (let [{:keys [ns]} (meta doc)]
-     (cond-> (into []
-                   (mapcat (fn [{:as cell :keys [type text result doc]}]
-                             (case type
-                               :markdown [(v/md (or doc text))]
-                               :code (let [{:keys [code? fold? result?]} (->display cell)]
-                                       (cond-> []
-                                         code?
-                                         (conj (cond-> (v/code text) fold? (assoc :nextjournal/viewer :code-folded)))
-                                         result?
-                                         (conj (cond
-                                                 (v/registration? (v/value result))
-                                                 (v/value result)
+  ([{:keys [inline-results?] :or {inline-results? false}} {:keys [ns blocks]}]
+   (cond-> (into []
+                 (mapcat (fn [{:as cell :keys [type text result doc]}]
+                           (case type
+                             :markdown [(v/md (or doc text))]
+                             :code (let [{:keys [code? fold? result?]} (->display cell)]
+                                     (cond-> []
+                                       code?
+                                       (conj (cond-> (v/code text) fold? (assoc :nextjournal/viewer :code-folded)))
+                                       result?
+                                       (conj (cond
+                                               (v/registration? (v/value result))
+                                               (v/value result)
 
-                                                 :else
-                                                 (->result ns result (and (not inline-results?)
-                                                                          (contains? result :nextjournal/blob-id))))))))))
-                   doc)
-       true v/notebook
-       ns (assoc :scope (v/datafy-scope ns))))))
+                                               :else
+                                               (->result ns result (and (not inline-results?)
+                                                                        (contains? result :nextjournal/blob-id))))))))))
+                 blocks)
+     true v/notebook
+     ns (assoc :scope (v/datafy-scope ns)))))
 
 #_(meta (doc->viewer (nextjournal.clerk/eval-file "notebooks/hello.clj")))
 #_(nextjournal.clerk/show! "notebooks/test.clj")

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -8,7 +8,7 @@
             [lambdaisland.uri :as uri]))
 
 (def help-doc
-  [{:type :markdown :text "Use `nextjournal.clerk/show!` to make your notebook appear…"}])
+  {:blocks [{:type :markdown :text "Use `nextjournal.clerk/show!` to make your notebook appear…"}]})
 
 (defonce !clients (atom #{}))
 (defonce !doc (atom help-doc))

--- a/test/nextjournal/clerk/hashing_test.clj
+++ b/test/nextjournal/clerk/hashing_test.clj
@@ -114,11 +114,9 @@
                             {:type :code
                              :text "#{3 1 2}"}]
                       :visibility #{:show}}
-                :->analysis-info {'(ns example-notebook) {:file :string,
-                                                          :form '(ns example-notebook),
+                :->analysis-info {'(ns example-notebook) {:form '(ns example-notebook),
                                                           :deps set?}
-                                  #{1 3 2} {:file :string,
-                                            :form '#{1 3 2},
+                                  #{1 3 2} {:form '#{1 3 2},
                                             :deps nil}}})
               (analyze-string "^:nextjournal.clerk/no-cache (ns example-notebook)
 ;; # 📶 Sorting

--- a/test/nextjournal/clerk/hashing_test.clj
+++ b/test/nextjournal/clerk/hashing_test.clj
@@ -13,7 +13,7 @@
   (testing "are variables set to no-cache?"
     (is (not (h/no-cache? '(rand-int 10))))
     (is (not (h/no-cache? '(def random-thing (rand-int 1000)))))
-    (is (not (h/no-cache? '(defn random-thing [] (rand-int 1000)))))
+    (is (not (h/no-cache? '(defn random-thing [] (rand-int 1000)))))n
     (is (h/no-cache? '(def ^:nextjournal.clerk/no-cache random-thing (rand-int 1000))))
     (is (h/no-cache? '(defn ^:nextjournal.clerk/no-cache random-thing [] (rand-int 1000))))
     (is (h/no-cache? '(defn ^{:nextjournal.clerk/no-cache true} random-thing [] (rand-int 1000))))
@@ -93,26 +93,28 @@
   (is (match? (m/equals
                {:graph {:dependencies {'(ns example-notebook) set?}
                         :dependents   map?}
-                :doc {:doc [{:type :code
-                             :text "^:nextjournal.clerk/no-cache (ns example-notebook)"
-                             :ns?  true}
-                            {:type :markdown
-                             :doc  {:type    :doc
-                                    :content [{:type :heading
-                                               :content [{:type :text, :text "📶 Sorting"}]
-                                               :heading-level 1}]
-                                    :toc     {:type :toc
-                                              :content
-                                              [{:level 1,
-                                                :type :toc
-                                                :title "📶 Sorting"
-                                                :node
-                                                {:type :heading
-                                                 :content [{:type :text, :text "📶 Sorting"}]
-                                                 :heading-level 1}
-                                                :path [:content 0]}]}}}
-                            {:type :code
-                             :text "#{3 1 2}"}]
+                :doc {:blocks [{:type :code
+                                :text "^:nextjournal.clerk/no-cache (ns example-notebook)"
+                                :form '(ns example-notebook)
+                                :ns?  true}
+                               {:type :markdown
+                                :doc  {:type    :doc
+                                       :content [{:type :heading
+                                                  :content [{:type :text, :text "📶 Sorting"}]
+                                                  :heading-level 1}]
+                                       :toc     {:type :toc
+                                                 :content
+                                                 [{:level 1,
+                                                   :type :toc
+                                                   :title "📶 Sorting"
+                                                   :node
+                                                   {:type :heading
+                                                    :content [{:type :text, :text "📶 Sorting"}]
+                                                    :heading-level 1}
+                                                   :path [:content 0]}]}}}
+                               {:type :code
+                                :text "#{3 1 2}"
+                                :form #{1 2 3}}]
                       :visibility #{:show}}
                 :->analysis-info {'(ns example-notebook) {:form '(ns example-notebook),
                                                           :deps set?}
@@ -128,7 +130,7 @@
                                       'circular/a #{clojure.core/str 'circular/a+circular/b}}}
                :->analysis-info {'circular/a any?
                                  'circular/b any?
-                                 'circular/a+circular/b {:form '(do ((str "boom " b)) ((str a " boom")))}}}
+                                 'circular/a+circular/b {:form '(do (def a (str "boom " b)) (def b(str a " boom")))}}}
               (analyze-string "(ns circular)
 (declare a)
 (def b (str a \" boom\"))

--- a/test/nextjournal/clerk/hashing_test.clj
+++ b/test/nextjournal/clerk/hashing_test.clj
@@ -86,7 +86,7 @@
     (is (not (h/symbol->jar 'java.net.http.HttpClient/newHttpClient)))))
 
 (defn analyze-string [s]
-  (-> (h/parse-clojure-string {:markdown? true} s)
+  (-> (h/parse-clojure-string {:doc? true} s)
       h/analyze-doc))
 
 (deftest analyze-doc

--- a/test/nextjournal/clerk/hashing_test.clj
+++ b/test/nextjournal/clerk/hashing_test.clj
@@ -13,7 +13,7 @@
   (testing "are variables set to no-cache?"
     (is (not (h/no-cache? '(rand-int 10))))
     (is (not (h/no-cache? '(def random-thing (rand-int 1000)))))
-    (is (not (h/no-cache? '(defn random-thing [] (rand-int 1000)))))n
+    (is (not (h/no-cache? '(defn random-thing [] (rand-int 1000)))))
     (is (h/no-cache? '(def ^:nextjournal.clerk/no-cache random-thing (rand-int 1000))))
     (is (h/no-cache? '(defn ^:nextjournal.clerk/no-cache random-thing [] (rand-int 1000))))
     (is (h/no-cache? '(defn ^{:nextjournal.clerk/no-cache true} random-thing [] (rand-int 1000))))
@@ -97,31 +97,14 @@
                                 :text "^:nextjournal.clerk/no-cache (ns example-notebook)"
                                 :form '(ns example-notebook)
                                 :ns?  true}
-                               {:type :markdown
-                                :doc  {:type    :doc
-                                       :content [{:type :heading
-                                                  :content [{:type :text, :text "📶 Sorting"}]
-                                                  :heading-level 1}]
-                                       :toc     {:type :toc
-                                                 :content
-                                                 [{:level 1,
-                                                   :type :toc
-                                                   :title "📶 Sorting"
-                                                   :node
-                                                   {:type :heading
-                                                    :content [{:type :text, :text "📶 Sorting"}]
-                                                    :heading-level 1}
-                                                   :path [:content 0]}]}}}
                                {:type :code
                                 :text "#{3 1 2}"
                                 :form #{1 2 3}}]
                       :visibility #{:show}}
                 :->analysis-info {'(ns example-notebook) {:form '(ns example-notebook),
                                                           :deps set?}
-                                  #{1 3 2} {:form '#{1 3 2},
-                                            :deps nil}}})
+                                  #{1 3 2} {:form '#{1 3 2}}}})
               (analyze-string "^:nextjournal.clerk/no-cache (ns example-notebook)
-;; # 📶 Sorting
 #{3 1 2}"))))
 
 (deftest circular-dependency

--- a/test/nextjournal/clerk/hashing_test.clj
+++ b/test/nextjournal/clerk/hashing_test.clj
@@ -86,42 +86,7 @@
     (is (not (h/symbol->jar 'java.net.http.HttpClient/newHttpClient)))))
 
 
-(deftest analyze-file
-  (is (match? (m/equals
-               {:graph {:dependencies {'(ns example-notebook) set?}
-                        :dependents   map?}
-                :doc {:doc [{:type :code
-                             :text "^:nextjournal.clerk/no-cache\n(ns example-notebook)"
-                             :ns?  true}
-                            {:type :markdown
-                             :doc  {:type    :doc
-                                    :content [{:type :heading
-                                               :content [{:type :text, :text "📶 Sorting"}]
-                                               :heading-level 1}]
-                                    :toc     {:type :toc
-                                              :content
-                                              [{:level 1,
-                                                :type :toc
-                                                :title "📶 Sorting"
-                                                :node
-                                                {:type :heading
-                                                 :content [{:type :text, :text "📶 Sorting"}]
-                                                 :heading-level 1}
-                                                :path [:content 0]}]}}}
-                            {:type :code
-                             :text "#{3 1 2}"}]
-                      :visibility #{:show}}
-                :->analysis-info {'(ns example-notebook) {:file "resources/tests/example_notebook.clj",
-                                                          :form '(ns example-notebook),
-                                                          :deps set?}
-                                  #{1 3 2} {:file "resources/tests/example_notebook.clj",
-                                            :form '#{1 3 2},
-                                            :deps nil}}})
-              (h/analyze-file {:markdown? true}
-                              {:graph (dep/graph)}
-                              "resources/tests/example_notebook.clj"))))
-
-(deftest analyze-string
+(deftest analyze-doc
   (is (match? (m/equals
                {:graph {:dependencies {'(ns example-notebook) set?}
                         :dependents   map?}
@@ -146,13 +111,13 @@
                             {:type :code
                              :text "#{3 1 2}"}]
                       :visibility #{:show}}
-                :->analysis-info {'(ns example-notebook) {:file "resources/tests/example_notebook.clj",
+                :->analysis-info {'(ns example-notebook) {:file :string,
                                                           :form '(ns example-notebook),
                                                           :deps set?}
-                                  #{1 3 2} {:file "resources/tests/example_notebook.clj",
+                                  #{1 3 2} {:file :string,
                                             :form '#{1 3 2},
                                             :deps nil}}})
-              (h/analyze-doc (h/parse-clojure-string "^:nextjournal.clerk/no-cache (ns example-notebook)
+              (h/analyze-doc (h/parse-clojure-string {:markdown? true} "^:nextjournal.clerk/no-cache (ns example-notebook)
 ;; # 📶 Sorting
 #{3 1 2}")))))
 

--- a/test/nextjournal/clerk/hashing_test.clj
+++ b/test/nextjournal/clerk/hashing_test.clj
@@ -121,6 +121,41 @@
                               {:graph (dep/graph)}
                               "resources/tests/example_notebook.clj"))))
 
+(deftest analyze-string
+  (is (match? (m/equals
+               {:graph {:dependencies {'(ns example-notebook) set?}
+                        :dependents   map?}
+                :doc {:doc [{:type :code
+                             :text "^:nextjournal.clerk/no-cache (ns example-notebook)"
+                             :ns?  true}
+                            {:type :markdown
+                             :doc  {:type    :doc
+                                    :content [{:type :heading
+                                               :content [{:type :text, :text "📶 Sorting"}]
+                                               :heading-level 1}]
+                                    :toc     {:type :toc
+                                              :content
+                                              [{:level 1,
+                                                :type :toc
+                                                :title "📶 Sorting"
+                                                :node
+                                                {:type :heading
+                                                 :content [{:type :text, :text "📶 Sorting"}]
+                                                 :heading-level 1}
+                                                :path [:content 0]}]}}}
+                            {:type :code
+                             :text "#{3 1 2}"}]
+                      :visibility #{:show}}
+                :->analysis-info {'(ns example-notebook) {:file "resources/tests/example_notebook.clj",
+                                                          :form '(ns example-notebook),
+                                                          :deps set?}
+                                  #{1 3 2} {:file "resources/tests/example_notebook.clj",
+                                            :form '#{1 3 2},
+                                            :deps nil}}})
+              (h/analyze-doc (h/parse-clojure-string "^:nextjournal.clerk/no-cache (ns example-notebook)
+;; # 📶 Sorting
+#{3 1 2}")))))
+
 (deftest circular-dependency
   (is (match? {:graph {:dependencies {'(ns circular) any?
                                       'circular/b #{clojure.core/str 'circular/a+circular/b}

--- a/test/nextjournal/clerk_test.clj
+++ b/test/nextjournal/clerk_test.clj
@@ -28,9 +28,11 @@
 (defn- lookup-var-in-*ns* [var-name]
   (find-var (symbol (str *ns*) var-name)))
 
+
 (deftest read+eval-cached
   (testing "basic eval'ing will give a result with a hash"
     (let [first-run (clerk/read+eval-cached {} {} #{:show} "{:x (inc 10)}")]
+      #_#_
       (is (match? {:nextjournal/value            {:x 11}
                    :nextjournal.clerk/visibility #{:show}
                    :nextjournal/blob-id          any?}
@@ -45,7 +47,7 @@
   (testing "eval'ing stores results in a cache"
     ;; ensure "a-var" is a variable in whatever namespace we're running in
     (intern *ns* 'a-var 0)
-
+    #_#_#_#_
     (is (match? {:nextjournal/value 1}
                 (clerk/read+eval-cached {} {} #{:show} "(inc a-var)")))
 
@@ -65,10 +67,16 @@
     ;; ensure "some-var" is a variable in whatever namespace we're running in
     (intern *ns* 'some-var 0)
     (testing "the variable is properly defined"
+      #_#_
       (is (match? {:nextjournal/value {::clerk/var-from-def #(= "some-var"
                                                                 (-> % symbol name))}}
                   (clerk/read+eval-cached {} {} #{:show} "(def some-var 99)")))
       (is (= 99 @(lookup-var-in-*ns* "some-var"))))))
 
 
-(deftest eval-doc)
+(defn eval-string [s]
+  (clerk/eval-doc (hashing/parse-clojure-string s)))
+
+(deftest eval-doc
+  (testing "hello 42"
+    (is (= [{}] (eval-string "(+ 39 3)")))))

--- a/test/nextjournal/clerk_test.clj
+++ b/test/nextjournal/clerk_test.clj
@@ -74,9 +74,14 @@
       (is (= 99 @(lookup-var-in-*ns* "some-var"))))))
 
 
-(defn eval-string [s]
-  (clerk/eval-doc (hashing/parse-clojure-string s)))
-
 (deftest eval-doc
   (testing "hello 42"
-    (is (= [{}] (eval-string "(+ 39 3)")))))
+    (is (match? [{:type :code,
+                  :result {:nextjournal/value 42}}]
+                (clerk/eval-string "(+ 39 3)")))
+    (is (match? [{:type :code,
+                  :result {:nextjournal/value 41}}]
+                (clerk/eval-string "(+ 39 2)")))
+    (is (match? [{:type :code,
+                  :result {:nextjournal/value 41}}]
+                (clerk/eval-string "^:nextjournal.clerk/no-cache (+ 39 2)")))))

--- a/test/nextjournal/clerk_test.clj
+++ b/test/nextjournal/clerk_test.clj
@@ -64,9 +64,11 @@
   (testing "handling binding forms i.e. def, defn"
     ;; ensure "some-var" is a variable in whatever namespace we're running in
     (intern *ns* 'some-var 0)
-
     (testing "the variable is properly defined"
       (is (match? {:nextjournal/value {::clerk/var-from-def #(= "some-var"
                                                                 (-> % symbol name))}}
                   (clerk/read+eval-cached {} {} #{:show} "(def some-var 99)")))
       (is (= 99 @(lookup-var-in-*ns* "some-var"))))))
+
+
+(deftest eval-doc)

--- a/test/nextjournal/clerk_test.clj
+++ b/test/nextjournal/clerk_test.clj
@@ -66,22 +66,22 @@
 
 (deftest eval-string
   (testing "hello 42"
-    (is (match? [{:type :code,
-                  :result {:nextjournal/value 42}}]
+    (is (match? {:blocks [{:type :code,
+                           :result {:nextjournal/value 42}}]}
                 (clerk/eval-string "(+ 39 3)")))
-    (is (match? [{:type :code,
-                  :result {:nextjournal/value 41}}]
+    (is (match? {:blocks [{:type :code,
+                           :result {:nextjournal/value 41}}]}
                 (clerk/eval-string "(+ 39 2)")))
-    (is (match? [{:type :code,
-                  :result {:nextjournal/value 41}}]
+    (is (match? {:blocks [{:type :code,
+                           :result {:nextjournal/value 41}}]}
                 (clerk/eval-string "^:nextjournal.clerk/no-cache (+ 39 2)"))))
 
   (testing "handling binding forms i.e. def, defn"
     ;; ensure "some-var" is a variable in whatever namespace we're running in
-    (intern (create-ns 'my-test-ns) 'some-var 0)
     (testing "the variable is properly defined"
-      (is (match? [map?
-                   {:type :code,
-                    :result {:nextjournal/value {::clerk/var-from-def (var my-test-ns/some-var)}}}]
-                  (clerk/eval-string "(ns ^:nextjournal.clerk/no-cache my-test-ns) (def some-var 99)")))
-      (is (= 99 @(var my-test-ns/some-var))))))
+      (let [{:keys [blocks]} (clerk/eval-string "(ns ^:nextjournal.clerk/no-cache my-test-ns) (def some-var 99)")]
+        (is (match? [map?
+                     {:type :code,
+                      :result {:nextjournal/value {::clerk/var-from-def var?}}}]
+                    blocks))
+        (is (= 99 @(find-var 'my-test-ns/some-var)))))))


### PR DESCRIPTION
This refactors the hashing and eval to:
- only parse & analyze each form once fixing an `Could not resolve var` error that could previously occur in the second analysis pass
- also provide string based interfaces and use for testing instead of going through files
- move Clerk's cache into the `.clerk` folder
- drop metadata and use a map to make conveyance of previous results more explicit