### PR TITLE
Don't attempt to check bounded count limit for non-freezable things

### DIFF
--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -88,7 +88,12 @@
 
 (defn ^:private cachable-value? [value]
   (and (some? value)
-       (nippy/freezable? value)
+       (try
+         (nippy/freezable? value)
+         ;; can error on e.g. lazy-cat fib
+         ;; TODO: propagate error information here
+         (catch Exception _
+           false))
        (not (analyzer/exceeds-bounded-count-limit? value))))
 
 #_(cachable-value? (vec (range 100)))

--- a/test/nextjournal/clerk/eval_test.clj
+++ b/test/nextjournal/clerk/eval_test.clj
@@ -35,6 +35,10 @@
       (is (match? {:blocks [{:result {:nextjournal/value -4}}]}
                   (eval/eval-doc {blob-id {:nextjournal/value -4}} doc)))))
 
+  (testing "does not hang on java.nio.Path result (issue #199)"
+    (eval/eval-string "(.toPath (clojure.java.io/file \"something\"))")
+    (eval/eval-string "[(.toPath (clojure.java.io/file \"something\"))]"))
+
   (testing "handling binding forms i.e. def, defn"
     ;; ensure "some-var" is a variable in whatever namespace we're running in
     (testing "the variable is properly defined"

--- a/test/nextjournal/clerk/eval_test.clj
+++ b/test/nextjournal/clerk/eval_test.clj
@@ -39,6 +39,9 @@
     (eval/eval-string "(.toPath (clojure.java.io/file \"something\"))")
     (eval/eval-string "[(.toPath (clojure.java.io/file \"something\"))]"))
 
+  (testing "does not error on lazy seq that integer overflows on freezable check"
+    (eval/eval-string "(def fib (lazy-cat [0 1] (map + fib (rest fib))))"))
+
   (testing "handling binding forms i.e. def, defn"
     ;; ensure "some-var" is a variable in whatever namespace we're running in
     (testing "the variable is properly defined"


### PR DESCRIPTION
Don't attempt to check bounded count limit for non-freezable things.

Also surface more context when Clerk eval fails, catch exception during nippy freezable check and add regression test.

Fixes #199.