### PR TITLE
Add inline comments to code blocks

### DIFF
--- a/notebooks/markdown.md
+++ b/notebooks/markdown.md
@@ -14,23 +14,23 @@ Nextjournal Markdown library is able to ingest a markdown string
 
 ```clojure
 (def markdown-input (slurp "https://daringfireball.net/projects/markdown/syntax.text"))
-```
 
-and parse it into a nested clojure structure
 
-```clojure
+;; and parse it into a _nested clojure structure_ (an AST)
+
+
 (def parsed (md/parse markdown-input))
 ```
 
 which you can manipulate with your favourite clojure functions
 
 ```clojure
-(def sliced (update parsed :content #(take 8 %)))
+(def sliced (update parsed :content #(take 8 %))) ;; take just a slice 
 ```
 
 and render back to hiccup with customisable elements. 
 
-At present, Clerk will split top level forms which are grouped togetehr under the same cell, this is to guarantee that Clerk's dependency analysys among forms will still effectively avoid needless recomputations when code changes. Forms are nevertheless still grouped as intended in the document.
+At present, Clerk will split top level forms which are grouped together under the same cell, this is to guarantee that Clerk's dependency analysys among forms will still effectively avoid needless recomputations when code changes. Forms are nevertheless still grouped as intended in the document.
 
 ```clojure
 (def renderers 

--- a/notebooks/viewers/in_text_eval.clj
+++ b/notebooks/viewers/in_text_eval.clj
@@ -22,7 +22,7 @@
                                              (custom-md/update-child-viewers #(v/add-viewers % md-eval-viewers))}))
 
 ^{::clerk/viewer clerk/hide-result}
-(v/reset-viewers! viewers-with-md-eval)
+(v/reset-viewers! viewers-with-md-eval) ;; register viewer globally for ns
 
 ;; ---
 

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-2YH5FB8wuvw4uMnhrk9gdMtLsWCm
+2a65qmq9SNootskfGaCMGL174uiZ

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-2a65qmq9SNootskfGaCMGL174uiZ
+2cX62ddmVxEPYstCjCtTC4jciht3

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -189,6 +189,20 @@
     (and (not visibility) (-> node n/string read-string ns?))
     (assoc :ns? true)))
 
+(defn including-comment-on-same-line [nodes]
+  (loop [{:as state :keys [nodes]} {:nodes nodes}]
+    (cond (empty? nodes) state
+          (n/linebreak? (first nodes)) (update :nodes rest)
+          (n/comment? (first nodes)) (-> state
+                                         (update :nodes rest)
+                                         (update :string str (n/string (first nodes))))
+          (n/whitespace? (first nodes)) (recur (-> state
+                                                   (update :nodes rest)
+                                                   (update :string str (n/string (first nodes)))))
+          :else state)))
+
+#_(-> "(inc 41) ;; foo\n;;bar" p/parse-string-all :children rest including-comment-on-same-line)
+
 (defn parse-clojure-string
   ([s] (parse-clojure-string {} s))
   ([{:as _opts :keys [doc?]} s]

--- a/test/nextjournal/clerk/hashing_test.clj
+++ b/test/nextjournal/clerk/hashing_test.clj
@@ -52,6 +52,16 @@
                                                                    {:type :toc}]}]}})
                 (h/parse-clojure-string {:doc? true} notebook)))))
 
+(deftest parse-inline-comments
+  (is (match? {:blocks [{:doc {:content [{:content [{:text "text before"}]}]}}
+                        {:text "'some-token ;; with inline comment" :type :code}
+                        {:doc {:content [{:content [{:text "text after"}]}]}}]}
+              (h/parse-clojure-string {:doc? true}
+                                      ";; text before
+                                      'some-token ;; with inline comment
+                                      ;; text after
+                                      "))))
+
 (deftest no-cache?
   (testing "are variables set to no-cache?"
     (is (not (h/no-cache? (h/analyze+emit '(rand-int 10)))))


### PR DESCRIPTION
Add comments on the same line after a code cell to the code cell instead of to the documents prose. Fixes #71.
<img width="800" alt="CleanShot 2022-06-07 at 17 08 47@2x" src="https://user-images.githubusercontent.com/1078464/172415670-804e00ba-5789-4b9c-a20c-106892bb7327.png">

