### PR TITLE
Analyze defrecords as Name, ->Name, map->Name

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.10.3"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/java.classpath {:mvn/version "1.0.0"}
         org.clojure/tools.analyzer.jvm {:mvn/version "1.1.0"}
         babashka/fs {:mvn/version "0.1.3"}

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-uUZuhPEEFLhmrxUXbMzzdg7QyBE
+gYJ4L7vxgSfDct7gobYgurakxG9

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -18,7 +18,6 @@
             [nextjournal.view.context :as view-context]
             [nextjournal.viewer.code :as code]
             [nextjournal.viewer.katex :as katex]
-            [nextjournal.viewer.markdown :as markdown]
             [nextjournal.viewer.mathjax :as mathjax]
             [nextjournal.viewer.plotly :as plotly]
             [nextjournal.viewer.vega-lite :as vega-lite]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -474,7 +474,7 @@
      (when (and !budget (not descend?) (not fetch-fn))
        (swap! !budget #(max (dec %) 0)))
      (merge {:path path}
-            (dissoc wrapped-value [:nextjournal/value :nextjournal/viewer])
+            (dissoc wrapped-value :nextjournal/value :nextjournal/viewer)
             (with-viewer (process-viewer viewer)
               (cond fetch-fn
                     (fetch-fn (merge opts fetch-opts {:describe-fn describe}) xs)

--- a/test/nextjournal/clerk/hashing_test.clj
+++ b/test/nextjournal/clerk/hashing_test.clj
@@ -185,6 +185,31 @@
                         #{3 1 2}"))))
 
 
+(deftest analyze-defrecord
+  (is (match? {:graph {:dependencies (m/equals {'(ns example-notebook) set?
+                                                'example-notebook/Node set?
+                                                'example-notebook/map->Node #{'example-notebook/Node}
+                                                'example-notebook/->Node #{'example-notebook/Node}})
+                       :dependents   map?}
+               :blocks [{:type :code
+                         :text "^:nextjournal.clerk/no-cache (ns example-notebook)"}
+                        {:type :code,
+                         :text "(defrecord Node [x y z])"
+                         :form '(defrecord Node [x y z])
+                         :var 'example-notebook/Node}]
+               :->analysis-info {'example-notebook/Node {:form '(defrecord Node [x y z])
+                                                         :ns-effect? false
+                                                         :var 'example-notebook/Node}
+                                 'example-notebook/map->Node {:var 'example-notebook/map->Node
+                                                              :deps #{'example-notebook/Node}
+                                                              :form '(def 'example-notebook/map->Node nil)}
+                                 'example-notebook/->Node {:var 'example-notebook/->Node
+                                                           :deps #{'example-notebook/Node}
+                                                           :form '(def 'example-notebook/->Node nil)}}}
+              (analyze-string "^:nextjournal.clerk/no-cache (ns example-notebook)
+                              (defrecord Node [x y z])"))))
+
+
 (deftest circular-dependency
   (is (match? {:graph {:dependencies {'(ns circular) any?
                                       'circular/b #{clojure.core/str 'circular/a+circular/b}


### PR DESCRIPTION
potential approach to fixing the warning mentioned in https://github.com/nextjournal/clerk/issues/121 where
```clojure
(defrecord Node [v l r])
```
results in Clerk outputting
```
Multiple definitions found in form, using first one:
:form (defrecord Node [val left right]) :used-var day-0003/->Node
```
because `(defrecord Node ...)` macroexpands to several `defn` forms including `->Node` and `map->Node`

This PR 
 - adapts the analysis to include a `defrecord` special case where the defrecord name is used instead of the first `defn` form.
 - creates an explicit dependency from the defrecord name to `->RecordName` and `map->RecordName` such that if the record body changes, any usages of `->RecordName` or `map->RecordName` will register as needing to be re-evaluated

Not sure if such a special case is acceptable or if we should re-do the dependency analysis to more holistically deal with expressions with multiple `def`s in them