### PR TITLE
Move default viewers to vars

### DIFF
--- a/notebooks/last_result.clj
+++ b/notebooks/last_result.clj
@@ -1,0 +1,30 @@
+(ns last-result
+  (:require [clojure.string :as str]
+            [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.viewer :as v]))
+
+(def viewer
+  (update v/notebook-viewer :transform-fn (fn [transform-fn-orig]
+                                            (comp transform-fn-orig
+                                                  (clerk/update-val (fn [doc] (update doc :blocks (partial take-last 1))))))))
+
+(def donut-chart
+  (v/plotly {:data [{:values [27 11 25 8 1 3 25]
+                     :labels ["US" "China" "European Union" "Russian Federation" "Brazil" "India" "Rest of World"]
+                     :text "CO2"
+                     :textposition "inside"
+                     :domain {:column 1}
+                     :hoverinfo "label+percent+name"
+                     :hole 0.4
+                     :type "pie"}]
+             :layout {:showlegend false
+                      :width 300
+                      :height 300
+                      :annotations [{:font {:size 20} :showarrow false :x 0.5 :y 0.5 :text "CO2"}]}
+             :config {:responsive true}}))
+
+^{::clerk/no-cache true}
+(clerk/add-viewers! [viewer])
+
+^{::clerk/width :full ::clerk/visibility :hide}
+(v/row donut-chart donut-chart donut-chart)

--- a/notebooks/viewers/last_result.clj
+++ b/notebooks/viewers/last_result.clj
@@ -1,9 +1,12 @@
-(ns last-result
+;; Last Result Viewer 🔚
+(ns viewers.last-result
   (:require [clojure.string :as str]
             [nextjournal.clerk :as clerk]
             [nextjournal.clerk.viewer :as v]))
 
-(def viewer
+;; This is a custom notebook viewer to only show the last result.
+
+(def last-result-viewer
   (update v/notebook-viewer :transform-fn (fn [transform-fn-orig]
                                             (comp transform-fn-orig
                                                   (clerk/update-val (fn [doc] (update doc :blocks (partial take-last 1))))))))
@@ -24,7 +27,7 @@
              :config {:responsive true}}))
 
 ^{::clerk/no-cache true}
-(clerk/add-viewers! [viewer])
+(clerk/add-viewers! [last-result-viewer])
 
 ^{::clerk/width :full ::clerk/visibility :hide}
 (v/row donut-chart donut-chart donut-chart)

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-3s1tsBSiYakr1bwogZhyzpxSgeta
+45fcVioMPkAar6B5EEBaaJcr728z

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-4XbCt6oZEmDyXty1oKno184pttyQ
+2QomkaERveEgZwKtSGc6f95nabbt

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-3Pv1bKGhZqLdjFwKxqkkGTmvTTbP
+3s1tsBSiYakr1bwogZhyzpxSgeta

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-45fcVioMPkAar6B5EEBaaJcr728z
+4XbCt6oZEmDyXty1oKno184pttyQ

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -403,6 +403,7 @@
          "viewers/image_layouts"
          "viewers/in_text_eval"
          "viewers/instants"
+         "viewers/last_result"
          "viewers/markdown"
          "viewers/printing"
          "viewers/plotly"

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -504,8 +504,8 @@
   {:pred char? :render-fn '(fn [c] (v/html [:span.cmt-string.inspected-value "\\" c]))})
 
 (def string-viewer
-  {:pred string? :render-fn (quote v/quoted-string-viewer) :fetch-opts (def -viewer
-                                                                         {:n 80})})
+  {:pred string? :render-fn (quote v/quoted-string-viewer) :fetch-opts {:n 80}})
+
 (def number-viewer
   {:pred number? :render-fn (quote v/number-viewer)})
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -597,7 +597,7 @@
   {:name :html
    :render-fn (quote v/html)
    :transform-fn (comp mark-presented
-                   (update-val (partial w/postwalk (when-wrapped inspect-wrapped-value))))})
+                       (update-val (partial w/postwalk (when-wrapped inspect-wrapped-value))))})
 
 (def plotly-viewer
   {:name :plotly :render-fn (quote v/plotly-viewer) :transform-fn mark-presented})
@@ -608,10 +608,10 @@
 (def markdown-viewer
   {:name :markdown :transform-fn (fn [wrapped-value]
                                    (-> wrapped-value
-                                     mark-presented
-                                     (update :nextjournal/value #(cond->> % (string? %) md/parse))
-                                     (update :nextjournal/viewers add-viewers markdown-viewers)
-                                     (with-md-viewer)))})
+                                       mark-presented
+                                       (update :nextjournal/value #(cond->> % (string? %) md/parse))
+                                       (update :nextjournal/viewers add-viewers markdown-viewers)
+                                       (with-md-viewer)))})
 
 (def code-viewer
   {:name :code :render-fn (quote v/code-viewer) :transform-fn (comp mark-presented (update-val (fn [v] (if (string? v) v (str/trim (with-out-str (pprint/pprint v)))))))})
@@ -644,18 +644,18 @@
    :transform-fn (fn [{:as wrapped-value :nextjournal/keys [viewers] :keys [offset path current-path]}]
                    (if-let [{:keys [head rows]} (normalize-table-data (->value wrapped-value))]
                      (-> wrapped-value
-                       (assoc :nextjournal/viewer :table/markup)
-                       (update :nextjournal/width #(or % :wide))
-                       (update :nextjournal/viewers update-table-viewers)
-                       (assoc :nextjournal/opts {:num-cols (-> rows first count)
-                                                 :number-col? (mapv number? (first rows))})
-                       (assoc :nextjournal/value (cond->> [(with-viewer :table/body (map (partial with-viewer :table/row) rows))]
-                                                   head (cons (with-viewer :table/head head)))))
+                         (assoc :nextjournal/viewer :table/markup)
+                         (update :nextjournal/width #(or % :wide))
+                         (update :nextjournal/viewers update-table-viewers)
+                         (assoc :nextjournal/opts {:num-cols (-> rows first count)
+                                                   :number-col? (mapv number? (first rows))})
+                         (assoc :nextjournal/value (cond->> [(with-viewer :table/body (map (partial with-viewer :table/row) rows))]
+                                                     head (cons (with-viewer :table/head head)))))
                      (-> wrapped-value
-                       mark-presented
-                       (assoc :nextjournal/width :wide)
-                       (assoc :nextjournal/value [(present wrapped-value)])
-                       (assoc :nextjournal/viewer {:render-fn 'v/table-error}))))})
+                         mark-presented
+                         (assoc :nextjournal/width :wide)
+                         (assoc :nextjournal/value [(present wrapped-value)])
+                         (assoc :nextjournal/viewer {:render-fn 'v/table-error}))))})
 
 (def table-error-viewer
   {:name :table-error :render-fn (quote v/table-error) :fetch-opts {:n 1}})
@@ -677,13 +677,13 @@
 
 (defn process-blocks [viewers {:as doc :keys [ns]}]
   (-> doc
-    (update :blocks (partial into [] (comp (mapcat (partial with-block-viewer doc))
-                                           (map (comp #(vector (->ViewerEval 'v/inspect) %)
-                                                  process-wrapped-value
-                                              apply-viewers*
-                                              (partial ensure-wrapped-with-viewers viewers))))))
-    (select-keys [:blocks :toc :title])
-    (cond-> ns (assoc :scope (datafy-scope ns)))))
+      (update :blocks (partial into [] (comp (mapcat (partial with-block-viewer doc))
+                                             (map (comp #(vector (->ViewerEval 'v/inspect) %)
+                                                        process-wrapped-value
+                                                        apply-viewers*
+                                                        (partial ensure-wrapped-with-viewers viewers))))))
+      (select-keys [:blocks :toc :title])
+      (cond-> ns (assoc :scope (datafy-scope ns)))))
 
 (def notebook-viewer
   {:name :clerk/notebook

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -498,130 +498,246 @@
    {:name :nextjournal.markdown/sidenote-ref
     :transform-fn (into-markup [:sup.sidenote-ref])}])
 
-;; keep viewer selection stricly in Clojure
+(def char-viewer
+  {:pred char? :render-fn '(fn [c] (v/html [:span.cmt-string.inspected-value "\\" c]))})
+
+(def string-viewer
+  {:pred string? :render-fn (quote v/quoted-string-viewer) :fetch-opts (def -viewer
+                                                                         {:n 80})})
+(def number-viewer
+  {:pred number? :render-fn (quote v/number-viewer)})
+
+(def number-hex-viewer
+  {:name :number-hex :render-fn '(fn [num] (v/number-viewer (str "0x" (.toString (js/Number. num) 16))))})
+
+(def symbol-viewer
+  {:pred symbol? :render-fn '(fn [x] (v/html [:span.cmt-keyword.inspected-value (str x)]))})
+
+(def keyword-viewer
+  {:pred keyword? :render-fn '(fn [x] (v/html [:span.cmt-atom.inspected-value (str x)]))})
+
+(def nil-viewer
+  {:pred nil? :render-fn '(fn [_] (v/html [:span.cmt-default.inspected-value "nil"]))})
+
+(def boolean-viewer
+  {:pred boolean? :render-fn '(fn [x] (v/html [:span.cmt-bool.inspected-value (str x)]))})
+
+(def map-entry-viewer
+  {:pred map-entry? :name :map-entry :render-fn '(fn [xs opts] (v/html (into [:<>] (comp (v/inspect-children opts) (interpose " ")) xs))) :fetch-opts {:n 2}})
+
+(def var-from-def-viewer
+  {:pred var-from-def? :transform-fn (update-val (comp deref :nextjournal.clerk/var-from-def))})
+
+(def read+inspect-viewer
+  {:name :read+inspect :render-fn '(fn [x] (try (v/html [v/inspect-paginated (v/read-string x)])
+                                                (catch js/Error _e
+                                                  (v/unreadable-edn-viewer x))))})
+
+(def vector-viewer
+  {:pred vector? :render-fn 'v/coll-viewer :opening-paren "[" :closing-paren "]" :fetch-opts {:n 20}})
+
+(def set-viewer
+  {:pred set? :render-fn 'v/coll-viewer :opening-paren "#{" :closing-paren "}" :fetch-opts {:n 20}})
+
+(def sequential-viewer
+  {:pred sequential? :render-fn 'v/coll-viewer :opening-paren "(" :closing-paren ")" :fetch-opts {:n 20}})
+
+(def map-viewer
+  {:pred map? :name :map :render-fn 'v/map-viewer :opening-paren "{" :closing-paren "}" :fetch-opts {:n 10}})
+
+(def var-viewer
+  {:pred var? :transform-fn (comp symbol ->value) :render-fn '(fn [x] (v/html [:span.inspected-value [:span.cmt-meta "#'" (str x)]]))})
+
+(def throwable-viewer
+  {:pred (fn [e] (instance? #?(:clj Throwable :cljs js/Error) e))
+   :name :error :render-fn (quote v/throwable-viewer) :transform-fn (comp mark-presented (update-val (comp demunge-ex-data datafy/datafy)))})
+
+(def buffered-image-viewer #?(:clj {:pred #(instance? BufferedImage %)
+                                    :transform-fn (fn [{image :nextjournal/value}]
+                                                    (let [stream (java.io.ByteArrayOutputStream.)
+                                                          w (.getWidth image)
+                                                          h (.getHeight image)
+                                                          r (float (/ w h))]
+                                                      (ImageIO/write image "png" stream)
+                                                      (-> {:nextjournal/value (.toByteArray stream)
+                                                           :nextjournal/content-type "image/png"
+                                                           :nextjournal/width (if (and (< 2 r) (< 900 w)) :full :wide)}
+                                                        mark-presented)))
+                                    :render-fn '(fn [blob] (v/html [:figure.flex.flex-col.items-center.not-prose [:img {:src (v/url-for blob)}]]))}))
+
+(def ideref-viewer
+  {:pred #(instance? IDeref %)
+   :transform-fn (fn [wrapped-value] (with-viewer :tagged-value
+                                       {:tag "object"
+                                        :value (let [r (->value wrapped-value)]
+                                                 (vector (type r)
+                                                   #?(:clj (with-viewer :number-hex (System/identityHashCode r)))
+                                                   (if-let [deref-as-map (resolve 'clojure.core/deref-as-map)]
+                                                     (deref-as-map r)
+                                                     r)))}))})
+
+(def regex-viewer
+  {:pred #?(:clj (partial instance? java.util.regex.Pattern) :cljs regexp?)
+   :transform-fn (fn [wrapped-value] (with-viewer :tagged-value {:tag "" :value (let [regex (->value wrapped-value)]
+                                                                                  #?(:clj (.pattern regex) :cljs (.-source regex)))}))})
+
+(def fallback-viewer
+  {:pred (constantly :true) :transform-fn (update-val #(with-viewer :read+inspect (pr-str %)))})
+
+(def elision-viewer
+  {:name :elision :render-fn (quote v/elision-viewer) :transform-fn mark-presented})
+
+(def katex-viewer
+  {:name :latex :render-fn (quote v/katex-viewer) :transform-fn mark-presented})
+
+(def mathjax-viewer
+  {:name :mathjax :render-fn (quote v/mathjax-viewer) :transform-fn mark-presented})
+
+(def html-viewer
+  {:name :html
+   :render-fn (quote v/html)
+   :transform-fn (comp mark-presented
+                   (update-val (partial w/postwalk (when-wrapped inspect-wrapped-value))))})
+
+(def plotly-viewer
+  {:name :plotly :render-fn (quote v/plotly-viewer) :transform-fn mark-presented})
+
+(def vega-lite-viewer
+  {:name :vega-lite :render-fn (quote v/vega-lite-viewer) :transform-fn mark-presented})
+
+(def markdown-viewer
+  {:name :markdown :transform-fn (fn [wrapped-value]
+                                   (-> wrapped-value
+                                     mark-presented
+                                     (update :nextjournal/value #(cond->> % (string? %) md/parse))
+                                     (update :nextjournal/viewers add-viewers markdown-viewers)
+                                     (with-md-viewer)))})
+
+(def code-viewer
+  {:name :code :render-fn (quote v/code-viewer) :transform-fn (comp mark-presented (update-val (fn [v] (if (string? v) v (str/trim (with-out-str (pprint/pprint v)))))))})
+
+(def code-folded-viewer
+  {:name :code-folded :render-fn (quote v/foldable-code-viewer) :transform-fn (comp mark-presented (update-val (fn [v] (if (string? v) v (with-out-str (pprint/pprint v))))))})
+
+(def reagent-viewer
+  {:name :reagent :render-fn (quote v/reagent-viewer) :transform-fn mark-presented})
+
+(def row-viewer
+  {:name :row :render-fn '(fn [items opts]
+                            (let [item-count (count items)]
+                              (v/html (into [:div {:class "md:flex md:flex-row md:gap-4 not-prose"
+                                                   :style opts}]
+                                        (map (fn [item]
+                                               [:div.flex.items-center.justify-center.flex-auto
+                                                (v/inspect opts item)])) items))))})
+
+(def col-viewer
+  {:name :col :render-fn '(fn [items opts]
+                            (v/html (into [:div {:class "md:flex md:flex-col md:gap-4 clerk-grid not-prose"
+                                                 :style opts}]
+                                      (map (fn [item]
+                                             [:div.flex.items-center.justify-center
+                                              (v/inspect opts item)])) items)))})
+
+(def table-viewer
+  {:name :table
+   :transform-fn (fn [{:as wrapped-value :nextjournal/keys [viewers] :keys [offset path current-path]}]
+                   (if-let [{:keys [head rows]} (normalize-table-data (->value wrapped-value))]
+                     (-> wrapped-value
+                       (assoc :nextjournal/viewer :table/markup)
+                       (update :nextjournal/width #(or % :wide))
+                       (update :nextjournal/viewers update-table-viewers)
+                       (assoc :nextjournal/opts {:num-cols (-> rows first count)
+                                                 :number-col? (mapv number? (first rows))})
+                       (assoc :nextjournal/value (cond->> [(with-viewer :table/body (map (partial with-viewer :table/row) rows))]
+                                                   head (cons (with-viewer :table/head head)))))
+                     (-> wrapped-value
+                       mark-presented
+                       (assoc :nextjournal/width :wide)
+                       (assoc :nextjournal/value [(present wrapped-value)])
+                       (assoc :nextjournal/viewer {:render-fn 'v/table-error}))))})
+
+(def table-error-viewer
+  {:name :table-error :render-fn (quote v/table-error) :fetch-opts {:n 1}})
+
+(def code-block-viewer
+  {:name :clerk/code-block :transform-fn (fn [{:as wrapped-value :nextjournal/keys [value]}]
+                                           (-> wrapped-value
+                                             (assoc :nextjournal/viewer (if (:fold? value) :code-folded :code))
+                                             (update :nextjournal/value :text)))})
+
+(def tagged-value-viewer
+  {:name :tagged-value :render-fn '(fn [{:keys [tag value space?]}] (v/html (v/tagged-value {:space? space?} (str "#" tag) [v/inspect-paginated value])))
+   :transform-fn (fn [wrapped-value]
+                   (-> wrapped-value
+                     (update-in [:nextjournal/value :value] present)
+                     mark-presented))})
+(def result-viewer
+  {:name :clerk/result :render-fn (quote v/result-viewer) :transform-fn mark-presented})
+
+(def notebook-viewer
+  {:name :clerk/notebook
+   :render-fn (quote v/notebook-viewer)
+   :transform-fn #?(:clj  (fn [{:as wrapped-value :nextjournal/keys [viewers]}]
+                            (-> wrapped-value
+                              mark-presented
+                              (update :nextjournal/value
+                                (fn [{:as doc :keys [ns]}]
+                                  (-> doc
+                                    (update :blocks (partial into [] (comp (mapcat (partial with-block-viewer doc))
+                                                                       (map (comp #(vector (->ViewerEval 'v/inspect) %)
+                                                                              process-wrapped-value
+                                                                              apply-viewers*
+                                                                              (partial ensure-wrapped-with-viewers viewers))))))
+                                    (select-keys [:blocks :toc :title])
+                                    (cond-> ns (assoc :scope (datafy-scope ns))))))))
+                    :cljs identity)})
+
+(def hide-result-viewer
+  {:name :hide-result :transform-fn (fn [_] nil)})
+
 (def default-viewers
   ;; maybe make this a sorted-map
-  [{:pred char? :render-fn '(fn [c] (v/html [:span.cmt-string.inspected-value "\\" c]))}
-   {:pred string? :render-fn (quote v/quoted-string-viewer) :fetch-opts {:n 80}}
-   {:pred number? :render-fn (quote v/number-viewer)}
-   {:name :number-hex :render-fn '(fn [num] (v/number-viewer (str "0x" (.toString (js/Number. num) 16))))}
-   {:pred symbol? :render-fn '(fn [x] (v/html [:span.cmt-keyword.inspected-value (str x)]))}
-   {:pred keyword? :render-fn '(fn [x] (v/html [:span.cmt-atom.inspected-value (str x)]))}
-   {:pred nil? :render-fn '(fn [_] (v/html [:span.cmt-default.inspected-value "nil"]))}
-   {:pred boolean? :render-fn '(fn [x] (v/html [:span.cmt-bool.inspected-value (str x)]))}
-   {:pred map-entry? :name :map-entry :render-fn '(fn [xs opts] (v/html (into [:<>] (comp (v/inspect-children opts) (interpose " ")) xs))) :fetch-opts {:n 2}}
-   {:pred var-from-def? :transform-fn (update-val (comp deref :nextjournal.clerk/var-from-def))}
-   {:name :read+inspect :render-fn '(fn [x] (try (v/html [v/inspect-paginated (v/read-string x)])
-                                                 (catch js/Error _e
-                                                   (v/unreadable-edn-viewer x))))}
-   {:pred vector? :render-fn 'v/coll-viewer :opening-paren "[" :closing-paren "]" :fetch-opts {:n 20}}
-   {:pred set? :render-fn 'v/coll-viewer :opening-paren "#{" :closing-paren "}" :fetch-opts {:n 20}}
-   {:pred sequential? :render-fn 'v/coll-viewer :opening-paren "(" :closing-paren ")" :fetch-opts {:n 20}}
-   {:pred map? :name :map :render-fn 'v/map-viewer :opening-paren "{" :closing-paren "}" :fetch-opts {:n 10}}
-   {:pred var? :transform-fn (comp symbol ->value) :render-fn '(fn [x] (v/html [:span.inspected-value [:span.cmt-meta "#'" (str x)]]))}
-   {:pred (fn [e] (instance? #?(:clj Throwable :cljs js/Error) e))
-    :name :error :render-fn (quote v/throwable-viewer) :transform-fn (comp mark-presented (update-val (comp demunge-ex-data datafy/datafy)))}
-   #?(:clj {:pred #(instance? BufferedImage %)
-            :transform-fn (fn [{image :nextjournal/value}]
-                            (let [stream (java.io.ByteArrayOutputStream.)
-                                  w (.getWidth image)
-                                  h (.getHeight image)
-                                  r (float (/ w h))]
-                              (ImageIO/write image "png" stream)
-                              (-> {:nextjournal/value (.toByteArray stream)
-                                   :nextjournal/content-type "image/png"
-                                   :nextjournal/width (if (and (< 2 r) (< 900 w)) :full :wide)}
-                                  mark-presented)))
-            :render-fn '(fn [blob] (v/html [:figure.flex.flex-col.items-center.not-prose [:img {:src (v/url-for blob)}]]))})
-   {:pred #(instance? IDeref %)
-    :transform-fn (fn [wrapped-value] (with-viewer :tagged-value
-                                        {:tag "object"
-                                         :value (let [r (->value wrapped-value)]
-                                                  (vector (type r)
-                                                          #?(:clj (with-viewer :number-hex (System/identityHashCode r)))
-                                                          (if-let [deref-as-map (resolve 'clojure.core/deref-as-map)]
-                                                            (deref-as-map r)
-                                                            r)))}))}
-   {:pred #?(:clj (partial instance? java.util.regex.Pattern) :cljs regexp?)
-    :transform-fn (fn [wrapped-value] (with-viewer :tagged-value {:tag "" :value (let [regex (->value wrapped-value)]
-                                                                                   #?(:clj (.pattern regex) :cljs (.-source regex)))}))}
-   {:pred (constantly :true) :transform-fn (update-val #(with-viewer :read+inspect (pr-str %)))}
-   {:name :elision :render-fn (quote v/elision-viewer) :transform-fn mark-presented}
-   {:name :latex :render-fn (quote v/katex-viewer) :transform-fn mark-presented}
-   {:name :mathjax :render-fn (quote v/mathjax-viewer) :transform-fn mark-presented}
-   {:name :html
-    :render-fn (quote v/html)
-    :transform-fn (comp mark-presented
-                        (update-val (partial w/postwalk (when-wrapped inspect-wrapped-value))))}
-   {:name :plotly :render-fn (quote v/plotly-viewer) :transform-fn mark-presented}
-   {:name :vega-lite :render-fn (quote v/vega-lite-viewer) :transform-fn mark-presented}
-   {:name :markdown :transform-fn (fn [wrapped-value]
-                                    (-> wrapped-value
-                                        mark-presented
-                                        (update :nextjournal/value #(cond->> % (string? %) md/parse))
-                                        (update :nextjournal/viewers add-viewers markdown-viewers)
-                                        (with-md-viewer)))}
-   {:name :code :render-fn (quote v/code-viewer) :transform-fn (comp mark-presented (update-val (fn [v] (if (string? v) v (str/trim (with-out-str (pprint/pprint v)))))))}
-   {:name :code-folded :render-fn (quote v/foldable-code-viewer) :transform-fn (comp mark-presented (update-val (fn [v] (if (string? v) v (with-out-str (pprint/pprint v))))))}
-   {:name :reagent :render-fn (quote v/reagent-viewer) :transform-fn mark-presented}
-   {:name :row :render-fn '(fn [items opts]
-                             (let [item-count (count items)]
-                               (v/html (into [:div {:class "md:flex md:flex-row md:gap-4 not-prose"
-                                                    :style opts}]
-                                         (map (fn [item]
-                                                [:div.flex.items-center.justify-center.flex-auto
-                                                 (v/inspect opts item)])) items))))}
-   {:name :col :render-fn '(fn [items opts]
-                             (v/html (into [:div {:class "md:flex md:flex-col md:gap-4 clerk-grid not-prose"
-                                                  :style opts}]
-                                       (map (fn [item]
-                                              [:div.flex.items-center.justify-center
-                                               (v/inspect opts item)])) items)))}
-   {:name :table
-    :transform-fn (fn [{:as wrapped-value :nextjournal/keys [viewers] :keys [offset path current-path]}]
-                    (if-let [{:keys [head rows]} (normalize-table-data (->value wrapped-value))]
-                      (-> wrapped-value
-                          (assoc :nextjournal/viewer :table/markup)
-                          (update :nextjournal/width #(or % :wide))
-                          (update :nextjournal/viewers update-table-viewers)
-                          (assoc :nextjournal/opts {:num-cols (-> rows first count)
-                                                    :number-col? (mapv number? (first rows))})
-                          (assoc :nextjournal/value (cond->> [(with-viewer :table/body (map (partial with-viewer :table/row) rows))]
-                                                      head (cons (with-viewer :table/head head)))))
-                      (-> wrapped-value
-                          mark-presented
-                          (assoc :nextjournal/width :wide)
-                          (assoc :nextjournal/value [(present wrapped-value)])
-                          (assoc :nextjournal/viewer {:render-fn 'v/table-error}))))}
-   {:name :table-error :render-fn (quote v/table-error) :fetch-opts {:n 1}}
-   {:name :clerk/code-block :transform-fn (fn [{:as wrapped-value :nextjournal/keys [value]}]
-                                            (-> wrapped-value
-                                                (assoc :nextjournal/viewer (if (:fold? value) :code-folded :code))
-                                                (update :nextjournal/value :text)))}
-   {:name :tagged-value :render-fn '(fn [{:keys [tag value space?]}] (v/html (v/tagged-value {:space? space?} (str "#" tag) [v/inspect-paginated value])))
-    :transform-fn (fn [wrapped-value]
-                    (-> wrapped-value
-                        (update-in [:nextjournal/value :value] present)
-                        mark-presented))}
-   {:name :clerk/result :render-fn (quote v/result-viewer) :transform-fn mark-presented}
-   {:name :clerk/notebook
-    :render-fn (quote v/notebook-viewer)
-    :transform-fn #?(:clj (fn [{:as wrapped-value :nextjournal/keys [viewers]}]
-                            (-> wrapped-value
-                                mark-presented
-                                (update :nextjournal/value
-                                        (fn [{:as doc :keys [ns]}]
-                                          (-> doc
-                                              (update :blocks (partial into [] (comp (mapcat (partial with-block-viewer doc))
-                                                                                     (map (comp #(vector (->ViewerEval 'v/inspect) %)
-                                                                                                process-wrapped-value
-                                                                                                apply-viewers*
-                                                                                                (partial ensure-wrapped-with-viewers viewers))))))
-                                              (select-keys [:blocks :toc :title])
-                                              (cond-> ns (assoc :scope (datafy-scope ns))))))))
-                     :cljs identity)}
-   {:name :hide-result :transform-fn (fn [_] nil)}])
-
+  [char-viewer
+   string-viewer
+   number-viewer
+   number-hex-viewer
+   symbol-viewer
+   keyword-viewer
+   nil-viewer
+   boolean-viewer
+   map-entry-viewer
+   var-from-def-viewer
+   read+inspect-viewer
+   vector-viewer
+   set-viewer
+   sequential-viewer
+   map-viewer
+   var-viewer
+   throwable-viewer
+   buffered-image-viewer
+   ideref-viewer
+   regex-viewer
+   fallback-viewer
+   elision-viewer
+   katex-viewer
+   mathjax-viewer
+   html-viewer
+   plotly-viewer
+   vega-lite-viewer
+   markdown-viewer
+   code-viewer
+   code-folded-viewer
+   reagent-viewer
+   row-viewer
+   col-viewer
+   table-viewer
+   table-error-viewer
+   code-block-viewer
+   tagged-value-viewer
+   result-viewer
+   notebook-viewer
+   hide-result-viewer])
 
 (defonce
   ^{:doc "atom containing a map of and per-namespace viewers or `:defaults` overridden viewers."}


### PR DESCRIPTION
To make inspecting & building on them easier. Use this to implement an example dashboard viewer that only shows the last result. This can be useful to build apps or dashboard without needing to hide every cell & result except one.

```clojure
(def last-result-viewer
  (update v/notebook-viewer :transform-fn (fn [transform-fn-orig]
                                            (comp transform-fn-orig
                                                  (clerk/update-val (fn [doc] (update doc :blocks (partial take-last 1))))))))
```

Fixes #133.