### PR TITLE
Overridable Markdown node Viewers

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -25,7 +25,7 @@
            :sci {:extra-deps  {applied-science/js-interop  {:mvn/version "0.3.0"}
                                borkdude/sci {:mvn/version "0.2.6"}
                                reagent/reagent {:mvn/version "1.1.0"}
-                               io.github.nextjournal/viewers {:git/sha "3e1569a67dbec87bcbd7d1343aa754222aeede77"}
+                               io.github.nextjournal/viewers {:git/sha "fd4a1b9ec220e17d2893988c57be2a239d165ef1"}
                                metosin/reitit-frontend     {:mvn/version "0.5.15"}}}
 
            :dev {:extra-deps {arrowic/arrowic {:mvn/version "0.1.1"}

--- a/notebooks/mathjax.clj
+++ b/notebooks/mathjax.clj
@@ -1,22 +1,21 @@
-(ns mathjax
+;; # MathJax
+(ns ^:nextjournal.clerk/no-cache mathjax
   (:require [nextjournal.clerk :as clerk]
             [nextjournal.clerk.viewer :as clerk-viewer]))
 
-#_(clerk/set-viewers! [{:name :latex :render-fn (quote v/mathjax-viewer) :fetch-fn (fn [_ x] x)}])
-#_(reset! clerk-viewer/!viewers clerk-viewer/all-viewers)
+(clerk/set-viewers! [{:name :latex
+                      :render-fn (quote v/mathjax-viewer)
+                      :fetch-fn (fn [_ x] x)}])
 
-(swap! clerk-viewer/!viewers update :root (partial mapv #(cond-> %
-                                                           (= :latex (:name %))
-                                                           (assoc :render-fn (quote v/mathjax-viewer)))))
+;; this is **strong** _cursive_ text
 
+;; - this is an inline formula $\phi$
+;; - in a list
 
 (clerk/tex "\\begin{equation}
  \\cos \\theta_1 = \\cos \\theta_2 \\implies \\theta_1 = \\theta_2
  \\label{eq:cosinjective}
  \\tag{COS-INJ}
  \\end{equation}")
-
-
-(clerk/tex "\\eqref{eq:cosinjective}")
 
 ;; As explained in $\eqref{eq:cosinjective}$.

--- a/notebooks/mathjax.clj
+++ b/notebooks/mathjax.clj
@@ -8,10 +8,21 @@
                       :render-fn (quote v/mathjax-viewer)
                       :fetch-fn (fn [_ x] x)}])
 
-;; this is **strong** _cursive_ text
+;; this is **strong** _cursive_ text.
+;;
+;; - this is an inline formula $\phi$ in
+;; - a list
+;;
+;; this is a block formula in markdown comment fragment
+;;
+;; $$
+;; \bigoplus_{\alpha<\omega}\iota_\alpha
+;; $$
+;; while this is a block formula rendererd as clerk result
 
-;; - this is an inline formula $\phi$
-;; - in a list
+(clerk/tex "\\int_a^b\\varphi(t)dt")
+
+;; this is only supported in MathJax
 
 (clerk/tex "\\begin{equation}
  \\cos \\theta_1 = \\cos \\theta_2 \\implies \\theta_1 = \\theta_2

--- a/notebooks/mathjax.clj
+++ b/notebooks/mathjax.clj
@@ -1,0 +1,22 @@
+(ns mathjax
+  (:require [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.viewer :as clerk-viewer]))
+
+#_(clerk/set-viewers! [{:name :latex :render-fn (quote v/mathjax-viewer) :fetch-fn (fn [_ x] x)}])
+#_(reset! clerk-viewer/!viewers clerk-viewer/all-viewers)
+
+(swap! clerk-viewer/!viewers update :root (partial mapv #(cond-> %
+                                                           (= :latex (:name %))
+                                                           (assoc :render-fn (quote v/mathjax-viewer)))))
+
+
+(clerk/tex "\\begin{equation}
+ \\cos \\theta_1 = \\cos \\theta_2 \\implies \\theta_1 = \\theta_2
+ \\label{eq:cosinjective}
+ \\tag{COS-INJ}
+ \\end{equation}")
+
+
+(clerk/tex "\\eqref{eq:cosinjective}")
+
+;; As explained in $\eqref{eq:cosinjective}$.

--- a/notebooks/mathjax.clj
+++ b/notebooks/mathjax.clj
@@ -1,4 +1,5 @@
 ;; # MathJax
+;; How to set default latex renderer to MathJax
 (ns ^:nextjournal.clerk/no-cache mathjax
   (:require [nextjournal.clerk :as clerk]
             [nextjournal.clerk.viewer :as clerk-viewer]))

--- a/notebooks/viewers/markdown.clj
+++ b/notebooks/viewers/markdown.clj
@@ -9,9 +9,6 @@
 ;; ### Lists
 ;; - one **strong**
 ;; - two ~~strikethrough~~
-;; ### Todos
-;; - [ ] one $\phi$-ormula
-;; - [x] checked two
 ;; ### Code
 ;; ```css
 ;; .viewer-markdown > :where(:last-child):not(:where([class~="not-prose"] *)) {
@@ -30,9 +27,23 @@ It's [Markdown](https://daringfireball.net/projects/markdown/), like you know it
 
 ;; ---
 ;; ## Overriding Markdown Viewers
-;; overriding single node viewers will have effect on the whole document
-(clerk/set-viewers! [{:name :nextjournal.markdown/ruler
+;; What's wrong with paragraph colors in this notebook? It's possible to override each markdown node viewer via `set-viewers!`, and this will instantly have effect on the whole document.
+(clerk/set-viewers! [{:name :nextjournal.markdown/paragraph
+                      :render-fn '(fn [{:keys [content]} opts]
+                                    (v/html
+                                     (into [:p {:style {:color "#0c4a6e"
+                                                        :font-size "110%"}}]
+                                           (map #(v/inspect opts %))
+                                           content)))}
+
+                     {:name :nextjournal.markdown/ruler
                       :render-fn '(constantly
                                    (v/html
-                                    [:hr {:style {:border "3px solid #f472b6"}}]))}])
+                                    [:hr {:style {:border "3px solid #f472b6"}}]))}
+                     {:name :latex
+                      :render-fn 'v/mathjax-viewer}])
+;; ### Current State
+;; - [x] Reactively update document when markdown viewers change
+;; - [x] Chaning viewers markdown depends on reactively update the document (see `:latex` viewer for $\phi$-or-$\mu$-ulas)
+;; - [ ] Expose convenient helpers to compose markup
 ;; ---

--- a/notebooks/viewers/markdown.clj
+++ b/notebooks/viewers/markdown.clj
@@ -1,4 +1,4 @@
-;; # Markdown ✍️
+;; # Markdown Viewer ✍️
 
 ^{:nextjournal.clerk/visibility #{:hide-ns}}
 (ns ^:nextjournal.clerk/no-cache viewers.markdown
@@ -10,7 +10,7 @@
 ;; - one **strong**
 ;; - two ~~strikethrough~~
 ;; ### Todos
-;; - [ ] one
+;; - [ ] one $\phi$-ormula
 ;; - [x] checked two
 ;; ### Code
 ;; ```css
@@ -25,11 +25,14 @@
 ;; ## Markdown Results
 ;; Clerk can in addition produce markdown result blocks
 
-(clerk/md "#### Text can be\n * **bold**\n * *italic\n * ~~Strikethrough~~\n
+(clerk/md "#### Text can be\n * **bold**\n * *italic*\n * ~~Strikethrough~~\n
 It's [Markdown](https://daringfireball.net/projects/markdown/), like you know it.")
 
 ;; ---
 ;; ## Overriding Markdown Viewers
+;; overriding single node viewers will have effect on the whole document
 (clerk/set-viewers! [{:name :nextjournal.markdown/ruler
-                      :render-fn '(constantly (v/html [:hr {:style {:border "3px solid #f472b6"}}]))}])
+                      :render-fn '(constantly
+                                   (v/html
+                                    [:hr {:style {:border "3px solid #f472b6"}}]))}])
 ;; ---

--- a/notebooks/viewers/markdown.clj
+++ b/notebooks/viewers/markdown.clj
@@ -33,7 +33,7 @@ It's [Markdown](https://daringfireball.net/projects/markdown/), like you know it
                                     (v/html
                                      (into [:p {:style {:color "#0c4a6e"
                                                         :font-size "110%"}}]
-                                           (map #(v/inspect opts %))
+                                           (v/inspect-children opts)
                                            content)))}
 
                      {:name :nextjournal.markdown/ruler

--- a/notebooks/viewers/markdown.clj
+++ b/notebooks/viewers/markdown.clj
@@ -5,7 +5,7 @@
   (:require [nextjournal.clerk :as clerk]))
 
 ;; ## Markdown Comments
-;; Clerk parses all _consecutive_ `;;`-led _clojure comment lines_ as [Markdown](#). All of markdown syntax should be supported:
+;; Clerk parses all _consecutive_ `;;`-led _clojure comment lines_ as [Markdown](https://daringfireball.net/projects/markdown). All of markdown syntax should be supported:
 ;; ### Lists
 ;; - one **strong**
 ;; - two ~~strikethrough~~
@@ -25,13 +25,11 @@
 ;; ## Markdown Results
 ;; Clerk can in addition produce markdown result blocks
 
-(clerk/md "### Text can be\n * **bold**\n * *italic\n * ~~Strikethrough~~\n
+(clerk/md "#### Text can be\n * **bold**\n * *italic\n * ~~Strikethrough~~\n
 It's [Markdown](https://daringfireball.net/projects/markdown/), like you know it.")
 
 ;; ---
 ;; ## Overriding Markdown Viewers
 (clerk/set-viewers! [{:name :nextjournal.markdown/ruler
-                      :render-fn '(fn [content opts]
-                                    (js/console.log :RulerCalled content)
-                                    (v/html [:span.red "This is a Red Ruler"]))}])
+                      :render-fn '(constantly (v/html [:hr {:style {:border "3px solid #f472b6"}}]))}])
 ;; ---

--- a/notebooks/viewers/markdown.clj
+++ b/notebooks/viewers/markdown.clj
@@ -7,7 +7,7 @@
 ;; ## Markdown Comments
 ;; Clerk parses all _consecutive_ `;;`-led _clojure comment lines_ as [Markdown](https://daringfireball.net/projects/markdown). All of markdown syntax should be supported:
 ;; ### Lists
-;; - one **strong**
+;; - one **strong** hashtag like #nomarkdownforoldcountry
 ;; - two ~~strikethrough~~
 ;; ### Code
 ;; ```css
@@ -27,7 +27,10 @@ It's [Markdown](https://daringfireball.net/projects/markdown/), like you know it
 
 ;; ---
 ;; ## Overriding Markdown Viewers
-;; What's wrong with paragraph colors in this notebook? It's possible to override each markdown node viewer via `set-viewers!`, and this will instantly have effect on the whole document.
+;; What's wrong with paragraph colors in this notebook? It's possible to override each markdown node viewer via `set-viewers!`[^setv], and this will instantly have effect on the whole document.
+;;
+;; [^setv]: `nextjournal.clerk/set-viewers!` takes a vector of viewer specs...
+
 (clerk/set-viewers! [{:name :nextjournal.markdown/paragraph
                       :render-fn '(fn [{:keys [content]} opts]
                                     (v/html
@@ -42,6 +45,7 @@ It's [Markdown](https://daringfireball.net/projects/markdown/), like you know it
                                     [:hr {:style {:border "3px solid #f472b6"}}]))}
                      {:name :latex
                       :render-fn 'v/mathjax-viewer}])
+
 ;; ### Current State
 ;; As an excuse to test _tables_ in markdown:
 ;;

--- a/notebooks/viewers/markdown.clj
+++ b/notebooks/viewers/markdown.clj
@@ -43,7 +43,12 @@ It's [Markdown](https://daringfireball.net/projects/markdown/), like you know it
                      {:name :latex
                       :render-fn 'v/mathjax-viewer}])
 ;; ### Current State
-;; - [x] Reactively update document when markdown viewers change
-;; - [x] Chaning viewers markdown depends on reactively update the document (see `:latex` viewer for $\phi$-or-$\mu$-ulas)
-;; - [ ] Expose convenient helpers to compose markup
+;; As an excuse to test _tables_ in markdown:
+;;
+;; | feature                                                                                                            |    |
+;; |:-------------------------------------------------------------------------------------------------------------------|:---|
+;; | Reactively update document when markdown viewers change                                                            |✅  |
+;; | Chaning viewers markdown depends on reactively update the document (see `:latex` viewer for $\phi$-or-$\mu$-ulas)  |✅  |
+;; | Expose convenient helpers to compose markup                                                                        |❌  |
+;;
 ;; ---

--- a/notebooks/viewers/markdown.clj
+++ b/notebooks/viewers/markdown.clj
@@ -1,5 +1,37 @@
 ;; # Markdown ✍️
-(ns markdown (:require [nextjournal.clerk :as clerk]))
+
+^{:nextjournal.clerk/visibility #{:hide-ns}}
+(ns ^:nextjournal.clerk/no-cache viewers.markdown
+  (:require [nextjournal.clerk :as clerk]))
+
+;; ## Markdown Comments
+;; Clerk parses all _consecutive_ `;;`-led _clojure comment lines_ as [Markdown](#). All of markdown syntax should be supported:
+;; ### Lists
+;; - one **strong**
+;; - two ~~strikethrough~~
+;; ### Todos
+;; - [ ] one
+;; - [x] checked two
+;; ### Code
+;; ```css
+;; .viewer-markdown > :where(:last-child):not(:where([class~="not-prose"] *)) {
+;;   margin-bottom: 0;
+;; }
+;; ```
+;; ### Images
+;; ![JCM](https://nextjournal.com/data/QmUyFWw9L8nZ6wvFTfJvtyqxtDyJiAr7EDZQxLVn64HASX?filename=Requiem-Ornaments-Byline.png&content-type=image/png)
+;;
+;; ---
+;; ## Markdown Results
+;; Clerk can in addition produce markdown result blocks
 
 (clerk/md "### Text can be\n * **bold**\n * *italic\n * ~~Strikethrough~~\n
 It's [Markdown](https://daringfireball.net/projects/markdown/), like you know it.")
+
+;; ---
+;; ## Overriding Markdown Viewers
+(clerk/set-viewers! [{:name :nextjournal.markdown/ruler
+                      :render-fn '(fn [content opts]
+                                    (js/console.log :RulerCalled content)
+                                    (v/html [:span.red "This is a Red Ruler"]))}])
+;; ---

--- a/notebooks/viewers/mathjax.clj
+++ b/notebooks/viewers/mathjax.clj
@@ -1,7 +1,7 @@
 ;; # ${\LaTeX}$ with MathJax
 ;; This is how to set Clerk's latex rendering to use ~~KaTeX~~ [MathJax](https://mathjax.org). _Right-click on formulas in this notebook to actually check it's rendered with Mathjax_.
 
-(ns ^:nextjournal.clerk/no-cache mathjax
+(ns ^:nextjournal.clerk/no-cache viewers.mathjax
   (:require [nextjournal.clerk :as clerk]))
 
 (clerk/set-viewers! [{:name :latex

--- a/notebooks/viewers/mathjax.clj
+++ b/notebooks/viewers/mathjax.clj
@@ -34,7 +34,5 @@
 ;; # Todos
 ;; ----------
 ;; - [x] render inline/display mode of formulas (both KaTeX and MathJax)
-;; - [ ] reimplement markdown node transformers as sci viewer functions
 ;; - [ ] handle clicks on equation references **(?)**
-;;
-;; ![mj](https://www.mathjax.org/badge/mj-logo.svg)
+

--- a/notebooks/viewers/mathjax.clj
+++ b/notebooks/viewers/mathjax.clj
@@ -1,8 +1,7 @@
-;; # MathJax
+;; # ${\LaTeX}$ with MathJax
 ;; How to set default latex renderer to MathJax
 (ns ^:nextjournal.clerk/no-cache mathjax
-  (:require [nextjournal.clerk :as clerk]
-            [nextjournal.clerk.viewer :as clerk-viewer]))
+  (:require [nextjournal.clerk :as clerk]))
 
 (clerk/set-viewers! [{:name :latex
                       :render-fn (quote v/mathjax-viewer)

--- a/notebooks/viewers/mathjax.clj
+++ b/notebooks/viewers/mathjax.clj
@@ -1,5 +1,6 @@
 ;; # ${\LaTeX}$ with MathJax
-;; Thisi is how to set Clerk's latex rendering to use [MathJax](https://mathjax.org). _Right-click on formulas in this notebook to actually check it's rendered with Mathjax_.
+;; This is how to set Clerk's latex rendering to use ~~KaTeX~~ [MathJax](https://mathjax.org). _Right-click on formulas in this notebook to actually check it's rendered with Mathjax_.
+
 (ns ^:nextjournal.clerk/no-cache mathjax
   (:require [nextjournal.clerk :as clerk]))
 
@@ -28,9 +29,12 @@
  \\label{eq:cosinjective}
  \\tag{COS-INJ}
  \\end{equation}")
-
-;; this is an example $\eqref{eq:cosinjective}$.
+;; this is an example of reference $\eqref{eq:cosinjective}$.
+;;
 ;; # Todos
+;; ----------
 ;; - [x] render inline/display mode of formulas (both KaTeX and MathJax)
 ;; - [ ] reimplement markdown node transformers as sci viewer functions
 ;; - [ ] handle clicks on equation references **(?)**
+;;
+;; ![mj](https://www.mathjax.org/badge/mj-logo.svg)

--- a/notebooks/viewers/mathjax.clj
+++ b/notebooks/viewers/mathjax.clj
@@ -1,5 +1,5 @@
 ;; # ${\LaTeX}$ with MathJax
-;; How to set default latex renderer to MathJax
+;; Thisi is how to set Clerk's latex rendering to use [MathJax](https://mathjax.org). _Right-click on formulas in this notebook to actually check it's rendered with Mathjax_.
 (ns ^:nextjournal.clerk/no-cache mathjax
   (:require [nextjournal.clerk :as clerk]))
 
@@ -7,21 +7,21 @@
                       :render-fn (quote v/mathjax-viewer)
                       :fetch-fn (fn [_ x] x)}])
 
-;; this is **strong** _cursive_ text.
+;; Check **inline formulas** are rendered correctly in _deeper fragments_
 ;;
 ;; - this is an inline formula $\phi$ in
 ;; - a list
 ;;
-;; this is a block formula in markdown comment fragment
+;; this is a block formula in a markdown comment fragment
 ;;
 ;; $$
 ;; \bigoplus_{\alpha<\omega}\iota_\alpha
 ;; $$
-;; while this is a block formula rendererd as clerk result
+;; while the following one is a block formula rendererd as clerk result
 
 (clerk/tex "\\int_a^b\\varphi(t)dt")
 
-;; this is only supported in MathJax
+;; equation references is only supported in MathJax
 
 (clerk/tex "\\begin{equation}
  \\cos \\theta_1 = \\cos \\theta_2 \\implies \\theta_1 = \\theta_2
@@ -29,4 +29,4 @@
  \\tag{COS-INJ}
  \\end{equation}")
 
-;; As explained in $\eqref{eq:cosinjective}$.
+;; this is an example $\eqref{eq:cosinjective}$.

--- a/notebooks/viewers/mathjax.clj
+++ b/notebooks/viewers/mathjax.clj
@@ -30,3 +30,7 @@
  \\end{equation}")
 
 ;; this is an example $\eqref{eq:cosinjective}$.
+;; # Todos
+;; - [x] render inline/display mode of formulas (both KaTeX and MathJax)
+;; - [ ] reimplement markdown node transformers as sci viewer functions
+;; - [ ] handle clicks on equation references **(?)**

--- a/resources/stylesheets/viewer.css
+++ b/resources/stylesheets/viewer.css
@@ -210,6 +210,12 @@
 
 /* MathJax */
 /* --------------------------------------------------------------- */
+
+mjx-container[display] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 mjx-container:not([display]) {
   display: inline-block;
 }

--- a/resources/stylesheets/viewer.css
+++ b/resources/stylesheets/viewer.css
@@ -111,6 +111,12 @@
   @apply mt-1;
 }
 
+/* compact TOC */
+.viewer-markdown .toc ul {
+  list-style: none;
+  @apply my-0;
+}
+
 /* Code Viewer */
 /* --------------------------------------------------------------- */
 
@@ -200,6 +206,12 @@
 }
 .viewer-markdown li > p {
   @apply inline;
+}
+
+/* MathJax */
+/* --------------------------------------------------------------- */
+mjx-container:not([display]) {
+  display: inline-block;
 }
 
 /* Todo Lists */

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -337,6 +337,7 @@
          "viewers/image"
          "viewers/image_layouts"
          "viewers/markdown"
+         "viewers/mathjax"
          "viewers/plotly"
          "viewers/table"
          "viewers/tex"

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -10,7 +10,7 @@
     (not= "false" prop)))
 
 (def default-resource-manifest
-  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VtrAyT1tkNwAPZyFu4amwY7s9rMteumpHLJUHWj4hhaAn7NxQnM1u9C5r9p37ZaEJ656h6Dh7NxGgHU6ztkNqEsnQ"})
+  {"/js/viewer.js" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvtpFHnfhgifbafZ1cEWyafMPzDLYn3MGyD5KAEa3WebTGGggFqiuGjn6EgYBFqxESBKxHXpWJeGJcANVJTs73Quq"})
 
 (def resource-manifest-from-props
   (when-let [prop (System/getProperty "clerk.resource_manifest")]

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -87,8 +87,9 @@
          (map (fn [x]
                 (let [viewer (viewer/viewer x)
                       blob-id (:blob-id (viewer/value x))
-                      prose? (= viewer :markdown)
+                      prose? (contains? #{:markdown :nextjournal.markdown/doc} viewer)
                       inner-viewer-name (some-> x viewer/value viewer/viewer :name)]
+                  ;; TODO: cleanup this mess
                   [:div {:class ["viewer" "overflow-x-auto"
                                  (when (keyword? viewer) (str "viewer-" (name viewer)))
                                  (when-not prose? "not-prose")

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -971,6 +971,9 @@ black")}]))}
    {:name :nextjournal.markdown/em :render-fn (into-markup [:em])}
    {:name :nextjournal.markdown/strong :render-fn (into-markup [:strong])}
    {:name :nextjournal.markdown/monospace :render-fn (into-markup [:code.monospace])}
+   {:name :nextjournal.markdown/link
+    :render-fn (fn [content {:as opts :keys [attrs]}]
+                 (html (into [:a attrs] (map (partial inspect opts)) content)))}
 
    ;; lists
    {:name :nextjournal.markdown/bullet-list :render-fn (into-markup [:ul])}

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -900,9 +900,9 @@ black")}]))}
 (defn katex-viewer [tex-string]
   (html (katex/to-html-string tex-string)))
 
-(defn html-viewer [markup]
+(defn html-viewer [markup {:as _opts :keys [inline?]}]
   (if (string? markup)
-    (html [:div {:dangerouslySetInnerHTML {:__html markup}}])
+    (html [(if inline? :span :div) {:dangerouslySetInnerHTML {:__html markup}}])
     (r/as-element markup)))
 
 (defn reagent-viewer [x]

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -1013,7 +1013,7 @@ black")}]))}
    ])
 
 (defn markdown-doc-viewer [content opts]
-  (html (into [:<>]
+  (html (into [:div]
               ;; TODO: ensure users can override nextjournal.markdown keys
               (map (partial inspect (update opts :viewers #(into default-markdown-viewers %))))
               content)))

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -1019,13 +1019,12 @@ black")}]))}
               content)))
 
 (dc/defcard markdown-doc-viewer
-  [:<>
+  [:div.viewer-markdown
    [inspect #:nextjournal{:viewer :nextjournal.markdown/doc,
                           :value [{:heading-level 1,
                                    :nextjournal/viewer :nextjournal.markdown/heading,
                                    :nextjournal/value [#:nextjournal{:value "MathJax",
                                                                      :viewer :nextjournal.markdown/text}]}]}]
-
 
    [inspect #:nextjournal{:viewer :nextjournal.markdown/doc,
                           :value [#:nextjournal{:viewer :nextjournal.markdown/paragraph,
@@ -1052,8 +1051,7 @@ black")}]))}
                                                         #:nextjournal{:viewer :nextjournal.markdown/list-item,
                                                                       :value [#:nextjournal{:viewer :nextjournal.markdown/paragraph,
                                                                                             :value [#:nextjournal{:value "a list",
-                                                                                                                  :viewer :nextjournal.markdown/text}]}]}]}]}
-    ]])
+                                                                                                                  :viewer :nextjournal.markdown/text}]}]}]}]}]])
 
 (def sci-viewer-namespace
   {'html html-viewer

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -966,7 +966,8 @@ black")}]))}
    {:name :nextjournal.markdown/softbreak :render-fn (constantly (html [:span " "]))}
    {:name :nextjournal.markdown/ruler :render-fn (constantly (html [:hr]))}
    {:name :nextjournal.markdown/code
-    :render-fn (fn [content _opts] (with-viewer :code (apply str (map viewer/value content))))}
+    :render-fn (fn [content _opts] (html [:div.viewer-code.w-full
+                                          [inspect (with-viewer :code (apply str (map viewer/value content)))]]))}
    {:name :nextjournal.markdown/image :render-fn (fn [_ {:keys [attrs]}] (html [:img attrs]))}
    {:name :nextjournal.markdown/heading
     :render-fn (fn [content {:as opts :keys [heading-level]}]

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -963,6 +963,7 @@ black")}]))}
   [{:name :nextjournal.markdown/text
     :render-fn (fn [content _opts] (html [:span content]))}
    {:name :nextjournal.markdown/paragraph :render-fn (into-markup [:p])}
+   {:name :nextjournal.markdown/softbreak :render-fn (constantly (html [:span " "]))}
    {:name :nextjournal.markdown/heading
     :render-fn (fn [content {:as opts :keys [heading-level]}]
                  (html (into [(keyword (str "h" heading-level))] (map (partial inspect opts)) content)))}

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -681,9 +681,6 @@
                       {:y (shuffle (range 10)) :name "The Empire"}]})])]
   {::dc/class "p-0"})
 
-
-(def ^:dynamic *viewers* nil)
-
 (dc/defcard inspect-rule-30-sci
   []
   [inspect {:path []

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -948,6 +948,109 @@ black")}]))}
   doc-url
   (sci/new-var 'doc-url (fn [x] (str "#" x))))
 
+;;;;;;;;;;;;;; Markdown Viewers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; TODO: turn into a macro with accessible `opts` and a placeholder for children content
+(defn into-markup [m]
+  (fn [content opts] (html (into m (map (partial inspect opts)) content))))
+
+(def default-markdown-viewers
+  [{:name :nextjournal.markdown/text
+    :render-fn (fn [content _opts] (html [:span content]))}
+   {:name :nextjournal.markdown/paragraph :render-fn (into-markup [:p])}
+   {:name :nextjournal.markdown/heading
+    :render-fn (fn [content {:as opts :keys [heading-level]}]
+                 (html (into [(keyword (str "h" heading-level))] (map (partial inspect opts)) content)))}
+
+   {:name :nextjournal.markdown/em :render-fn (into-markup [:em])}
+   {:name :nextjournal.markdown/strong :render-fn (into-markup [:strong])}
+   {:name :nextjournal.markdown/bullet-list :render-fn (into-markup [:ul])}
+   {:name :nextjournal.markdown/list-item :render-fn (into-markup [:li])}
+
+   ;;{:name :nextjournal.markdown/ruler
+   ;; :render-fn (fn [content opts])}
+
+   ;;{:name :nextjournal.markdown/em
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/sidenote
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/numbered-list
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/softbreak
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/monospace
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/sidenote-ref
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/block-formula
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/link
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/strikethrough
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/code
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/formula
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/image
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/table-head
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/doc
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/todo-item
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/hashtag
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/paragraph
+   ;; :render-fn (fn [content opts])}
+   ;;{:name :nextjournal.markdown/blockquote
+   ;; :render-fn (fn [content opts])}
+
+   ])
+
+(defn markdown-doc-viewer [content opts]
+  (html (into [:div.viewer-markdown]
+              ;; TODO: ensure users can override nextjournal.markdown keys
+              (map (partial inspect (update opts :viewers #(into default-markdown-viewers %))))
+              content)))
+
+(dc/defcard markdown-doc-viewer
+  [:<>
+   [inspect #:nextjournal{:viewer :nextjournal.markdown/doc,
+                          :value [{:heading-level 1,
+                                   :nextjournal/viewer :nextjournal.markdown/heading,
+                                   :nextjournal/value [#:nextjournal{:value "MathJax",
+                                                                     :viewer :nextjournal.markdown/text}]}]}]
+
+
+   [inspect #:nextjournal{:viewer :nextjournal.markdown/doc,
+                          :value [#:nextjournal{:viewer :nextjournal.markdown/paragraph,
+                                                :value [#:nextjournal{:value "this is ", :viewer :nextjournal.markdown/text}
+                                                        #:nextjournal{:viewer :nextjournal.markdown/strong,
+                                                                      :value [#:nextjournal{:value "strong",
+                                                                                            :viewer :nextjournal.markdown/text}]}
+                                                        #:nextjournal{:value " ", :viewer :nextjournal.markdown/text}
+                                                        #:nextjournal{:viewer :nextjournal.markdown/em,
+                                                                      :value [#:nextjournal{:value "cursive",
+                                                                                            :viewer :nextjournal.markdown/text}]}
+                                                        #:nextjournal{:value " text", :viewer :nextjournal.markdown/text}]}]}]
+
+   [inspect #:nextjournal{:viewer :nextjournal.markdown/doc,
+                          :value [#:nextjournal{:viewer :nextjournal.markdown/bullet-list,
+                                                :value [#:nextjournal{:viewer :nextjournal.markdown/list-item,
+                                                                      :value [#:nextjournal{:viewer :nextjournal.markdown/paragraph,
+                                                                                            :value [#:nextjournal{:value "this",
+                                                                                                                  :viewer :nextjournal.markdown/text}]}]}
+                                                        #:nextjournal{:viewer :nextjournal.markdown/list-item,
+                                                                      :value [#:nextjournal{:viewer :nextjournal.markdown/paragraph,
+                                                                                            :value [#:nextjournal{:value "is",
+                                                                                                                  :viewer :nextjournal.markdown/text}]}]}
+                                                        #:nextjournal{:viewer :nextjournal.markdown/list-item,
+                                                                      :value [#:nextjournal{:viewer :nextjournal.markdown/paragraph,
+                                                                                            :value [#:nextjournal{:value "a list",
+                                                                                                                  :viewer :nextjournal.markdown/text}]}]}]}]}
+    ]])
+
 (def sci-viewer-namespace
   {'html html-viewer
    'inspect inspect
@@ -978,7 +1081,10 @@ black")}]))}
    'reagent-viewer reagent-viewer
 
    'doc-url doc-url
-   'url-for url-for})
+   'url-for url-for
+
+   'markdown-doc-viewer markdown-doc-viewer
+   })
 
 (defonce !sci-ctx
   (atom (sci/init {:async? true

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -993,14 +993,18 @@ black")}]))}
    {:name :nextjournal.markdown/formula
     :render-fn (fn [{:keys [text]} opts] (inspect (assoc opts :inline? true) (with-viewer :latex text)))}
 
+   {:name :nextjournal.markdown/table :render-fn (into-markup [:table])}
+   {:name :nextjournal.markdown/table-head :render-fn (into-markup [:thead])}
+   {:name :nextjournal.markdown/table-body :render-fn (into-markup [:tbody])}
+   {:name :nextjournal.markdown/table-row :render-fn (into-markup [:tr])}
+   {:name :nextjournal.markdown/table-header
+    :render-fn (fn [{:keys [content attrs]} opts]
+                 (html (into [:th {:style (md.transform/table-alignment attrs)}] (inspect-children opts) content)))}
+   {:name :nextjournal.markdown/table-data
+    :render-fn (fn [{:keys [content attrs]} opts]
+                 (html (into [:td {:style (md.transform/table-alignment attrs)}] (inspect-children opts) content)))}
    #_ ;; TODO:
-   (:table-header
-    :table-data
-    :table-head
-    :table-body
-    :table-row
-    :table
-    :hashtag
+   (:hashtag
     :sidenote
     :sidenote-ref
     )

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -897,8 +897,8 @@ black")}]))}
 (defn clerk-eval [form]
   (.ws_send ^js goog/global (pr-str form)))
 
-(defn katex-viewer [tex-string]
-  (html (katex/to-html-string tex-string)))
+(defn katex-viewer [tex-string {:keys [inline?]}]
+  (html (katex/to-html-string tex-string #js {:displayMode (not inline?)})))
 
 (defn html-viewer [markup {:as _opts :keys [inline?]}]
   (if (string? markup)
@@ -908,7 +908,9 @@ black")}]))}
 (defn reagent-viewer [x]
   (r/as-element (cond-> x (fn? x) vector)))
 
-(def mathjax-viewer (comp normalize-viewer mathjax/viewer))
+(defn mathjax-viewer [tex-string opts]
+  (normalize-viewer (mathjax/viewer tex-string opts)))
+
 (def code-viewer (comp normalize-viewer code/viewer))
 (def plotly-viewer (comp normalize-viewer plotly/viewer))
 (def vega-lite-viewer (comp normalize-viewer vega-lite/viewer))
@@ -965,14 +967,23 @@ black")}]))}
     :render-fn (fn [content {:as opts :keys [heading-level]}]
                  (html (into [(keyword (str "h" heading-level))] (map (partial inspect opts)) content)))}
 
+   ;; marks
    {:name :nextjournal.markdown/em :render-fn (into-markup [:em])}
    {:name :nextjournal.markdown/strong :render-fn (into-markup [:strong])}
+   {:name :nextjournal.markdown/monospace :render-fn (into-markup [:code.monospace])}
+
+   ;; lists
    {:name :nextjournal.markdown/bullet-list :render-fn (into-markup [:ul])}
    {:name :nextjournal.markdown/list-item :render-fn (into-markup [:li])}
 
+   ;; formulas
+   {:name :nextjournal.markdown/block-formula
+    :render-fn (fn [content _opts] (with-viewer :latex content))}
+   {:name :nextjournal.markdown/formula
+    :render-fn (fn [content opts] (inspect (assoc opts :inline? true) (with-viewer :latex content)))}
+
    ;;{:name :nextjournal.markdown/ruler
    ;; :render-fn (fn [content opts])}
-
    ;;{:name :nextjournal.markdown/em
    ;; :render-fn (fn [content opts])}
    ;;{:name :nextjournal.markdown/sidenote
@@ -985,15 +996,11 @@ black")}]))}
    ;; :render-fn (fn [content opts])}
    ;;{:name :nextjournal.markdown/sidenote-ref
    ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/block-formula
-   ;; :render-fn (fn [content opts])}
    ;;{:name :nextjournal.markdown/link
    ;; :render-fn (fn [content opts])}
    ;;{:name :nextjournal.markdown/strikethrough
    ;; :render-fn (fn [content opts])}
    ;;{:name :nextjournal.markdown/code
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/formula
    ;; :render-fn (fn [content opts])}
    ;;{:name :nextjournal.markdown/image
    ;; :render-fn (fn [content opts])}

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -964,6 +964,10 @@ black")}]))}
     :render-fn (fn [content _opts] (html [:span content]))}
    {:name :nextjournal.markdown/paragraph :render-fn (into-markup [:p])}
    {:name :nextjournal.markdown/softbreak :render-fn (constantly (html [:span " "]))}
+   {:name :nextjournal.markdown/ruler :render-fn (constantly (html [:hr]))}
+   {:name :nextjournal.markdown/code
+    :render-fn (fn [content _opts] (with-viewer :code (apply str (map viewer/value content))))}
+   {:name :nextjournal.markdown/image :render-fn (fn [_ {:keys [attrs]}] (html [:img attrs]))}
    {:name :nextjournal.markdown/heading
     :render-fn (fn [content {:as opts :keys [heading-level]}]
                  (html (into [(keyword (str "h" heading-level))] (map (partial inspect opts)) content)))}
@@ -972,6 +976,8 @@ black")}]))}
    {:name :nextjournal.markdown/em :render-fn (into-markup [:em])}
    {:name :nextjournal.markdown/strong :render-fn (into-markup [:strong])}
    {:name :nextjournal.markdown/monospace :render-fn (into-markup [:code.monospace])}
+   {:name :nextjournal.markdown/strikethrough :render-fn (into-markup [:s])}
+   {:name :nextjournal.markdown/blockquote :render-fn (into-markup [:blockquote])}
    {:name :nextjournal.markdown/link
     :render-fn (fn [content {:as opts :keys [attrs]}]
                  (html (into [:a attrs] (map (partial inspect opts)) content)))}
@@ -993,25 +999,17 @@ black")}]))}
    {:name :nextjournal.markdown/formula
     :render-fn (fn [content opts] (inspect (assoc opts :inline? true) (with-viewer :latex content)))}
 
-   ;;{:name :nextjournal.markdown/ruler
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/sidenote
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/softbreak
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/sidenote-ref
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/strikethrough
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/code
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/image
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/hashtag
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/blockquote
-   ;; :render-fn (fn [content opts])}
-
+   #_ ;; TODO:
+   (:table-header
+    :table-data
+    :table-head
+    :table-body
+    :table-row
+    :table
+    :hashtag
+    :sidenote
+    :sidenote-ref
+    )
    ])
 
 (defn markdown-doc-viewer [content opts]

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -978,6 +978,13 @@ black")}]))}
    ;; lists
    {:name :nextjournal.markdown/bullet-list :render-fn (into-markup [:ul])}
    {:name :nextjournal.markdown/list-item :render-fn (into-markup [:li])}
+   {:name :nextjournal.markdown/numbered-list :render-fn (into-markup [:ol])}
+   {:name :nextjournal.markdown/todo-list :render-fn (into-markup [:ul.contains-task-list])}
+   {:name :nextjournal.markdown/todo-item
+    :render-fn (fn [content {:as opts :keys [attrs]}]
+                 (html (into [:li [:input {:type "checkbox" :default-checked (:checked attrs)}]]
+                             (map (partial inspect opts))
+                             content)))}
 
    ;; formulas
    {:name :nextjournal.markdown/block-formula
@@ -987,19 +994,11 @@ black")}]))}
 
    ;;{:name :nextjournal.markdown/ruler
    ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/em
-   ;; :render-fn (fn [content opts])}
    ;;{:name :nextjournal.markdown/sidenote
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/numbered-list
    ;; :render-fn (fn [content opts])}
    ;;{:name :nextjournal.markdown/softbreak
    ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/monospace
-   ;; :render-fn (fn [content opts])}
    ;;{:name :nextjournal.markdown/sidenote-ref
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/link
    ;; :render-fn (fn [content opts])}
    ;;{:name :nextjournal.markdown/strikethrough
    ;; :render-fn (fn [content opts])}
@@ -1007,15 +1006,7 @@ black")}]))}
    ;; :render-fn (fn [content opts])}
    ;;{:name :nextjournal.markdown/image
    ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/table-head
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/doc
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/todo-item
-   ;; :render-fn (fn [content opts])}
    ;;{:name :nextjournal.markdown/hashtag
-   ;; :render-fn (fn [content opts])}
-   ;;{:name :nextjournal.markdown/paragraph
    ;; :render-fn (fn [content opts])}
    ;;{:name :nextjournal.markdown/blockquote
    ;; :render-fn (fn [content opts])}

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -1012,8 +1012,7 @@ black")}]))}
 
 (defn markdown-doc-viewer [content opts]
   (html (into [:div]
-              ;; TODO: ensure users can override nextjournal.markdown keys
-              (map (partial inspect (update opts :viewers #(into default-markdown-viewers %))))
+              (map (partial inspect (update opts :viewers #(concat % default-markdown-viewers))))
               content)))
 
 (dc/defcard markdown-doc-viewer

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -149,8 +149,8 @@
 #_(->display {:result {:nextjournal.clerk/visibility #{:hide}} :ns? true})
 
 (defn update+rename-key
-  ([m k nk] (update+rename-key m k nk identity))
-  ([m k nk f] (-> m (assoc nk (f (k m))) (dissoc k))))
+  ([m k new-k] (update+rename-key m k new-k identity))
+  ([m k new-k f] (-> m (assoc new-k (f (get m k))) (dissoc k))))
 (defn describe-doc [{:as node :keys [text type content]}]
   (cond-> node
     text

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -167,7 +167,10 @@
 ;; keep viewer selection stricly in Clojure
 (def default-viewers
   ;; maybe make this a sorted-map
-  [{:pred char? :render-fn '(fn [c] (v/html [:span.syntax-string.inspected-value "\\" c]))}
+  [{:name :nextjournal.markdown/doc
+    :render-fn (quote v/markdown-doc-viewer)}
+
+   {:pred char? :render-fn '(fn [c] (v/html [:span.syntax-string.inspected-value "\\" c]))}
    {:pred string? :render-fn (quote v/quoted-string-viewer) :fetch-opts {:n elide-string-length}}
    {:pred number? :render-fn '(fn [x] (v/html [:span.syntax-number.inspected-value
                                                (if (js/Number.isNaN x) "NaN" (str x))]))}

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -533,7 +533,7 @@
                   (instance? clojure.lang.Namespace scope)
                   (var? scope)))
       (swap! !viewers assoc scope viewers)
-      (with-viewer :eval! `'(v/set-viewers! ~(datafy-scope scope) ~viewers)))))
+      (with-viewer :eval! `(v/set-viewers! ~(datafy-scope scope) ~viewers)))))
 
 
 (defn registration? [x]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -167,10 +167,7 @@
 ;; keep viewer selection stricly in Clojure
 (def default-viewers
   ;; maybe make this a sorted-map
-  [{:name :nextjournal.markdown/doc
-    :render-fn (quote v/markdown-doc-viewer)}
-
-   {:pred char? :render-fn '(fn [c] (v/html [:span.syntax-string.inspected-value "\\" c]))}
+  [{:pred char? :render-fn '(fn [c] (v/html [:span.syntax-string.inspected-value "\\" c]))}
    {:pred string? :render-fn (quote v/quoted-string-viewer) :fetch-opts {:n elide-string-length}}
    {:pred number? :render-fn '(fn [x] (v/html [:span.syntax-number.inspected-value
                                                (if (js/Number.isNaN x) "NaN" (str x))]))}
@@ -208,6 +205,7 @@
    {:name :hiccup :render-fn (quote v/html)} ;; TODO: drop once markdown doesn't use it anymore
    {:name :plotly :render-fn (quote v/plotly-viewer) :fetch-fn fetch-all}
    {:name :vega-lite :render-fn (quote v/vega-lite-viewer) :fetch-fn fetch-all}
+   {:name :nextjournal.markdown/doc :render-fn (quote v/markdown-doc-viewer)}
    {:name :markdown :render-fn (quote v/markdown-viewer) :fetch-fn fetch-all}
    {:name :code :render-fn (quote v/code-viewer) :fetch-fn fetch-all :transform-fn #(let [v (value %)] (if (string? v) v (with-out-str (pprint/pprint v))))}
    {:name :code-folded :render-fn (quote v/foldable-code-viewer) :fetch-fn fetch-all :transform-fn #(let [v (value %)] (if (string? v) v (with-out-str (pprint/pprint v))))}

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -8,7 +8,12 @@
             [lambdaisland.uri :as uri]))
 
 (def help-doc
-  {:blocks [{:type :markdown :text "Use `nextjournal.clerk/show!` to make your notebook appear…"}]})
+  {:blocks [{:type :markdown
+             :doc {:type :doc,
+                   :content [{:type :paragraph,
+                              :content [{:type :text, :text "Use "}
+                                        {:type :monospace, :content [{:type :text, :text "nextjournal.clerk/show!"}]}
+                                        {:type :text, :text " to make your notebook appear…"}]}]}}]})
 
 (defonce !clients (atom #{}))
 (defonce !doc (atom help-doc))

--- a/test/nextjournal/clerk/hashing_test.clj
+++ b/test/nextjournal/clerk/hashing_test.clj
@@ -25,20 +25,20 @@
 
 (deftest parse-clojure-string
   (testing "is returning blocks with types and markdown structure attached"
-    (is (match? (m/equals {:blocks [{:type :code, :text "^:nextjournal.clerk/no-cache (ns example-notebook)", :ns? true}
-                                    {:type :markdown, :text " # 📶 Sorting\n"}
-                                    {:type :markdown, :text " ## Sorting Sets\n The following set should be sorted upon description\n"}
-                                    {:type :code, :text "#{3 1 2}"}
-                                    {:type :markdown, :text " ## Sorting Maps\n"}
-                                    {:type :code, :text "{2 \"bar\" 1 \"foo\"}"}],
-                           :visibility #{:show},
-                           :title "📶 Sorting",
-                           :toc {:type :toc,
-                                 :children [{:type :toc,
-                                             :content [{:type :text, :text "📶 Sorting"}],
-                                             :heading-level 1,
-                                             :children [{:type :toc, :content [{:type :text, :text "Sorting Sets"}], :heading-level 2}
-                                                        {:type :toc, :content [{:type :text, :text "Sorting Maps"}], :heading-level 2}]}]}})
+    (is (match? {:blocks [{:type :code, :text "^:nextjournal.clerk/no-cache (ns example-notebook)", :ns? true}
+                          {:type :markdown, :doc {:type :doc :content [{:type :heading}]}}
+                          {:type :markdown, :doc {:type :doc :content [{:type :heading} {:type :paragraph}]}}
+                          {:type :code, :text "#{3 1 2}"}
+                          {:type :markdown, :doc {:type :doc :content [{:type :heading}]}}
+                          {:type :code, :text "{2 \"bar\" 1 \"foo\"}"}],
+                 :visibility #{:show},
+                 :title "📶 Sorting",
+                 :toc {:type :toc,
+                       :children [{:type :toc,
+                                   :content [{:type :text, :text "📶 Sorting"}],
+                                   :heading-level 1,
+                                   :children [{:type :toc, :content [{:type :text, :text "Sorting Sets"}], :heading-level 2}
+                                              {:type :toc, :content [{:type :text, :text "Sorting Maps"}], :heading-level 2}]}]}}
                 (h/parse-clojure-string {:doc? true} notebook)))))
 
 (deftest no-cache?


### PR DESCRIPTION
This set of changes (partially <sup>1</sup>) fits markdown rendering into the viewers API framework, in doing so we achieve: 

* each markdown node (`:heading`, `:paragraph`, `:monospace`, etc) gets assigned an individual viewer and as such its appearance is completely customisable by the user via `set-viewers!` function. Check the [markdown viewers notebook](https://snapshots.nextjournal.com/clerk/build/b1b010e26856c0b8ba20085f797802fd241d9509/index.html#/notebooks/viewers/markdown.clj).
* markdown viewers might depend on other viewers. For instance the formula viewer now is implemented  on top of the `:latex` viewer: changing the latter will affect all formulas inserted in markdown fragments. Check the [mathjax example](https://snapshots.nextjournal.com/clerk/build/b1b010e26856c0b8ba20085f797802fd241d9509/index.html#/notebooks/viewers/mathjax.clj).

It is debatable if this is sufficient or if we want to move viewer selection on the clojure side as per latest trend.

- [ ] fix safari issues with `Error: MathJax retry`

#### Notes
<sup>1</sup>: Markdown blocks are not described but passed to the client wrapped in `with-viewer` format. The client is still responsible for looking up the right viewer for each markdown node.