### PR TITLE
Support non-root git location in static builds link

### DIFF
--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -412,7 +412,7 @@
   - `:bundle?` builds a single page app versus a folder with an html page for each notebook (defaults to `true`)
   - `:path-prefix` a prefix to urls
   - `:out-path` a relative path to a folder to contain the static pages (defaults to `\"public/build\"`)
-  - `:git/sha`, `:git/url` when both present, each page displays a link to `(str url \"blob\" sha path-to-notebook)`"
+  - `:git/sha`, `:git/url`, (optional) `:deps/root` when present, each page displays a link to `(str url \"blob\" sha root path-to-notebook)`"
   [{:as opts :keys [paths out-path bundle? browse?]
     :or {paths clerk-docs
          out-path (str "public" fs/file-separator "build")

--- a/src/nextjournal/clerk/static_app.cljs
+++ b/src/nextjournal/clerk/static_app.cljs
@@ -15,7 +15,7 @@
       (str "#/" url)
       (str "/" path-prefix url))))
 
-(defn show [{:as view-data :git/keys [sha url] :keys [doc path url->path]}]
+(defn show [{:as view-data :git/keys [sha url] :deps/keys [root] :keys [doc path url->path]}]
   (sci-viewer/set-state {:doc doc})
   [:<>
    [:div.flex.flex-col.items-center
@@ -33,7 +33,7 @@
         [:<>
          " from "
          [:a.hover:text-indigo-500.font-medium.border-b.border-dotted.border-gray-300
-          {:href (str url "/blob/" sha "/" (url->path path))} (url->path path) "@" [:span.tabular-nums (subs sha 0 7)]]])]]]
+          {:href (str url "/blob/" sha root "/" (url->path path))} (url->path path) "@" [:span.tabular-nums (subs sha 0 7)]]])]]]
    [sci-viewer/root]])
 
 (dc/defcard show []


### PR DESCRIPTION
Added a `:deps/root` optional parameter to static build function to link to a deps project at a non-root git location. Chose `:deps/root` to mirror the deps.edn dependency coordinate attribute for a non-root file location.