### PR TITLE
`viewer-for` helper

### DIFF
--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-uUZuhPEEFLhmrxUXbMzzdg7QyBE
+2UWc1sXHz2uwQRfXVEdWooa5YQxm

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-2UWc1sXHz2uwQRfXVEdWooa5YQxm
+4PVz5HPHNoFmomWnPrTP8h5i3c9c


### PR DESCRIPTION
Sometimes it is hard to know what viewer will be applied to a value.
You can get this info from `nextjournal.clerk.viewer/describe` but it also runs the `transform-fn` and recursively applies viewer functions into nested values.

I think it might be useful for development to have a construct that looks up the top level viewer for a value without considering nested values or performing transformations. In this PR I implemented it as `viewer-for`

Note that it seems to deviate a little bit as compared to the viewer that `describe` returns:

```clojure
((comp :nextjournal/viewer describe) [1])
;; =>
{:render-fn {:form v/coll-viewer, :f nil},
 :opening-paren "[",
 :closing-paren ("]"),
 :fetch-opts {:n 20}}
```
while

```clojure
(viewer-for [1])
;; =>
{:pred #function[clojure.core/vector?--5479],
 :render-fn v/coll-viewer,
 :opening-paren "[",
 :closing-paren "]",
 :fetch-opts {:n 20}}
 ```