### PR TITLE
Restrict forms considered for disk-cache across JVM restarts

### DIFF
--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-2QomkaERveEgZwKtSGc6f95nabbt
+MZAFz7cCjz5iXe9gpb2mNybfmhh

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -131,7 +131,7 @@
 
 (defn read+eval-cached [{:as _doc doc-visibility :visibility :keys [blob->result ->analysis-info ->hash]} codeblock]
   (let [{:keys [form vars var]} codeblock
-        {:keys [ns-effect? no-cache?]} (->analysis-info (if (seq vars) (first vars) form))
+        {:keys [ns-effect? no-cache? freezable?]} (->analysis-info (if (seq vars) (first vars) form))
         no-cache?      (or ns-effect? no-cache?)
         hash           (when-not no-cache? (or (get ->hash (if var var form))
                                                (hashing/hash-codeblock ->hash codeblock)))
@@ -153,7 +153,7 @@
     (fs/create-dirs config/cache-dir)
     (cond-> (or (when-let [blob->result (and (not no-cache?) (get-in blob->result [hash :nextjournal/value]))]
                   (wrapped-with-metadata blob->result visibility hash))
-                (when cached-result?
+                (when (and cached-result? freezable?)
                   (lookup-cached-result var hash cas-hash visibility))
                 (eval+cache! form hash digest-file var no-cache? visibility))
       (seq opts-from-form-meta)

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -98,14 +98,19 @@
   (binding [config/*in-clerk* true]
     (let [analyzed-form (analyze+emit (rewrite-defcached form))
           vars (defined-vars analyzed-form)
+          var (when (and (= 1 (count vars)) (or (def? analyzed-form)
+                                                (deflike? form)))
+                (first vars))
           deps (apply disj (var-dependencies analyzed-form) vars)]
       (cond-> {:form form
                ;; TODO: drop var downstream so hash stays stable under change
                :ns-effect? (some? (some #{'clojure.core/require 'clojure.core/in-ns} deps))
+               :freezable? (and (not (some #{'clojure.core/intern 'clojure.core/import*} deps))
+                                (<= (count vars) 1)
+                                (if (seq vars) (= var (first vars)) true))
                :no-cache? (no-cache? form)}
+        var (assoc :var var)
         vars (assoc :vars vars)
-        (and (= 1 (count vars)) (or (def? analyzed-form)
-                                    (deflike? form))) (assoc :var (first vars))
         (seq deps) (assoc :deps deps)))))
 
 #_(:vars (analyze '(do (def a 41) (def b (inc a)))))
@@ -122,6 +127,9 @@
               ([x] (inc x))))
 #_(analyze '(defonce !state (atom {})))
 #_(analyze '(do (def foo :bar) (def foo-2 :bar)))
+#_(analyze '(do (def foo :bar) :baz))
+#_(analyze '(intern *ns* 'foo :bar))
+#_(analyze '(import javax.imageio.ImageIO))
 
 (defn remove-leading-semicolons [s]
   (str/replace s #"^[;]+" ""))
@@ -212,7 +220,7 @@
                     (assoc :add-comment-on-line? (not (n/comment? node)))
                     (update :nodes rest)
                     (update-in [:blocks (dec (count blocks)) :text] str (-> node n/string str/trim-newline)))
-                
+
                 (and doc? (n/comment? node))
                 (-> state
                     (assoc :add-comment-on-line? false)

--- a/src/nextjournal/clerk/hashing.clj
+++ b/src/nextjournal/clerk/hashing.clj
@@ -105,7 +105,7 @@
       (cond-> {:form form
                ;; TODO: drop var downstream so hash stays stable under change
                :ns-effect? (some? (some #{'clojure.core/require 'clojure.core/in-ns} deps))
-               :freezable? (and (not (some #{'clojure.core/intern 'clojure.core/import*} deps))
+               :freezable? (and (not (some #{'clojure.core/intern} deps))
                                 (<= (count vars) 1)
                                 (if (seq vars) (= var (first vars)) true))
                :no-cache? (no-cache? form)}


### PR DESCRIPTION
Prevent forms from being cached across JVM restarts from Clerk. Conditions for excluding them are:

* one or more inline defs, e.g. `(do (def foo :bar) :baz)`
* forms depending on `clojure.core/intern`

Note that these forms will still be considered for the in-memory cache and only re-evaluate whenever the form changes but will always evaluate the first time a notebook is shown in a fresh JVM.