### PR TITLE
Support simple maps in table viewer

### DIFF
--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -213,7 +213,7 @@
   Performs normalization on the data, supporting:
   * seqs of maps
   * maps of seqs
-  * seqs of seqs
+  * seqs of seqs (including maps)
 
   If you want a header for seqs of seqs use `use-headers`.
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -204,6 +204,7 @@
   (cond
     (and (map? data) (-> data :rows sequential?)) (normalize-seq-to-vec data)
     (and (map? data) (sequential? (first (vals data)))) (normalize-map-of-seq data)
+    (map? data) (normalize-seq-of-seq (seq data))
     (and (sequential? data) (map? (first data))) (normalize-seq-of-map data)
     (and (sequential? data) (sequential? (first data))) (normalize-seq-of-seq data)
     :else nil))


### PR DESCRIPTION
With this PR I propose to add support for simple maps in the table viewer. Note that this behavior is already possible by just calling `seq` on the map (which is what we're doing anyway in the implementation).

But I think that a table representation of a map (with keys and values) makes sense enough for the API to be explicitly supported.

<img width="995" alt="CleanShot 2022-08-03 at 19 34 40@2x" src="https://user-images.githubusercontent.com/283733/182661919-62e3b510-fa04-4333-9c47-29e36c2e76ba.png">
