### PR TITLE
Expand glob paths and support symbols pointing to vars for `build-static-app!`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,7 +143,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0.3.0
 
       - name: 🏗 Build Clerk Static App with default Notebooks
-        run: clojure -J-Dclojure.main.report=stderr -X:demo nextjournal.clerk/build-static-app! :git/sha '"${{ github.sha }}"' :git/url '"https://github.com/nextjournal/clerk"' :browse false
+        run: clojure -J-Dclojure.main.report=stderr -X:demo:nextjournal/clerk :git/sha '"${{ github.sha }}"' :git/url '"https://github.com/nextjournal/clerk"' :browse false
 
       - name: 📠 Copy static build to bucket under SHA
         run: |

--- a/.nrepl-port
+++ b/.nrepl-port
@@ -1,1 +1,0 @@
-.shadow-cljs/nrepl.port

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,8 @@
 
         rewrite-clj/rewrite-clj {:mvn/version "1.0.699-alpha"}}
 
- :aliases {:nextjournal/clerk {:exec-fn nextjournal.clerk/build-static-app!}
+ :aliases {:nextjournal/clerk {:exec-fn nextjournal.clerk/build-static-app!
+                               :exec-args {:paths nextjournal.clerk/clerk-docs}}
            :sci {:extra-deps {applied-science/js-interop {:mvn/version "0.3.3"}
                               org.babashka/sci {:mvn/version "0.3.2"}
                               reagent/reagent {:mvn/version "1.1.0"}

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-uUZuhPEEFLhmrxUXbMzzdg7QyBE
+7peuLnjNi6U1svno2nKhFxnyAmy


### PR DESCRIPTION
This expands the `paths` given to `build-static-app!` according to the rules in 
https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String)

We optionally also support programmatically providing `paths` in `build-static-app!` by supporting a symbol in `:exec-args` of the `deps.edn`. We will then resolve the var behind the symbol and if that resolves to a function, call it.