### PR TITLE
Restore support for Java 8 by bumping markdown

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
 
         com.nextjournal/beholder {:mvn/version "1.0.0"}
 
-        io.github.nextjournal/markdown {:mvn/version "0.4.116"}
+        io.github.nextjournal/markdown {:mvn/version "0.4.121"}
 
         com.taoensso/nippy {:mvn/version "3.1.1"}
         mvxcvi/multihash {:mvn/version "2.0.3"}

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-Wv8hGV7cmRqw3oaUZ1wRL4qCfvw
+3hoZ5UZEWazyJPnUcTvAbLMmp6zJ


### PR DESCRIPTION
Fixes #178 by using a markdown lib version using an older GraalJS.