### PR TITLE
Use relative links inside the static-app

### DIFF
--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-7peuLnjNi6U1svno2nKhFxnyAmy
+4WQQKmi9imN2FttDVoa5h3o7yEa5

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -414,7 +414,6 @@
 
   - `:paths` a vector of relative paths to notebooks to include in the build
   - `:bundle?` builds a single page app versus a folder with an html page for each notebook (defaults to `true`)
-  - `:path-prefix` a prefix to urls
   - `:out-path` a relative path to a folder to contain the static pages (defaults to `\"public/build\"`)
   - `:git/sha`, `:git/url` when both present, each page displays a link to `(str url \"blob\" sha path-to-notebook)`"
   [opts docs]
@@ -488,8 +487,8 @@
     (report-fn {:stage :finished :state state :duration duration :total-duration (elapsed-ms start)})))
 
 #_(build-static-app! {:paths (take 5 clerk-docs)})
-#_(build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true})
-#_(build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? false :path-prefix "build/"})
+#_(build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/viewer_api.md"] :bundle? true})
+#_(build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/viewer_api.md"] :bundle? false})
 #_(build-static-app! {:paths ["notebooks/viewers/**"]})
 
 ;; And, as is the culture of our people, a commend block containing

--- a/src/nextjournal/clerk/static_app.cljs
+++ b/src/nextjournal/clerk/static_app.cljs
@@ -14,7 +14,11 @@
   (let [url (path->url path)]
     (if bundle?
       (str "#/" url)
-      (let [url (or url "index.html")
+      (let [url (cond-> url
+                  (and (= (.. js/document -location -protocol) "file:")
+                       (or (nil? url)
+                           (str/ends-with? url "/")))
+                  (str "index.html"))
             dir-depth (get (frequencies current-path) \/ 0)
             relative-root (apply str (repeat dir-depth "../"))]
         (str relative-root url)))))

--- a/src/nextjournal/clerk/static_app.cljs
+++ b/src/nextjournal/clerk/static_app.cljs
@@ -10,11 +10,14 @@
             [reitit.frontend.easy :as rfe]
             [sci.core :as sci]))
 
-(defn doc-url [{:keys [path->url path-prefix bundle?]} path]
+(defn doc-url [{:keys [path->url current-path bundle?]} path]
   (let [url (path->url path)]
     (if bundle?
       (str "#/" url)
-      (str "/" path-prefix url))))
+      (let [url (or url "index.html")
+            dir-depth (get (frequencies current-path) \/ 0)
+            relative-root (apply str (repeat dir-depth "../"))]
+        (str relative-root url)))))
 
 (defn show [{:as view-data :git/keys [sha url] :keys [doc path url->path]}]
   (let [header [:div.mb-8.text-xs.sans-serif.text-gray-400.not-prose


### PR DESCRIPTION
Also rewrite top-level links to point to "index.html".
This allows browsing Clerk output with a browser directly on the file
system, and serving from buckets at arbitrary top-level directories.

Drop now obsolete `:path-prefix` option to `build-static-app!`.