### PR TITLE
Perform bounded count limit check on tree

### DIFF
--- a/notebooks/pagination.clj
+++ b/notebooks/pagination.clj
@@ -6,6 +6,8 @@
 
 (range)
 
+{:a [(range)]}
+
 (def notebooks
   (clojure.java.io/file "notebooks"))
 

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-3SshewHX3mBVYq4djdiLZZbR9rbQ
+33q7yYkYY3piY4mZmbRBKZNqGZQK

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-43ccwcZmpPff2E2o2ad1PcBzCtat
+3SshewHX3mBVYq4djdiLZZbR9rbQ

--- a/test/nextjournal/clerk_test.clj
+++ b/test/nextjournal/clerk_test.clj
@@ -99,7 +99,16 @@
     (is (match? {:blocks [{:result {:nextjournal/viewer fn?}}]}
                 (clerk/eval-string "^{:nextjournal.clerk/viewer nextjournal.clerk/table} (def markup [:h1 \"hi\"])")))
     (is (match? {:blocks [{:result {:nextjournal/viewer :html}}]}
-                (clerk/eval-string "^{:nextjournal.clerk/viewer :html} (def markup [:h1 \"hi\"])")))))
+                (clerk/eval-string "^{:nextjournal.clerk/viewer :html} (def markup [:h1 \"hi\"])"))))
+
+  (testing "can handle unbounded sequences"
+
+    (is (match? {:blocks [{:result {:nextjournal/value seq?}}]}
+                (clerk/eval-string "(range)")))
+
+
+    (is (match? {:blocks [{:result {:nextjournal/value {:a seq?}}}]}
+                (clerk/eval-string "{:a (range)}")))))
 
 (defn eval-inspect? [x] (= x (viewer/->viewer-eval 'v/inspect)))
 

--- a/test/nextjournal/clerk_test.clj
+++ b/test/nextjournal/clerk_test.clj
@@ -102,11 +102,8 @@
                 (clerk/eval-string "^{:nextjournal.clerk/viewer :html} (def markup [:h1 \"hi\"])"))))
 
   (testing "can handle unbounded sequences"
-
     (is (match? {:blocks [{:result {:nextjournal/value seq?}}]}
                 (clerk/eval-string "(range)")))
-
-
     (is (match? {:blocks [{:result {:nextjournal/value {:a seq?}}}]}
                 (clerk/eval-string "{:a (range)}")))))
 


### PR DESCRIPTION
As of now, a notebook would hang showing values like

```clojure
{:a (range)}
```

This is because the map above passes the check `exceeds-bounded-count-limit?` with `false` resulting in Clerk trying to cache such value
https://github.com/nextjournal/clerk/blob/0e7b3b4f57be6198a10f6f7df78bc2aa24895594/src/nextjournal/clerk.clj#L112-L116
and eventually having `nippy/freeze` hang.

I propose a lazy walk of clojure structures in search for unbounded sub-structures. Might be improved with adding the depth to the count as well.
