### PR TITLE
Improve viewer api

### DIFF
--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -156,11 +156,10 @@
     x))
 
 (defn fetch-all [opts xs]
-  (clojure.walk/postwalk (partial inspect-leafs opts) xs))
+  (w/postwalk (partial inspect-leafs opts) xs))
 
 (defn- var-from-def? [x]
   (get x :nextjournal.clerk/var-from-def))
-
 
 (declare !viewers)
 
@@ -363,7 +362,7 @@
     (describe xs (merge {:!budget (atom (:budget opts 200)) :path [] :viewers (get-viewers *ns* (viewers xs))} opts) [])))
   ([xs opts current-path]
    (let [{:as opts :keys [!budget viewers path offset]} (merge {:offset 0} opts)
-         {:as wrapped-value xs-viewers :nextjournal/viewers} (try (wrapped-with-viewer xs viewers) ;; TODO: respect `viewers` on `xs`
+         {:as wrapped-value xs-viewers :nextjournal/viewers} (try (wrapped-with-viewer xs viewers)
                                                                   (catch #?(:clj Exception :cljs js/Error) _ex
                                                                     (do (println _ex)
                                                                         nil)))

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -4,7 +4,7 @@
             [nextjournal.clerk.viewer :as v]))
 
 (defn find-elision [desc]
-  (first (filter (comp #{:elision} :nextjournal/viewer)
+  (first (filter (comp #{:elision} :name :nextjournal/viewer)
                  (tree-seq (comp vector? :nextjournal/value) :nextjournal/value desc))))
 
 (defn describe+fetch [value]

--- a/test/nextjournal/clerk/webserver_test.clj
+++ b/test/nextjournal/clerk/webserver_test.clj
@@ -15,6 +15,6 @@
           {:nextjournal/keys [value]} (read-result edn)
           {elision-viewer :nextjournal/viewer elision-fetch-opts :nextjournal/value} (peek value)
           {:keys [body]} (webserver/serve-blob doc (merge fetch-opts {:fetch-opts elision-fetch-opts}))]
-      (is (= :elision elision-viewer))
+      (is (= :elision (:name elision-viewer)))
       (is body)
       (is (= (-> body read-result :nextjournal/value first :nextjournal/value) 20)))))


### PR DESCRIPTION
* support the viewer api inside of the `html` viewer
* make all viewer functions consistently take an optional opts map for additional customizability like setting the width
* move the table viewer to be implemented using the viewer api and support it via keyword metadata. Also fixes an issue where the table viewer wasn't useable via metadata with the keyword value `^{:nextjournal.clerk/viewer :table}`