### PR TITLE
Use PngEncoder lib for 10x improvement in encoding performance

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -13,6 +13,7 @@
         com.taoensso/nippy {:mvn/version "3.1.1"}
         mvxcvi/multihash {:mvn/version "2.0.3"}
         javax.xml.bind/jaxb-api {:mvn/version "2.3.1"} ;; needed to make multihash work on JDK11+
+        com.pngencoder/pngencoder {:mvn/version "0.13.1"}
 
         http-kit/http-kit {:mvn/version "2.5.3"}
         hiccup/hiccup {:mvn/version "2.0.0-alpha2"}

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-3rF7bdWVKxG449VFqbzEzYgbAGjZ
+3voMxveM9mnwz2BVsc415UdKzM8Y

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -12,10 +12,10 @@
             [nextjournal.markdown :as md]
             [nextjournal.markdown.transform :as md.transform]
             [lambdaisland.uri.normalize :as uri.normalize])
-  #?(:clj (:import (clojure.lang IDeref)
+  #?(:clj (:import (com.pngencoder PngEncoder)
+                   (clojure.lang IDeref)
                    (java.lang Throwable)
                    (java.awt.image BufferedImage)
-                   (javax.imageio ImageIO)
                    (java.util Base64))))
 
 (defrecord ViewerEval [form])
@@ -582,12 +582,13 @@
 
 (def buffered-image-viewer #?(:clj {:pred #(instance? BufferedImage %)
                                     :transform-fn (fn [{image :nextjournal/value}]
-                                                    (let [stream (java.io.ByteArrayOutputStream.)
-                                                          w (.getWidth image)
+                                                    (let [w (.getWidth image)
                                                           h (.getHeight image)
                                                           r (float (/ w h))]
-                                                      (ImageIO/write image "png" stream)
-                                                      (-> {:nextjournal/value (.toByteArray stream)
+                                                      (-> {:nextjournal/value (.. (PngEncoder.)
+                                                                                  (withBufferedImage image)
+                                                                                  (withCompressionLevel 1)
+                                                                                  (toBytes))
                                                            :nextjournal/content-type "image/png"
                                                            :nextjournal/width (if (and (< 2 r) (< 900 w)) :full :wide)}
                                                           mark-presented)))


### PR DESCRIPTION
We previously ran into https://github.com/pngencoder/pngencoder/issues/34 which has now been fixed in 13.1.