### PR TITLE
catch and rethrow eval error with additional context

### DIFF
--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -181,7 +181,14 @@
         blocks (into [] (map (fn [{:as cell :keys [type]}]
                                (cond-> cell
                                  (= :code type)
-                                 (assoc :result (read+eval-cached results-last-run ->hash visibility cell))))) blocks)]
+                                 (assoc :result
+                                        (try
+                                          (read+eval-cached results-last-run ->hash visibility cell)
+                                          (catch Exception e
+                                            (throw (ex-info "Evaluation in Clerk resulted in an exception"
+                                                            {:form (:form cell)
+                                                             :file (:file parsed-doc)}
+                                                            e)))))))) blocks)]
     (assoc parsed-doc :blocks blocks :blob->result (blob->result blocks) :ns *ns* :->analysis-info ->analysis-info :analyzed-doc doc :->hash ->hash :parsed-doc parsed-doc)))
 
 (defn parse-file [file]


### PR DESCRIPTION
It can be hard to track down the source of notebook evaluation errors. This PR adds the original file name and form for which the evaluation exception is relevant.

for a notebook with an expression like `(throw (ex-info "boom" {:hi :there}))` we have:

## before change
![20220203_14h37m04s_grim](https://user-images.githubusercontent.com/94817/152353376-a8710c3a-90a6-46a1-b86a-652da3bec694.png)

## after change

![20220203_14h36m22s_grim](https://user-images.githubusercontent.com/94817/152353344-a5b7ca54-3b5f-44da-8966-30a2e8864792.png)
