### PR TITLE
Normalize viewers to support full map form

### DIFF
--- a/notebooks/dice.clj
+++ b/notebooks/dice.clj
@@ -10,21 +10,20 @@
 (defonce dice (atom nil))
 
 ;; Here, we define a viewer using hiccup that will the dice as well as a button. Note that this button has an `:on-click` event handler that uses `v/clerk-eval` to tell Clerk to evaluate the argument, in this cases `(roll!)` when clicked.
-^::clerk/no-cache
-(clerk/with-viewer '(fn [side]
-                      (v/html [:div.text-center
-                               (when side
-                                 [:div.mt-2 {:style {:font-size "6em"}} side])
-                               [:button.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
-                                {:on-click (fn [e] (v/clerk-eval '(roll!)))} "Roll 🎲!"]]))
-  @dice)
+^{::clerk/no-cache true
+  ::clerk/viewer '(fn [side]
+                    (v/html [:div.text-center
+                             (when side
+                               [:div.mt-2 {:style {:font-size "6em"}} side])
+                             [:button.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
+                              {:on-click (fn [e] (v/clerk-eval '(roll!)))} "Roll 🎲!"]]))}
+@dice
 
 ;; Our roll! function `resets!` our `dice` with a random side and prints and says the result. Finally it updates the notebook.
 (defn roll! []
   (reset! dice (rand-nth sides))
   (prn @dice)
-  (shell/sh "say" (name ('{🟡 :gelb 🟠 :orange 🟢 :grün 🔵 :blau 🃏 :joker} @dice)))
-  (clerk/show! "notebooks/dice.clj"))
+  (shell/sh "say" (name ('{🟡 :gelb 🟠 :orange 🟢 :grün 🔵 :blau 🃏 :joker} @dice))))
 
 
 #_(roll!)

--- a/notebooks/elements.clj
+++ b/notebooks/elements.clj
@@ -5,6 +5,15 @@
             [babashka.fs :as fs]
             [nextjournal.clerk :as clerk]))
 
+^{::clerk/viewer {:fetch-fn (fn [_ x] x)
+                  :render-fn '(fn [board]
+                                (let [cell #(vector :div.inline-block
+                                                    {:class (if (zero? %)
+                                                              "bg-white border-solid border-2 border-black"
+                                                              "bg-black")
+                                                     :style {:width 16 :height 16}})
+                                      row #(into [:div.flex.inline-flex] (map cell) %)]
+                                  (v/html (into [:div.flex.flex-col] (map row) board))))}}
 (let [rule30 {[1 1 1] 0
               [1 1 0] 0
               [1 0 1] 0
@@ -16,16 +25,7 @@
       n 33
       g1 (assoc (vec (repeat n 0)) (/ (dec n) 2) 1)
       evolve #(mapv rule30 (partition 3 1 (repeat 0) (cons 0 %)))]
-  (clerk/with-viewer
-    (fn [board]
-      (let [cell (fn [c] (vector :div.inline-block
-                                 {:class (if (zero? c)
-                                           "bg-white border-solid border-2 border-black"
-                                           "bg-black")
-                                  :style {:width 16 :height 16}}))
-            row (fn [r] (into [:div.flex.inline-flex] (map cell) r))]
-        (v/html (into [:div.flex.flex-col] (map row) board))))
-    (->> g1 (iterate evolve) (take 17))))
+  (->> g1 (iterate evolve) (take 17)))
 
 ;; Clerk uses static analysis and a tiny bit of data flow to avoid needless recomputation.
 (defn fix-case [s]

--- a/notebooks/interactivity.clj
+++ b/notebooks/interactivity.clj
@@ -3,34 +3,48 @@
 (ns ^:nextjournal.clerk/no-cache interactivity
   (:require [nextjournal.clerk :as clerk]))
 
-(clerk/set-viewers! [{:pred #(when-let [v (get % ::clerk/var-from-def)]
-                               (and v (instance? clojure.lang.IDeref (deref v))))
-                      :fetch-fn (fn [_ x] x)
-                      :transform-fn (fn [{::clerk/keys [var-from-def]}]
-                                      {:var-name (symbol var-from-def) :value @@var-from-def})
-                      :render-fn '(fn [{:keys [var-name value]}]
-                                    (v/html (cond (number? value)
-                                                  [:input {:type :range
-                                                           :initial-value value
-                                                           :on-change #(v/clerk-eval `(reset! ~var-name (Integer/parseInt ~(.. % -target -value))))}]
-                                                  (string? value)
-                                                  (v/html [:input {:type :text
-                                                                   :placeholder "Schreib mal"
-                                                                   :initial-value value
-                                                                   :class "px-3 py-3 placeholder-blueGray-300 text-blueGray-600 relative bg-white bg-white rounded text-sm border border-blueGray-300 outline-none focus:outline-none focus:ring w-full"
-                                                                   :on-input #(v/clerk-eval `(reset! ~var-name ~(.. % -target -value)))}]))))}])
+;; Let's try a little Slider using `::clerk/viewers` 🎚
 
-;; Let's try a little Slider 🎚
+
+^{::clerk/viewers [{:pred ::clerk/var-from-def
+                    :fetch-fn (fn [_ x] x)
+                    :transform-fn (fn [{::clerk/keys [var-from-def]}]
+                                    {:var-name (symbol var-from-def) :value @@var-from-def})
+                    :render-fn '(fn [{:keys [var-name value]}]
+                                  (v/html [:input {:type :range
+                                                   :initial-value value
+                                                   :on-change #(v/clerk-eval `(reset! ~var-name (Integer/parseInt ~(.. % -target -value))))}]))}]}
 (defonce slider-state (atom 42))
-
-#_(ns-unmap *ns* 'slider-state)
 
 @slider-state
 
+;; And a second one using `::clerk/viewer` 🎚
+^{::clerk/viewer {:fetch-fn (fn [_ x] x)
+                  :transform-fn (fn [{:as x ::clerk/keys [var-from-def]}]
+                                  {:var-name (symbol var-from-def) :value @@var-from-def})
+                  :render-fn '(fn [{:as x :keys [var-name value]}]
+                                (v/html [:input {:type :range
+                                                 :initial-value value
+                                                 :on-change #(v/clerk-eval `(reset! ~var-name (Integer/parseInt ~(.. % -target -value))))}]))}}
+(defonce slider-2-state (atom 42))
+
+@slider-2-state
+
+;; And a text box.
+
+^{::clerk/viewer {:pred #(when-let [v (get % ::clerk/var-from-def)]
+                           (and v (instance? clojure.lang.IDeref (deref v))))
+                  :fetch-fn (fn [_ x] x)
+                  :transform-fn (fn [{::clerk/keys [var-from-def]}]
+                                  {:var-name (symbol var-from-def) :value @@var-from-def})
+                  :render-fn '(fn [{:keys [var-name value]}]
+                                (v/html [:input {:type :text
+                                                 :placeholder "Schreib mal"
+                                                 :initial-value value
+                                                 :class "px-3 py-3 placeholder-blueGray-300 text-blueGray-600 relative bg-white bg-white rounded text-sm border border-blueGray-300 outline-none focus:outline-none focus:ring w-full"
+                                                 :on-input #(v/clerk-eval `(reset! ~var-name ~(.. % -target -value)))}]))}}
 (defonce text-state (atom ""))
 
-#_ (reset! text-state "")
-#_ (ns-unmap *ns* 'text-state)
 
 @text-state
 

--- a/notebooks/viewer_api.clj
+++ b/notebooks/viewer_api.clj
@@ -55,6 +55,10 @@
 (clerk/with-viewer '#(v/html [:div "Greetings to " [:strong %] "!"])
   "James Clerk Maxwell")
 
+^{::clerk/viewer {:render-fn '#(v/html [:span "The answer is " % "."])
+                  :transform-fn inc}}
+(do 41)
+
 (clerk/with-viewers [{:pred number? :render-fn '#(v/html [:div.inline-block [(keyword (str "h" %)) (str "Heading " %)]])}]
   [1 2 3 4 5])
 
@@ -63,7 +67,7 @@
                                                                              :class (if (pos? %) "bg-black" "bg-white border-solid border-2 border-black")}])}]
   (take 10 (repeatedly #(rand-int 2))))
 
-(clerk/with-viewers
+^{::clerk/viewers
   [{:pred #(and (string? %)
                 (re-matches
                  (re-pattern
@@ -74,12 +78,12 @@
                           {:style {:width 16
                                    :height 16
                                    :border "1px solid rgba(0,0,0,.2)"
-                                   :background-color %}}])}]
-  ["#571845"
-   "rgb(144,12,62)"
-   "rgba(199,0,57,1.0)"
-   "hsl(11,100%,60%)"
-   "hsla(46, 97%, 48%, 1.000)"])
+                                   :background-color %}}])}]}
+["#571845"
+ "rgb(144,12,62)"
+ "rgba(199,0,57,1.0)"
+ "hsl(11,100%,60%)"
+ "hsla(46, 97%, 48%, 1.000)"]
 
 
 #_(clerk/show! "notebooks/viewer_api.clj")

--- a/notebooks/viewer_normalization.clj
+++ b/notebooks/viewer_normalization.clj
@@ -1,0 +1,22 @@
+^{:nextjournal.clerk/visibility :hide}
+(ns viewer-normalization
+  (:require [nextjournal.clerk :as clerk]))
+
+(clerk/with-viewer '(fn [v] (v/html [:span "The answer is " v "."]))
+  42)
+
+^{::clerk/viewer '#(v/html [:span "The answer is " % "."])}
+(do 42)
+
+^{::clerk/viewer {:render-fn '(fn [v] (v/html [:span "The answer is " v "."]))}}
+(do 42)
+
+
+(clerk/with-viewer {:render-fn '(fn [v] (v/html [:span "The answer is " v "."]))}
+  42)
+
+(clerk/with-viewer {:render-fn '(fn [v] (v/html [:span "The answer is " v "."])) :transform-fn inc}
+  41)
+
+^{::clerk/viewer {:render-fn '#(v/html [:span "The answer is " % "."]) :transform-fn inc}}
+(do 41)

--- a/notebooks/viewer_normalization.clj
+++ b/notebooks/viewer_normalization.clj
@@ -20,3 +20,13 @@
 
 ^{::clerk/viewer {:render-fn '#(v/html [:span "The answer is " % "."]) :transform-fn inc}}
 (do 41)
+
+(clerk/with-viewers [{:pred (constantly true) :render-fn '(fn [v] (v/html [:span "The answer is " v "."])) :transform-fn inc}]
+  41)
+
+^{::clerk/viewer {:render-fn '#(v/html [:span "The answer is " % "."]) :transform-fn inc}}
+(do 41)
+
+
+^{::clerk/viewers [{:pred (constantly true) :render-fn '(fn [v] (v/html [:span "The answer is " v "."])) :transform-fn inc}]}
+(do 41)

--- a/notebooks/visibility.clj
+++ b/notebooks/visibility.clj
@@ -19,9 +19,9 @@
 ;; While this one is completely hidden, without the ability to uncollapse it.
 ^{::clerk/visibility :hide} (shuffle (range 25))
 
-;; In the rare case you'd like to hide the result of a cell, use `clerk/hide-result`.
-^{::clerk/visibility :show}
-(clerk/hide-result (range 500))
+;; In the rare case you'd like to hide the result of a cell, use the `clerk/hide-result` viewer.
+^{::clerk/visibility :show ::clerk/viewer clerk/hide-result}
+(def my-range (range 500))
 
 ;; In a follow-up, we'll remove the `::clerk/visibility` metadata from the code cells to not distract from the essence.
 

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -116,10 +116,12 @@
                    result)]
       (wrapped-with-metadata result visibility blob-id))))
 
-(defn maybe-resolve-viewer [{:as opts :nextjournal/keys [viewer]}]
+(defn maybe-eval-viewers [{:as opts :nextjournal/keys [viewer viewers]}]
   (cond-> opts
     viewer
-    (update :nextjournal/viewer eval)))
+    (update :nextjournal/viewer eval)
+    viewers
+    (update :nextjournal/viewers eval)))
 
 (defn read+eval-cached [results-last-run ->hash doc-visibility codeblock]
   (let [{:keys [ns-effect? form var]} codeblock
@@ -134,9 +136,9 @@
                             cas-hash
                             (-> cas-hash ->cache-file fs/exists?))
         opts-from-form-meta (-> (meta form)
-                                (select-keys [::viewer ::width])
+                                (select-keys [::viewer ::viewers ::width])
                                 v/normalize-viewer-opts
-                                maybe-resolve-viewer)]
+                                maybe-eval-viewers)]
     #_(prn :cached? (cond no-cache? :no-cache
                           cached-result? true
                           cas-hash :no-cas-file

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -118,8 +118,8 @@
 
 (defn maybe-resolve-viewer [{:as opts :nextjournal/keys [viewer]}]
   (cond-> opts
-    (symbol? viewer)
-    (update :nextjournal/viewer resolve)))
+    viewer
+    (update :nextjournal/viewer eval)))
 
 (defn read+eval-cached [results-last-run ->hash doc-visibility codeblock]
   (let [{:keys [ns-effect? form var]} codeblock

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -352,6 +352,7 @@
          "visibility"
          "viewer_api"
          "viewer_api_meta"
+         "viewer_normalization"
          "viewers/html"
          "viewers/image"
          "viewers/image_layouts"

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -87,7 +87,8 @@
 
 (defn apply-viewer-unwrapping-var-from-def [{:as result :nextjournal/keys [value viewer]}]
   (if viewer
-    (let [value (if (get value :nextjournal.clerk/var-from-def)
+    (let [{:keys [transform-fn]} viewer
+          value (if (and (not transform-fn) (get value :nextjournal.clerk/var-from-def))
                   (-> value :nextjournal.clerk/var-from-def deref)
                   value)]
       (assoc result :nextjournal/value (if (or (var? viewer) (fn? viewer))

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -87,7 +87,7 @@
 
 (defn apply-viewer-unwrapping-var-from-def [{:as result :nextjournal/keys [value viewer]}]
   (if viewer
-    (let [{:keys [transform-fn]} viewer
+    (let [{:keys [transform-fn]} (and (map? viewer) viewer)
           value (if (and (not transform-fn) (get value :nextjournal.clerk/var-from-def))
                   (-> value :nextjournal.clerk/var-from-def deref)
                   value)]

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -92,7 +92,7 @@
       (assoc result :nextjournal/value (if (var? viewer)
                                          (viewer value)
                                          {:nextjournal/value value
-                                          :nextjournal/viewer viewer})))
+                                          :nextjournal/viewer (v/normalize-viewer viewer)})))
     result))
 
 #_(apply-viewer-unwrapping-var-from-def {:nextjournal/value [:h1 "hi"] :nextjournal/viewer :html})

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -279,7 +279,7 @@
 
 (declare wrapped-with-viewer)
 
-(defn apply-viewer [{:as viewer :keys [render-fn transform-fn]} v]
+(defn apply-viewer [viewers {:as viewer :keys [render-fn transform-fn]} v]
   (let [v (cond-> v transform-fn transform-fn)]
     (if (and transform-fn (not render-fn))
       (wrapped-with-viewer v viewers)
@@ -291,16 +291,16 @@
    (if-let [selected-viewer (viewer x)]
      (if (keyword? selected-viewer)
        (if-let [named-viewer (find-named-viewer viewers selected-viewer)]
-         (apply-viewer named-viewer (value x))
+         (apply-viewer viewers named-viewer (value x))
          (throw (ex-info (str "cannot find viewer named " selected-viewer) {:selected-viewer selected-viewer :x (value x) :viewers viewers})))
-       (apply-viewer selected-viewer (value x)))
+       (apply-viewer viewers selected-viewer (value x)))
      (let [v (value x)]
-       (loop [viewers viewers]
-         (if-let [{:as matching-viewer :keys [pred]} (first viewers)]
+       (loop [vs viewers]
+         (if-let [{:as matching-viewer :keys [pred]} (first vs)]
            (if (and (ifn? pred) (pred v))
-             (apply-viewer matching-viewer v)
-             (recur (rest viewers)))
-           (throw (ex-info (str "cannot find matchting viewer for `" (pr-str x) "`") {:viewers viewers :x v}))))))))
+             (apply-viewer viewers matching-viewer v)
+             (recur (rest vs)))
+           (throw (ex-info (str "cannot find matchting viewer for `" (pr-str x) "`") {:viewers vs :x v}))))))))
 
 #_(wrapped-with-viewer {:one :two})
 #_(wrapped-with-viewer [1 2 3])

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -277,25 +277,28 @@
 (defn find-named-viewer [viewers viewer-name]
   (first (filter (comp #{viewer-name} :name) viewers)))
 
+(declare wrapped-with-viewer)
+
+(defn apply-viewer [{:as viewer :keys [render-fn transform-fn]} val]
+  (let [val (cond-> val transform-fn transform-fn)]
+    (if (and transform-fn (not render-fn))
+      (wrapped-with-viewer val viewers)
+      (wrap-value val viewer))))
+
 (defn wrapped-with-viewer
   ([x] (wrapped-with-viewer x default-viewers))
   ([x viewers]
    (if-let [selected-viewer (viewer x)]
-     (cond (keyword? selected-viewer)
-           (if-let [{:as named-viewer :keys [transform-fn]} (find-named-viewer viewers selected-viewer)]
-             (wrap-value (cond-> x transform-fn transform-fn) named-viewer)
-             (throw (ex-info (str "cannot find viewer named " selected-viewer) {:selected-viewer selected-viewer :x (value x) :viewers viewers})))
-           (viewer-fn? selected-viewer)
-           (wrap-value x selected-viewer))
+     (if (keyword? selected-viewer)
+       (if-let [named-viewer (find-named-viewer viewers selected-viewer)]
+         (apply-viewer named-viewer val)
+         (throw (ex-info (str "cannot find viewer named " selected-viewer) {:selected-viewer selected-viewer :x (value x) :viewers viewers})))
+       (apply-viewer selected-viewer (value x)))
      (let [val (value x)]
        (loop [v viewers]
          (if-let [{:as matching-viewer :keys [pred]} (first v)]
            (if (and (ifn? pred) (pred val))
-             (let [{:keys [render-fn transform-fn]} matching-viewer
-                   val (cond-> val transform-fn transform-fn)]
-               (if (and transform-fn (not render-fn))
-                 (wrapped-with-viewer val viewers)
-                 (wrap-value val matching-viewer)))
+             (apply-viewer matching-viewer val)
              (recur (rest v)))
            (throw (ex-info (str "cannot find matchting viewer for `" (pr-str x) "`") {:viewers viewers :x val}))))))))
 
@@ -543,6 +546,16 @@
   (set/rename-keys opts {:nextjournal.clerk/viewer :nextjournal/viewer
                          :nextjournal.clerk/width :nextjournal/width}))
 
+(defn normalize-viewer [viewer]
+  (if (or (keyword? viewer)
+          (map? viewer))
+    viewer
+    {:render-fn viewer}))
+
+#_(normalize-viewer '#(v/html [:h3 "Hello " % "!"]))
+#_(normalize-viewer :latex)
+#_(normalize-viewer {:render-fn '#(v/html [:h3 "Hello " % "!"]) :transform-fn identity})
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; public api
 
@@ -553,9 +566,7 @@
    (merge (normalize-viewer-opts opts)
           (-> x
               wrap-value
-              (assoc :nextjournal/viewer (cond-> viewer
-                                           (or (list? viewer) (symbol? viewer))
-                                           ->viewer-fn))))))
+              (assoc :nextjournal/viewer (normalize-viewer viewer))))))
 
 #_(with-viewer :latex "x^2")
 #_(with-viewer '#(v/html [:h3 "Hello " % "!"]) "x^2")

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -280,9 +280,11 @@
 (declare wrapped-with-viewer)
 
 (defn apply-viewer [viewers {:as viewer :keys [render-fn transform-fn]} v]
-  (let [v (cond-> v transform-fn transform-fn)]
+  (let [v (if transform-fn
+            (-> v value transform-fn)
+            v)]
     (if (and transform-fn (not render-fn))
-      (wrapped-with-viewer v viewers)
+      (wrapped-with-viewer (value v) viewers)
       (wrap-value v viewer))))
 
 (defn wrapped-with-viewer
@@ -291,9 +293,9 @@
    (if-let [selected-viewer (viewer x)]
      (if (keyword? selected-viewer)
        (if-let [named-viewer (find-named-viewer viewers selected-viewer)]
-         (apply-viewer viewers named-viewer (value x))
+         (apply-viewer viewers named-viewer x)
          (throw (ex-info (str "cannot find viewer named " selected-viewer) {:selected-viewer selected-viewer :x (value x) :viewers viewers})))
-       (apply-viewer viewers selected-viewer (value x)))
+       (apply-viewer viewers selected-viewer x))
      (let [v (value x)]
        (loop [vs viewers]
          (if-let [{:as matching-viewer :keys [pred]} (first vs)]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -280,12 +280,12 @@
 (declare wrapped-with-viewer)
 
 (defn apply-viewer [viewers {:as viewer :keys [render-fn transform-fn]} v]
-  (let [v (if transform-fn
-            (-> v value transform-fn)
-            v)]
+  (let [v' (if transform-fn
+             (-> v value transform-fn)
+             v)]
     (if (and transform-fn (not render-fn))
-      (wrapped-with-viewer (value v) viewers)
-      (wrap-value v viewer))))
+      (wrapped-with-viewer (value v') viewers)
+      (merge (wrap-value v' viewer) (when (map? v) (select-keys v [:nextjournal/width]))))))
 
 (defn wrapped-with-viewer
   ([x] (wrapped-with-viewer x default-viewers))

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -1,6 +1,7 @@
 (ns nextjournal.clerk.viewer-test
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
+            [matcher-combinators.test :refer [match?]]
             [nextjournal.clerk.viewer :as v]))
 
 (defn find-elision [desc]
@@ -42,6 +43,26 @@
   (testing "deep vector with elements around"
     (let [value (reduce (fn [acc i] (vector i acc (inc i))) :fin (range 10 0 -1))]
       (is (= value (describe+fetch value))))))
+
+(deftest wrapped-with-viewer
+  (testing "selects number viewer"
+    (is (match? {:nextjournal/value 42
+                 :nextjournal/viewer {:pred fn?}}
+                (v/wrapped-with-viewer 42))))
+
+  (testing "html viewer has no default width"
+    (is (nil? (:nextjournal/width (v/wrapped-with-viewer (v/html [:h1 "hi"]))))))
+
+  (testing "hiccup viewer width can be overriden"
+    (is (= :wide
+           (:nextjournal/width (v/wrapped-with-viewer (v/html {:nextjournal.clerk/width :wide} [:h1 "hi"]))))))
+
+  (testing "table viewer defaults to wide width"
+    (is (= :wide
+           (:nextjournal/width (v/wrapped-with-viewer (v/table {:a [1] :b [2] :c [3]}))))))
+  (testing "table viewer (with :transform-fn) width can be overriden"
+    (is (= :full
+           (:nextjournal/width (v/wrapped-with-viewer (v/table {:nextjournal.clerk/width :full} {:a [1] :b [2] :c [3]})))))))
 
 (deftest assign-closing-parens
   (testing "closing parenthesis are moved to right-most children in the tree"

--- a/test/nextjournal/clerk_test.clj
+++ b/test/nextjournal/clerk_test.clj
@@ -85,11 +85,14 @@
 
 (deftest eval-string+doc->viewer
   (testing "assigns correct width from viewer function opts"
-    (is (match? [{:nextjournal/width :full}]
+    (is (match? [{:nextjournal/width :wide}
+                 {:nextjournal/width :full}]
                 (-> "^{:nextjournal.clerk/visibility :hide} (ns clerk-test-width
   (:require [nextjournal.clerk :as clerk]))
 
-(clerk/html {::clerk/width :full} [:div.bg-red-200 [:h1 \"Wide Hiccup\"]])"
+(clerk/html {::clerk/width :wide} [:div.bg-red-200 [:h1 \"Wide Hiccup\"]])
+
+(clerk/table {::clerk/width :full} {:a [1] :b [2] :c [3]})"
                     clerk/eval-string
                     view/doc->viewer
                     :nextjournal/value

--- a/test/nextjournal/clerk_test.clj
+++ b/test/nextjournal/clerk_test.clj
@@ -78,7 +78,7 @@
                 (clerk/eval-string "(ns ^:nextjournal.clerk/no-cache my-defonce-test-ns) (defonce state (atom {}))"))))
 
   (testing "assigning viewers from form meta"
-    (is (match? {:blocks [{:result {:nextjournal/viewer #'nextjournal.clerk/table}}]}
+    (is (match? {:blocks [{:result {:nextjournal/viewer #'nextjournal.clerk.viewer/table}}]}
                 (clerk/eval-string "^{:nextjournal.clerk/viewer nextjournal.clerk/table} (def markup [:h1 \"hi\"])")))
     (is (match? {:blocks [{:result {:nextjournal/viewer :html}}]}
                 (clerk/eval-string "^{:nextjournal.clerk/viewer :html} (def markup [:h1 \"hi\"])")))))

--- a/test/nextjournal/clerk_test.clj
+++ b/test/nextjournal/clerk_test.clj
@@ -84,6 +84,17 @@
                 (clerk/eval-string "^{:nextjournal.clerk/viewer :html} (def markup [:h1 \"hi\"])")))))
 
 (deftest eval-string+doc->viewer
+  (testing "assigns correct width from viewer function opts"
+    (is (match? [{:nextjournal/width :full}]
+                (-> "^{:nextjournal.clerk/visibility :hide} (ns clerk-test-width
+  (:require [nextjournal.clerk :as clerk]))
+
+(clerk/html {::clerk/width :full} [:div.bg-red-200 [:h1 \"Wide Hiccup\"]])"
+                    clerk/eval-string
+                    view/doc->viewer
+                    :nextjournal/value
+                    :blocks))))
+
   (testing "assigns the correct width from form meta"
     (is (match? [{:nextjournal/width :full}
                  {:nextjournal/width :wide}]


### PR DESCRIPTION
For the functional (`clerk/with-viewer` and `clerk/with-viewers`) and metadata api (`^{::clerk/viewer ,,,}` and `^{::clerk/viewers ,,,}`).