### PR TITLE
Support ShadowCLJS nREPL dev flow on IntelliJ/Cursive

### DIFF
--- a/dev/nextjournal/clerk/dev_launcher.clj
+++ b/dev/nextjournal/clerk/dev_launcher.clj
@@ -1,17 +1,23 @@
 (ns nextjournal.clerk.dev-launcher
   "A dev launcher that launches nrepl, shadow-cljs and once the first cljs compliation completes, Clerk.
-  
+
   Avoiding other ns requires here so the REPL comes up early."
-  (:require [nrepl.cmdline :as nrepl])
+  (:require [nrepl.cmdline :as nrepl]
+            [shadow.cljs.devtools.config :as shadow.config])
   (:import (java.lang.management ManagementFactory)
            (java.util Locale)))
 
-(defn start [serve-opts]
-  (future (nrepl/dispatch-commands {:middleware '[cider.nrepl/cider-middleware]}))
+(defn start [{:as opts :keys [shadow-nrepl? load-cider-middleware?] :or {load-cider-middleware? true}}]
+  (println "Starting Clerk with options: " opts)
+  (when-not shadow-nrepl?
+    (future (nrepl/dispatch-commands (when load-cider-middleware? {:middleware '[cider.nrepl/cider-middleware]}))))
   (require 'shadow.cljs.silence-default-loggers)
-  ((requiring-resolve 'shadow.cljs.devtools.server/start!))
+  ((requiring-resolve 'shadow.cljs.devtools.server/start!)
+   (cond-> (shadow.config/load-cljs-edn)
+     shadow-nrepl?
+     (dissoc :nrepl)))
   ((requiring-resolve 'shadow.cljs.devtools.api/watch) :browser)
-  ((requiring-resolve 'nextjournal.clerk/serve!) serve-opts)
+  ((requiring-resolve 'nextjournal.clerk/serve!) opts)
   (println "Clerk dev system ready in"
            (String/format (Locale. "en-US")
                           "%.2fs"

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -7,7 +7,7 @@
 
   ;; start without file watcher
   (clerk/serve! {})
-  
+
   ;; start with file watcher
   (clerk/serve! {:watch-paths ["notebooks" "src"]})
 
@@ -35,6 +35,9 @@
   (clerk/show! "notebooks/viewers/html.clj")
 
   (clerk/show! "notebooks/sicmutils.clj")
+
+  ;; "upgrade" shadow nREPL to cljs
+  (shadow.cljs.devtools.api/repl :browser)
 
   (clerk/clear-cache!)
   )


### PR DESCRIPTION
This facilitates Cursive folks in the development of Clerk's CLJS layer. The present dev environment is geared toward Cider users only.

1. use Shadow provided nREPL `bb dev :shadow-nrepl? true`
2. skip loading Cider middleware on stock nREPL `bb dev :load-cider-middleware? false`