### PR TITLE
Support Dark Mode 🌓

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -25,7 +25,7 @@
            :sci {:extra-deps  {applied-science/js-interop  {:mvn/version "0.3.0"}
                                borkdude/sci {:mvn/version "0.2.6"}
                                reagent/reagent {:mvn/version "1.1.0"}
-                               io.github.nextjournal/viewers {:git/sha "3e1569a67dbec87bcbd7d1343aa754222aeede77"}
+                               io.github.nextjournal/viewers {:git/sha "b1580bff1e6996d5221f38ad23284bbbecc1e0e7"}
                                metosin/reitit-frontend     {:mvn/version "0.5.15"}}}
 
            :dev {:extra-deps {arrowic/arrowic {:mvn/version "0.1.1"}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@codemirror/state": "0.18.7",
     "@codemirror/view": "0.18.19",
     "d3-require": "^1.2.4",
+    "emoji-regex": "^10.0.0",
     "katex": "^0.12.0",
     "lezer-clojure": "0.1.10",
     "markdown-it": "12.3.2",

--- a/resources/stylesheets/tailwind.config.js
+++ b/resources/stylesheets/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: "class",
   content: ["./public/build/index.html", "./public/build/**/*.html", "./build/viewer.js"],
   theme: {
     extend: {},

--- a/resources/stylesheets/viewer.css
+++ b/resources/stylesheets/viewer.css
@@ -17,7 +17,7 @@
     @apply font-serif antialiased text-gray-900 sm:overscroll-y-none;
   }
   code, .code {
-    @apply font-mono text-sm text-gray-900 bg-slate-50 px-0.5 py-px rounded;
+    @apply font-mono text-sm text-gray-900 bg-slate-50 px-0.5 py-px rounded dark:bg-slate-800;
   }
   code::before, code::after { @apply content-none !important; }
   h1, h2, h3, h4, h5, h6 {
@@ -83,6 +83,10 @@
 .disclose:hover {
   border-color: var(--near-black-color) transparent;
 }
+.dark .disclose,
+.dark .disclose:hover {
+  border-color: white transparent;
+}
 .disclose.collapsed {
   @apply rotate-[-90deg];
 }
@@ -111,11 +115,17 @@
   @apply mt-1;
 }
 
+/* compact TOC */
+.viewer-markdown .toc ul {
+  list-style: none;
+  @apply my-0;
+}
+
 /* Code Viewer */
 /* --------------------------------------------------------------- */
 
 .viewer-code {
-  @apply font-mono bg-slate-100 rounded-sm py-4 px-8 text-sm mt-4 overflow-x-auto;
+  @apply font-mono bg-slate-100 rounded-sm py-4 px-8 text-sm mt-4 overflow-x-auto dark:bg-slate-800;
 }
 @media (min-width: 960px){
   .viewer-notebook .viewer-code {
@@ -125,34 +135,51 @@
 /* Don’t show focus outline when double-clicking cell in Safari */
 .cm-scroller { @apply focus:outline-none; }
 
-/* Data Viewer */
+/* Syntax Highlighting */
 /* --------------------------------------------------------------- */
 
-.inspected-value { @apply text-xs font-mono; }
+.inspected-value { @apply text-xs font-mono leading-[1.25rem]; }
+.cmt-strong, .cmt-heading { @apply font-bold; }
+.cmt-emphasis { @apply italic; }
+.cmt-strikethrough { @apply line-through; }
+.cmt-link { @apply underline; }
+.untyped-value { @apply whitespace-nowrap; }
 
-.syntax-tag, .cm-number, .syntax-number, .cm-string, .syntax-string,
-.cm-atom, .syntax-keyword, .cm-builtin, .cm-keyword, .syntax-symbol,
-.syntax-bool, .syntax-nil, .syntax-untyped, .syntax-key, .syntax-index {
-  @apply font-mono;
+.cm-editor, .cmt-default, .viewer-result {
+  @apply text-slate-700 dark:text-slate-300;
 }
-
-.syntax-tag     { @apply text-pink-900 !important; }
-.cm-number      { @apply text-sky-900 !important; }
-.syntax-number  { @apply text-sky-900 !important; }
-.cm-string      { @apply text-teal-700 !important; }
-.syntax-string  { @apply text-teal-700 !important; }
-.cm-atom        { @apply text-sky-900 !important; }
-.syntax-keyword { @apply text-sky-900 !important; }
-.cm-builtin     { @apply text-pink-900 !important; }
-.cm-keyword     { @apply text-pink-900 !important; }
-.syntax-symbol  { @apply text-pink-900 !important; }
-.syntax-bool    { @apply text-sky-900 !important; }
-.syntax-nil     { @apply text-sky-900 !important; }
-.syntax-untyped { @apply text-rose-500 !important; }
-.syntax-key     { @apply text-fuchsia-900 !important; }
-.syntax-index   { @apply text-fuchsia-900 !important; }
-
-.syntax-untyped { @apply whitespace-nowrap; }
+.cmt-keyword {
+  @apply text-pink-800 dark:text-pink-400;
+}
+.cmt-name, .cmt-deleted, .cmt-character, .cmt-propertyName, .cmt-macroName {
+  @apply text-red-700 dark:text-red-400;
+}
+.cmt-variableName, .cmt-variableName2, .cmt-labelName {
+  @apply text-sky-700 dark:text-sky-300;
+}
+.cmt-typeName, .cmt-className, .cmt-number, .cmt-changed, .cmt-annotation,
+.cmt-modifier, .cmt-self, .cmt-namespace {
+  @apply text-orange-800 dark:text-orange-300;
+}
+.cmt-url, .cmt-escape, .cmt-string2,
+.cmt-regexp, .cmt-link {
+  @apply text-cyan-700 dark:text-cyan-300;
+}
+.cmt-meta, .cmt-comment, .cmt-operator, .cmt-operatorKeyword {
+  @apply text-slate-500 dark:text-slate-400;
+}
+.cmt-punctuation {
+  @apply text-slate-600 dark:text-slate-500;
+}
+.cmt-atom, .cmt-bool {
+  @apply text-amber-700 dark:text-amber-200;
+}
+.cmt-processingInstruction, .cmt-string, .cmt-inserted, .cmt-literal {
+  @apply text-teal-700 dark:text-teal-300;
+}
+.cmt-invalid {
+  @apply text-slate-900 dark:text-white;
+}
 
 .result-data {
   @apply font-mono text-sm overflow-x-auto whitespace-nowrap leading-normal;
@@ -185,7 +212,9 @@
 .viewer-notebook,
 .viewer-markdown {
   @apply prose
-    prose-a:text-indigo-600 prose-a:font-medium prose-a:no-underline hover:prose-a:underline
+    dark:prose-invert
+    prose-a:text-blue-600 prose-a:no-underline hover:prose-a:underline
+    dark:prose-a:text-blue-300
     prose-p:mt-4 prose-p:leading-snug
     prose-ol:mt-4 prose-ol:mb-6 prose-ol:leading-snug
     prose-ul:mt-4 prose-ul:mb-6 prose-ul:leading-snug
@@ -276,6 +305,9 @@
 .viewer-code-folded + .viewer:not(.viewer-markdown):not(.viewer-code):not(.viewer-code-folded),
 .viewer-result + .viewer-result {
   @apply mt-2;
+}
+.viewer-result {
+  @apply leading-tight;
 }
 @media (min-width: 768px) {
   .devcard-desc > div {

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -123,7 +123,7 @@
 #_(opts->query {:s 10 :num 42})
 
 (defn unreadable-edn [edn]
-  (html [:span.inspected-value.whitespace-nowrap.text-gray-700 edn]))
+  (html [:span.inspected-value.whitespace-nowrap.cmt-default edn]))
 
 (defn error-badge [& content]
   [:div.bg-red-50.rounded-sm.text-xs.text-red-400.px-2.py-1.items-center.sans-serif.inline-flex
@@ -203,6 +203,18 @@
   (map-indexed (fn [idx x]
                  (inspect (update opts :path conj idx) x))))
 
+(def expand-style
+  ["cursor-pointer"
+   "bg-indigo-50"
+   "hover:bg-indigo-100"
+   "border-b"
+   "border-gray-400"
+   "hover:border-gray-500"
+   "dark:bg-slate-900"
+   "dark:hover:bg-slate-700"
+   "dark:border-slate-600"
+   "dark:hover:border-slate-500"])
+
 (defn coll-viewer [xs {:as opts :keys [path viewer !expanded-at]}]
   (html (let [expanded? (@!expanded-at path)
               {:keys [opening-paren closing-paren]} viewer]
@@ -212,7 +224,7 @@
             [:span.bg-opacity-70.whitespace-nowrap
              (when (< 1 (count xs))
                {:on-click (partial toggle-expanded !expanded-at path)
-                :class "cursor-pointer bg-indigo-50 hover:bg-indigo-100 hover:rounded-sm border-b border-gray-400 hover:border-gray-500"})
+                :class expand-style})
              opening-paren]
             (into [:<>]
                   (comp (inspect-children opts)
@@ -254,8 +266,8 @@
            [:span.sans-serif.relative.whitespace-nowrap
             {:style {:border-radius 2 :padding (when (fn? fetch-fn) "1px 3px") :font-size 11 :top -1}
              :class (if (fn? fetch-fn)
-                      "cursor-pointer bg-indigo-200 hover:bg-indigo-300"
-                      "text-gray-400")
+                      "cursor-pointer bg-indigo-200 hover:bg-indigo-300 dark:bg-slate-700 dark:hover:bg-slate-600 text-gray-900 dark:text-white"
+                      "text-gray-400 dark:text-slate-300")
              :on-click #(when (fn? fetch-fn)
                           (fetch-fn fetch-opts))} remaining (when unbounded? "+") (if (fn? fetch-fn) " more…" " more elided")])]))
 
@@ -268,7 +280,7 @@
             [:span.bg-opacity-70.whitespace-nowrap
              (when (expandable? xs)
                {:on-click (partial toggle-expanded !expanded-at path)
-                :class "cursor-pointer bg-indigo-50 hover:bg-indigo-100 hover:rounded-sm border-b border-gray-400 hover:border-gray-500"})
+                :class expand-style})
              "{"]
             (into [:<>]
                   (comp (inspect-children opts)
@@ -280,7 +292,7 @@
   (html (into [:span] (map #(cond->> % (not (string? %)) (inspect opts))) s)))
 
 (defn quoted-string-viewer [s opts]
-  (html [:span.syntax-string.inspected-value "\"" (viewer/value (string-viewer s opts)) "\""]))
+  (html [:span.cmt-string.inspected-value "\"" (viewer/value (string-viewer s opts)) "\""]))
 
 
 (defn sort! [!sort i k]
@@ -309,10 +321,10 @@
   ;; currently boxing the value in a vector to retain the type info
   ;; TODO: find a better way to do this
   (html
-   [:div.bg-red-100.px-6.py-4.rounded.text-xs
-    [:h4.mt-0.uppercase.text-xs "Table Error"]
+   [:div.bg-red-100.dark:bg-slate-800.px-6.py-4.rounded-md.text-xs.dark:border-2.dark:border-red-400
+    [:h4.mt-0.uppercase.text-xs.dark:text-red-400.tracking-wide "Table Error"]
     [:p.mt-4.font-medium "Clerk’s table viewer does not recognize the format of your data:"]
-    [:div.mt-2.flex.items-center
+    [:div.mt-2.flex
      [:div.text-red-500.mr-2 x-icon]
      [inspect data]]
     [:p.mt-4.font-medium "Currently, the following formats are supported:"]
@@ -339,9 +351,9 @@
         (html
          (let [{:keys [head rows]} (cond->> data sort-key (sort-data srt))
                num-cols (-> rows viewer/value first viewer/value count)]
-           [:table.text-xs.sans-serif
+           [:table.text-xs.sans-serif.text-gray-900.dark:text-white
             (when head
-              [:thead.border-b.border-gray-300
+              [:thead.border-b.border-gray-300.dark:border-slate-700
                (into [:tr]
                      (map-indexed (fn [i k]
                                     [:th.relative.pl-6.pr-2.py-1.align-bottom.font-medium
@@ -366,23 +378,23 @@
                                    (let [{:as fetch-opts :keys [remaining unbounded?]} (viewer/value row)]
                                      [view-context/consume :fetch-fn
                                       (fn [fetch-fn]
-                                        [:tr.border-t
+                                        [:tr.border-t.dark:border-slate-700
                                          [:td.text-center.py-1
                                           {:col-span num-cols
                                            :class (if (fn? fetch-fn)
-                                                    "bg-indigo-50 hover:bg-indigo-100 cursor-pointer"
-                                                    "text-gray-400")
+                                                    "bg-indigo-50 hover:bg-indigo-100 dark:bg-slate-800 dark:hover:bg-slate-700 cursor-pointer"
+                                                    "text-gray-400 text-slate-500")
                                            :on-click #(when (fn? fetch-fn)
                                                         (fetch-fn fetch-opts))}
                                           remaining (when unbounded? "+") (if (fn? fetch-fn) " more…" " more elided")]])])
                                    (let [row (viewer/value row)]
                                      (into
-                                      [:tr.hover:bg-gray-200
-                                       {:class (if (even? i) "bg-opacity-5 bg-black" "bg-white")}]
+                                      [:tr.hover:bg-gray-200.dark:hover:bg-slate-700
+                                       {:class (if (even? i) "bg-black/5 dark:bg-slate-800" "bg-white dark:bg-slate-900")}]
                                       (map-indexed (fn [j d]
                                                      [:td.pl-6.pr-2.py-1
                                                       {:class [(when (number? d) "text-right")
-                                                               (when (= j sort-index) "bg-opacity-5 bg-black")]}
+                                                               (when (= j sort-index) "bg-black/5 dark:bg-slate-800")]}
                                                       [inspect (update opts :path conj i j) d]]) row))))) (viewer/value rows)))]))))))
 
 
@@ -411,7 +423,7 @@
 
 (defn tagged-value [tag value]
   [:span.inspected-value.whitespace-nowrap
-   [:span.syntax-tag tag] value])
+   [:span.cmt-meta tag] value])
 
 (defn normalize-viewer [x]
   (if-let [viewer (-> x meta :nextjournal/viewer)]
@@ -421,7 +433,7 @@
 (def js-viewers
   [{:pred #(implements? IDeref %) :render-fn #(tagged-value (-> %1 type pr-str) (inspect (deref %1) %2))}
    {:pred goog/isObject :render-fn js-object-viewer}
-   {:pred array? :render-fn (partial coll-viewer {:open [:<> [:span.syntax-tag "#js "] "["] :close "]"})}])
+   {:pred array? :render-fn (partial coll-viewer {:open [:<> [:span.cmt-meta "#js "] "["] :close "]"})}])
 
 
 (defonce !doc (ratom/atom nil))

--- a/src/nextjournal/clerk/static_app.cljs
+++ b/src/nextjournal/clerk/static_app.cljs
@@ -48,7 +48,7 @@
                :nextjournal/value [{:nextjournal/value "# Hello Clerk 👋", :nextjournal/viewer :markdown}
                                    {:nextjournal/value "(+ 39 3)", :nextjournal/viewer :code}
                                    {:nextjournal/viewer :clerk/result,
-                                    :nextjournal/value {:nextjournal/edn "{:path [], :nextjournal/value 42, :nextjournal/viewer {:render-fn #function+ (fn [x] (v/html [:span.syntax-number.inspected-value (if (js/Number.isNaN x) \"NaN\" (str x))]))}}"}, :path []}],},
+                                    :nextjournal/value {:nextjournal/edn "{:path [], :nextjournal/value 42, :nextjournal/viewer {:render-fn #function+ (fn [x] (v/html [:span.cmt-number.inspected-value (if (js/Number.isNaN x) \"NaN\" (str x))]))}}"}, :path []}],},
          :path->url {"notebooks/hello.clj" "notebooks/hello.clj"}
          :url->path {"notebooks/hello.clj" "notebooks/hello.clj"}}])
 

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -197,7 +197,7 @@
     (hiccup/include-js (@config/!resource->url "/js/viewer.js"))
     (hiccup/include-css "https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.css")
     (hiccup/include-css "https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&family=Fira+Mono:wght@400;700&family=Fira+Sans+Condensed:ital,wght@0,700;1,700&family=Fira+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&family=PT+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap")]
-   [:body
+   [:body.dark:bg-slate-900
     [:div#clerk]
     [:script "let viewer = nextjournal.clerk.sci_viewer
 let state = " (-> state ->edn pr-str) "

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -167,24 +167,24 @@
 ;; keep viewer selection stricly in Clojure
 (def default-viewers
   ;; maybe make this a sorted-map
-  [{:pred char? :render-fn '(fn [c] (v/html [:span.syntax-string.inspected-value "\\" c]))}
+  [{:pred char? :render-fn '(fn [c] (v/html [:span.cmt-string.inspected-value "\\" c]))}
    {:pred string? :render-fn (quote v/quoted-string-viewer) :fetch-opts {:n elide-string-length}}
-   {:pred number? :render-fn '(fn [x] (v/html [:span.syntax-number.inspected-value
+   {:pred number? :render-fn '(fn [x] (v/html [:span.cmt-number.inspected-value
                                                (if (js/Number.isNaN x) "NaN" (str x))]))}
-   {:pred symbol? :render-fn '(fn [x] (v/html [:span.syntax-symbol.inspected-value x]))}
-   {:pred keyword? :render-fn '(fn [x] (v/html [:span.syntax-keyword.inspected-value (str x)]))}
-   {:pred nil? :render-fn '(fn [_] (v/html [:span.syntax-nil.inspected-value "nil"]))}
-   {:pred boolean? :render-fn '(fn [x] (v/html [:span.syntax-bool.inspected-value (str x)]))}
-   {:pred fn? :name :fn :render-fn '(fn [x] (v/html [:span.inspected-value [:span.syntax-tag "#function"] "[" x "]"]))}
+   {:pred symbol? :render-fn '(fn [x] (v/html [:span.cmt-keyword.inspected-value x]))}
+   {:pred keyword? :render-fn '(fn [x] (v/html [:span.cmt-atom.inspected-value (str x)]))}
+   {:pred nil? :render-fn '(fn [_] (v/html [:span.cmt-default.inspected-value "nil"]))}
+   {:pred boolean? :render-fn '(fn [x] (v/html [:span.cmt-bool.inspected-value (str x)]))}
+   {:pred fn? :name :fn :render-fn '(fn [x] (v/html [:span.inspected-value [:span.cmt-meta "#function"] "[" x "]"]))}
    {:pred map-entry? :name :map-entry :render-fn '(fn [xs opts] (v/html (into [:<>] (comp (v/inspect-children opts) (interpose " ")) xs))) :fetch-opts {:n 2}}
    {:pred var-from-def? :transform-fn (fn [x] (-> x :nextjournal.clerk/var-from-def deref))}
    {:pred vector? :render-fn 'v/coll-viewer :opening-paren "[" :closing-paren "]" :fetch-opts {:n 20}}
    {:pred set? :render-fn 'v/coll-viewer :opening-paren "#{" :closing-paren "}" :fetch-opts {:n 20}}
    {:pred sequential? :render-fn 'v/coll-viewer :opening-paren "(" :closing-paren ")" :fetch-opts {:n 20}}
    {:pred map? :name :map :render-fn 'v/map-viewer :opening-paren "{" :closing-paren "}" :fetch-opts {:n 10}}
-   {:pred uuid? :render-fn '(fn [x] (v/html (v/tagged-value "#uuid" [:span.syntax-string.inspected-value "\"" (str x) "\""])))}
-   {:pred inst? :render-fn '(fn [x] (v/html (v/tagged-value "#inst" [:span.syntax-string.inspected-value "\"" (str x) "\""])))}
-   {:pred var? :transform-fn symbol :render-fn '(fn [x] (v/html [:span.inspected-value [:span.syntax-tag "#'" (str x)]]))}
+   {:pred uuid? :render-fn '(fn [x] (v/html (v/tagged-value "#uuid" [:span.cmt-string.inspected-value "\"" (str x) "\""])))}
+   {:pred inst? :render-fn '(fn [x] (v/html (v/tagged-value "#inst" [:span.cmt-string.inspected-value "\"" (str x) "\""])))}
+   {:pred var? :transform-fn symbol :render-fn '(fn [x] (v/html [:span.inspected-value [:span.cmt-meta "#'" (str x)]]))}
    {:pred (fn [e] (instance? #?(:clj Throwable :cljs js/Error) e)) :fetch-fn fetch-all
     :name :error :render-fn (quote v/throwable-viewer) :transform-fn (comp demunge-ex-data datafy/datafy)}
    #?(:clj {:pred #(instance? BufferedImage %)
@@ -197,7 +197,7 @@
                                                :nextjournal/content-type "image/png"
                                                :nextjournal/width (if (and (< 2 r) (< 900 w)) :full :wide)})))
             :render-fn '(fn [blob] (v/html [:figure.flex.flex-col.items-center [:img {:src (v/url-for blob)}]]))})
-   {:pred (fn [_] true) :transform-fn pr-str :render-fn '(fn [x] (v/html [:span.inspected-value.whitespace-nowrap.text-gray-700 x]))}
+   {:pred (fn [_] true) :transform-fn pr-str :render-fn '(fn [x] (v/html [:span.inspected-value.whitespace-nowrap.cmt-default x]))}
    {:name :elision :render-fn (quote v/elision-viewer) :fetch-fn fetch-all}
    {:name :latex :render-fn (quote v/katex-viewer) :fetch-fn fetch-all}
    {:name :mathjax :render-fn (quote v/mathjax-viewer) :fetch-fn fetch-all}


### PR DESCRIPTION
* [x] Dark mode
* [ ] ~~Dark mode toggle (default is system settings, store in localStorage)~~

This adds support for dark mode but doesn’t use it yet. You can give it a spin by exectuing the following in your browser’s web console:

```js
document.querySelector("html").classList.add("dark")
```

Closes #29.

<img width="1098" alt="CleanShot 2022-02-08 at 16 08 35@2x" src="https://user-images.githubusercontent.com/1944/153022658-55ae95b3-f616-4b12-9952-cccd40fd1609.png">
