### PR TITLE
Support `:nextjournal.clerk/no-cache` meta on form also for vars

### DIFF
--- a/test/nextjournal/clerk/hashing_test.clj
+++ b/test/nextjournal/clerk/hashing_test.clj
@@ -83,6 +83,12 @@ par two"))))
       (is (not (h/no-cache? (h/analyze+emit '(rand-int 10)))))
       (is (not (h/no-cache? (h/analyze+emit '(def random-thing (rand-int 1000))))))
       (is (not (h/no-cache? (h/analyze+emit '(defn random-thing [] (rand-int 1000))))))
+      (is (h/no-cache? (h/analyze+emit '^:nextjournal.clerk/no-cache (rand-int 10))))
+      (is (h/no-cache? (h/analyze+emit '^:nextjournal.clerk/no-cache (def random-thing (rand-int 1000)))))
+      (is (h/no-cache? (h/analyze+emit '^:nextjournal.clerk/no-cache (defn random-thing [] (rand-int 1000))))))
+
+
+    (testing "deprecated way to set no-cache"
       (is (h/no-cache? (h/analyze+emit '(def ^:nextjournal.clerk/no-cache random-thing (rand-int 1000)))))
       (is (h/no-cache? (h/analyze+emit '(defn ^:nextjournal.clerk/no-cache random-thing [] (rand-int 1000)))))
       (is (h/no-cache? (h/analyze+emit '(defn ^{:nextjournal.clerk/no-cache true} random-thing [] (rand-int 1000)))))))


### PR DESCRIPTION
Previously it would have to go on a different place for vars than for unnamed top-level expressions.

Setting it on the var will be deprecated and so consistently setting it on the form is recommend from now on.