### PR TITLE
Import slideshow viewer from clerk-slideshow repo

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -52,7 +52,8 @@
                                org.xerial/sqlite-jdbc {:mvn/version "3.34.0"}
                                org.clojure/data.csv {:mvn/version "1.0.0"}
                                hickory/hickory {:mvn/version "0.7.1"}
-                               sicmutils/sicmutils {:mvn/version "0.20.0"}}}
+                               sicmutils/sicmutils {:mvn/version "0.20.0"}
+                               io.github.nextjournal/clerk-slideshow {:git/sha "562f634494a1e1a9149ed78d5d39fd9486cc00ba"}}}
 
            :build {:deps {io.github.clojure/tools.build {:git/tag "v0.6.1" :git/sha "515b334"}
                           io.github.slipset/deps-deploy {:git/sha "b4359c5d67ca002d9ed0c4b41b710d7e5a82e3bf"}

--- a/notebooks/slideshow.clj
+++ b/notebooks/slideshow.clj
@@ -10,25 +10,24 @@
 ;;
 ;; `->slide` wraps a collection of blocks into markup suitable for rendering a slide.
 (defn ->slide [blocks]
+  ;; TODO: move to render-fn
   [:div.flex.flex-col.justify-center
    {:style {:min-block-size "100vh"}}
    (into [:div.text-xl.p-20 {:class ["prose max-w-none prose-h1:mb-0 prose-h2:mb-8 rose-h3:mb-8 prose-h4:mb-8"
                                      "prose-h1:text-6xl prose-h2:text-5xl prose-h3:text-3xl prose-h4:text-2xl"]}]
-         (map (fn [{:as block :keys [result]}]
-                (if result
-                  ;; TODO: ideally use (v/with-viewer :clerk/result-block block), currenlty messes wrapping during postwalk below
-                  (v/transform-result {:nextjournal/value block})
-                  ;; render code blocks with markdown for convenience
-                  (v/md block))))
          blocks)])
 
 ;; ---
 ;; The `doc->slides` helper function takes a Clerk notebook and partitions its blocks into slides by occurrences of markdown rulers.
 (defn doc->slides [{:as doc :keys [blocks]}]
   (sequence (comp (mapcat (partial v/with-block-viewer doc))
-                  (mapcat #(if (= :markdown (v/->viewer %)) (-> % v/->value :content) [(v/->value %)]))
-                  (partition-by (comp #{:ruler} :type))
-                  (remove (comp #{:ruler} :type first))
+                  (mapcat #(cond
+                             (= :markdown (v/->viewer %)) (map v/md (-> % v/->value :content))
+                             (= :clerk/code-block (v/->viewer %)) [(-> % v/->value v/md)]
+                             'else [%]))
+                  (partition-by (comp #{:ruler} :type v/->value))
+                  (remove (comp #{:ruler} :type v/->value first))
+                  (map (fn [bs] (map #(cond-> % (= :clerk/result-block (v/->viewer %)) v/apply-viewers) bs)))
                   (map ->slide))
             blocks))
 ;; ---
@@ -36,6 +35,9 @@
 (def slideshow-viewer
   {:name :clerk/notebook
    :transform-fn (comp v/mark-presented
+                       ;; TODO: drop mark-presented and the postwalk here in favour of a collection of slides as maps with preserved keys
+                       ;; {:as slide :keys [blocks]}
+                       ;; then use [v/inspect-presented block] in the viewer here
                        (v/update-val (comp (partial w/postwalk (v/when-wrapped v/inspect-wrapped-value))
                                            doc->slides)))
    :render-fn '(fn [slides]

--- a/notebooks/slideshow.clj
+++ b/notebooks/slideshow.clj
@@ -1,114 +1,26 @@
 ;; # 🎠 Clerk Slideshow
 ;; ---
-^{:nextjournal.clerk/visibility {:code :hide}}
 (ns slideshow
   (:require [nextjournal.clerk :as clerk]
-            [nextjournal.clerk.viewer :as v]
-            [clojure.walk :as w]))
+            [nextjournal.clerk-slideshow :as clerk-slideshow]))
 
-;; With a custom viewer and some helper functions, we can show a Clerk notebooks as Slideshow.
+;; This notebook uses a [slideshow viewer](https://github.com/nextjournal/clerk-slideshow) to override its built-in default notebook viewer.
+^{::clerk/visibility {:result :hide}}
+(clerk/add-viewers! [clerk-slideshow/viewer])
+
+;; By registering it for the current namespace, it takes over the rendering of the whole notebook page and turns it into a presentation.
 ;;
-;; `slide-viewer` wraps a collection of blocks into markup suitable for rendering a slide.
-
-(def slide-viewer
-  {:render-fn '(fn [blocks opts]
-                 (v/html
-                  [:div.flex.flex-col.justify-center
-                   {:style {:min-block-size "100vh"}}
-                   (into [:div.text-xl.p-20 {:class ["prose max-w-none prose-h1:mb-0 prose-h2:mb-8 rose-h3:mb-8 prose-h4:mb-8"
-                                                     "prose-h1:text-6xl prose-h2:text-5xl prose-h3:text-3xl prose-h4:text-2xl"]}]
-                         ;; TODO: fix markup for code blocks to use (v/inspect-children opts)
-                         (map (fn [{:as block {:keys [name]} :nextjournal/viewer}]
-                                [:div {:class (when (= :code name) "viewer-code")}
-                                 [v/inspect-presented block]])) blocks)]))})
-
+;; Use left and right keys to navigate, `ESC` for a summary deck.
+;;
 ;; ---
-;; The `doc->slides` helper function takes a Clerk notebook and partitions its blocks into slides by occurrences of markdown rulers.
-(defn doc->slides [{:as doc :keys [blocks]}]
-  (sequence (comp (mapcat (partial v/with-block-viewer doc))
-                  (mapcat #(if (= :markdown (v/->viewer %)) (map v/md (-> % v/->value :content)) [%]))
-                  (partition-by (comp #{:ruler} :type v/->value))
-                  (remove (comp #{:ruler} :type v/->value first))
-                  (map (partial v/with-viewer slide-viewer)))
-            blocks))
-;; ---
-;; Lastly, the `slideshow-viewer` overrides the notebook viewer
-(def slideshow-viewer
-  {:name :clerk/notebook
-   :transform-fn (v/update-val doc->slides)
-   :render-fn '(fn [slides]
-                 (v/html
-                  (reagent/with-let [!state (reagent/atom {:current-slide 0
-                                                           :grid? false
-                                                           :viewport-width js/innerWidth
-                                                           :viewport-height js/innerHeight})
-                                     ref-fn (fn [el]
-                                              (when el
-                                                (swap! !state assoc :stage-el el)
-                                                (js/addEventListener "resize"
-                                                                     #(swap! !state assoc
-                                                                             :viewport-width js/innerWidth
-                                                                             :viewport-height js/innerHeight))
-                                                (js/document.addEventListener "keydown"
-                                                                              (fn [e]
-                                                                                (case (.-key e)
-                                                                                  "Escape" (swap! !state update :grid? not)
-                                                                                  "ArrowRight" (when-not (:grid? !state)
-                                                                                                 (swap! !state update :current-slide #(min (dec (count slides)) (inc %))))
-                                                                                  "ArrowLeft" (when-not (:grid? !state)
-                                                                                                (swap! !state update :current-slide #(max 0 (dec %))))
-                                                                                  nil)))))
-                                     default-transition {:type :spring :duration 0.4 :bounce 0.1}]
-                                    (let [{:keys [grid? current-slide viewport-width viewport-height]} @!state]
-                                      [:div.overflow-hidden.relative.bg-slate-50
-                                       {:ref ref-fn :id "stage" :style {:width viewport-width :height viewport-height}}
-                                       (into [:> (.. framer-motion -motion -div)
-                                              {:style {:width (if grid? viewport-width (* (count slides) viewport-width))}
-                                               :initial false
-                                               :animate {:x (if grid? 0 (* -1 current-slide viewport-width))}
-                                               :transition default-transition}]
-                                             (map-indexed
-                                              (fn [i slide]
-                                                (let [width 250
-                                                      height 150
-                                                      gap 40
-                                                      slides-per-row (int (/ viewport-width (+ gap width)))
-                                                      col (mod i slides-per-row)
-                                                      row (int (/ i slides-per-row))]
-                                                  [:> (.. framer-motion -motion -div)
-                                                   {:initial false
-                                                    :class ["absolute left-0 top-0 overflow-x-hidden bg-white"
-                                                            (when grid?
-                                                              "rounded-lg shadow-lg overflow-y-hidden cursor-pointer ring-1 ring-slate-200 hover:ring hover:ring-blue-500/50 active:ring-blue-500")]
-                                                    :animate {:width (if grid? width viewport-width)
-                                                              :height (if grid? height viewport-height)
-                                                              :x (if grid? (+ gap (* (+ gap width) col)) (* i viewport-width))
-                                                              :y (if grid? (+ gap (* (+ gap height) row)) 0)}
-                                                    :transition default-transition
-                                                    :on-click #(when grid? (swap! !state assoc :current-slide i :grid? false))}
-                                                   [:> (.. framer-motion -motion -div)
-                                                    {:style {:width viewport-width
-                                                             :height viewport-height
-                                                             :transformOrigin "left top"}
-                                                     :initial false
-                                                     :animate {:scale (if grid? (/ width viewport-width) 1)}
-                                                     :transition default-transition}
-                                                    [v/inspect-presented slide]]]))
-                                              slides))]))))})
-
-
-(clerk/add-viewers! [slideshow-viewer])
-
-;; ---
-
 ;; ## 📊 Plotly
-^{::clerk/visibility :hide}
+^{::clerk/visibility {:code :hide}}
 (clerk/plotly {:data [{:z [[1 2 3] [3 2 1]] :type "surface"}]})
 
 ;; ---
 
 ;; ## 📈 Vega Lite
-^{::clerk/visibility :hide}
+^{::clerk/visibility {:code :hide}}
 (clerk/vl {:width 650 :height 400 :data {:url "https://vega.github.io/vega-datasets/data/us-10m.json"
                                          :format {:type "topojson" :feature "counties"}}
            :transform [{:lookup "id" :from {:data {:url "https://vega.github.io/vega-datasets/data/unemployment.tsv"}

--- a/notebooks/slideshow.clj
+++ b/notebooks/slideshow.clj
@@ -14,7 +14,12 @@
    {:style {:min-block-size "100vh"}}
    (into [:div.text-xl.p-20 {:class ["prose max-w-none prose-h1:mb-0 prose-h2:mb-8 rose-h3:mb-8 prose-h4:mb-8"
                                      "prose-h1:text-6xl prose-h2:text-5xl prose-h3:text-3xl prose-h4:text-2xl"]}]
-         (map (comp (fn [block] (if (:type block) (v/md block) (v/with-viewer :clerk/result block)))))
+         (map (fn [{:as block :keys [result]}]
+                (if result
+                  ;; TODO: ideally use (v/with-viewer :clerk/result-block block), currenlty messes wrapping during postwalk below
+                  (v/transform-result {:nextjournal/value block})
+                  ;; render code blocks with markdown for convenience
+                  (v/md block))))
          blocks)])
 
 ;; ---

--- a/notebooks/slideshow.clj
+++ b/notebooks/slideshow.clj
@@ -8,38 +8,34 @@
 
 ;; With a custom viewer and some helper functions, we can show a Clerk notebooks as Slideshow.
 ;;
-;; `->slide` wraps a collection of blocks into markup suitable for rendering a slide.
-(defn ->slide [blocks]
-  ;; TODO: move to render-fn
-  [:div.flex.flex-col.justify-center
-   {:style {:min-block-size "100vh"}}
-   (into [:div.text-xl.p-20 {:class ["prose max-w-none prose-h1:mb-0 prose-h2:mb-8 rose-h3:mb-8 prose-h4:mb-8"
-                                     "prose-h1:text-6xl prose-h2:text-5xl prose-h3:text-3xl prose-h4:text-2xl"]}]
-         blocks)])
+;; `slide-viewer` wraps a collection of blocks into markup suitable for rendering a slide.
+
+(def slide-viewer
+  {:render-fn '(fn [blocks opts]
+                 (v/html
+                  [:div.flex.flex-col.justify-center
+                   {:style {:min-block-size "100vh"}}
+                   (into [:div.text-xl.p-20 {:class ["prose max-w-none prose-h1:mb-0 prose-h2:mb-8 rose-h3:mb-8 prose-h4:mb-8"
+                                                     "prose-h1:text-6xl prose-h2:text-5xl prose-h3:text-3xl prose-h4:text-2xl"]}]
+                         ;; TODO: fix markup for code blocks to use (v/inspect-children opts)
+                         (map (fn [{:as block {:keys [name]} :nextjournal/viewer}]
+                                [:div {:class (when (= :code name) "viewer-code")}
+                                 [v/inspect-presented block]])) blocks)]))})
 
 ;; ---
 ;; The `doc->slides` helper function takes a Clerk notebook and partitions its blocks into slides by occurrences of markdown rulers.
 (defn doc->slides [{:as doc :keys [blocks]}]
   (sequence (comp (mapcat (partial v/with-block-viewer doc))
-                  (mapcat #(cond
-                             (= :markdown (v/->viewer %)) (map v/md (-> % v/->value :content))
-                             (= :clerk/code-block (v/->viewer %)) [(-> % v/->value v/md)]
-                             'else [%]))
+                  (mapcat #(if (= :markdown (v/->viewer %)) (map v/md (-> % v/->value :content)) [%]))
                   (partition-by (comp #{:ruler} :type v/->value))
                   (remove (comp #{:ruler} :type v/->value first))
-                  (map (fn [bs] (map #(cond-> % (= :clerk/result-block (v/->viewer %)) v/apply-viewers) bs)))
-                  (map ->slide))
+                  (map (partial v/with-viewer slide-viewer)))
             blocks))
 ;; ---
 ;; Lastly, the `slideshow-viewer` overrides the notebook viewer
 (def slideshow-viewer
   {:name :clerk/notebook
-   :transform-fn (comp v/mark-presented
-                       ;; TODO: drop mark-presented and the postwalk here in favour of a collection of slides as maps with preserved keys
-                       ;; {:as slide :keys [blocks]}
-                       ;; then use [v/inspect-presented block] in the viewer here
-                       (v/update-val (comp (partial w/postwalk (v/when-wrapped v/inspect-wrapped-value))
-                                           doc->slides)))
+   :transform-fn (v/update-val doc->slides)
    :render-fn '(fn [slides]
                  (v/html
                   (reagent/with-let [!state (reagent/atom {:current-slide 0
@@ -63,42 +59,42 @@
                                                                                                 (swap! !state update :current-slide #(max 0 (dec %))))
                                                                                   nil)))))
                                      default-transition {:type :spring :duration 0.4 :bounce 0.1}]
-                    (let [{:keys [grid? current-slide viewport-width viewport-height]} @!state]
-                      [:div.overflow-hidden.relative.bg-slate-50
-                       {:ref ref-fn :id "stage" :style {:width viewport-width :height viewport-height}}
-                       (into [:> (.. framer-motion -motion -div)
-                              {:style {:width (if grid? viewport-width (* (count slides) viewport-width))}
-                               :initial false
-                               :animate {:x (if grid? 0 (* -1 current-slide viewport-width))}
-                               :transition default-transition}]
-                             (map-indexed
-                              (fn [i slide]
-                                (let [width 250
-                                      height 150
-                                      gap 40
-                                      slides-per-row (int (/ viewport-width (+ gap width)))
-                                      col (mod i slides-per-row)
-                                      row (int (/ i slides-per-row))]
-                                  [:> (.. framer-motion -motion -div)
-                                   {:initial false
-                                    :class ["absolute left-0 top-0 overflow-x-hidden bg-white"
-                                            (when grid?
-                                              "rounded-lg shadow-lg overflow-y-hidden cursor-pointer ring-1 ring-slate-200 hover:ring hover:ring-blue-500/50 active:ring-blue-500")]
-                                    :animate {:width (if grid? width viewport-width)
-                                              :height (if grid? height viewport-height)
-                                              :x (if grid? (+ gap (* (+ gap width) col)) (* i viewport-width))
-                                              :y (if grid? (+ gap (* (+ gap height) row)) 0)}
-                                    :transition default-transition
-                                    :on-click #(when grid? (swap! !state assoc :current-slide i :grid? false))}
-                                   [:> (.. framer-motion -motion -div)
-                                    {:style {:width viewport-width
-                                             :height viewport-height
-                                             :transformOrigin "left top"}
-                                     :initial false
-                                     :animate {:scale (if grid? (/ width viewport-width) 1)}
-                                     :transition default-transition}
-                                    slide]]))
-                              slides))]))))})
+                                    (let [{:keys [grid? current-slide viewport-width viewport-height]} @!state]
+                                      [:div.overflow-hidden.relative.bg-slate-50
+                                       {:ref ref-fn :id "stage" :style {:width viewport-width :height viewport-height}}
+                                       (into [:> (.. framer-motion -motion -div)
+                                              {:style {:width (if grid? viewport-width (* (count slides) viewport-width))}
+                                               :initial false
+                                               :animate {:x (if grid? 0 (* -1 current-slide viewport-width))}
+                                               :transition default-transition}]
+                                             (map-indexed
+                                              (fn [i slide]
+                                                (let [width 250
+                                                      height 150
+                                                      gap 40
+                                                      slides-per-row (int (/ viewport-width (+ gap width)))
+                                                      col (mod i slides-per-row)
+                                                      row (int (/ i slides-per-row))]
+                                                  [:> (.. framer-motion -motion -div)
+                                                   {:initial false
+                                                    :class ["absolute left-0 top-0 overflow-x-hidden bg-white"
+                                                            (when grid?
+                                                              "rounded-lg shadow-lg overflow-y-hidden cursor-pointer ring-1 ring-slate-200 hover:ring hover:ring-blue-500/50 active:ring-blue-500")]
+                                                    :animate {:width (if grid? width viewport-width)
+                                                              :height (if grid? height viewport-height)
+                                                              :x (if grid? (+ gap (* (+ gap width) col)) (* i viewport-width))
+                                                              :y (if grid? (+ gap (* (+ gap height) row)) 0)}
+                                                    :transition default-transition
+                                                    :on-click #(when grid? (swap! !state assoc :current-slide i :grid? false))}
+                                                   [:> (.. framer-motion -motion -div)
+                                                    {:style {:width viewport-width
+                                                             :height viewport-height
+                                                             :transformOrigin "left top"}
+                                                     :initial false
+                                                     :animate {:scale (if grid? (/ width viewport-width) 1)}
+                                                     :transition default-transition}
+                                                    [v/inspect-presented slide]]]))
+                                              slides))]))))})
 
 
 (clerk/add-viewers! [slideshow-viewer])

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-4JEHSjLuR2K8zH2jnBv3tMq68r6N
+3rau7AxxNuqJe1GVYdUBMwnsJeZx


### PR DESCRIPTION
* Fixes the slideshow notebook viewer and improves it by dropping the inline inspections (eval-on-read) in favour of building collection of presented values (à la tables).
* Moves the viewer to the https://github.com/nextjournal/clerk-slideshow repo
* Adds clerk-slideshow to :demo alias 

