### PR TITLE
🔗 Set url hash when clicking ToC items

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -32,7 +32,7 @@
                               org.babashka/sci {:mvn/version "0.4.33"}
                               reagent/reagent {:mvn/version "1.1.1"}
                               io.github.babashka/sci.configs {:git/sha "fcd367c6a6115c5c4e41f3a08ee5a8d5b3387a18"}
-                              io.github.nextjournal/viewers {:git/sha "3284aae7379bde3fcf41d17c663bed421fb31d6d"}
+                              io.github.nextjournal/viewers {:git/sha "1aaedea7709611cbb393add4c85c7a2dd551260e"}
                               metosin/reitit-frontend {:mvn/version "0.5.15"}}}
 
            :dev {:extra-deps {arrowic/arrowic {:mvn/version "0.1.1"}

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-29NTbGRUegkfDDXWWf1Lhw4RUZxr
+gYDx9Lcov3g4BqALTKkopf1vktp

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-gYDx9Lcov3g4BqALTKkopf1vktp
+EoZoseuBuD6jUbVUdLZwCTXW59W

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -211,3 +211,4 @@
 #_(build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle false :browse false})
 #_(build-static-app! {:paths ["notebooks/viewers/**"]})
 #_(build-static-app! {:index "notebooks/rule_30.clj"  :git/sha "bd85a3de12d34a0622eb5b94d82c9e73b95412d1" :git/url "https://github.com/nextjournal/clerk"})
+#_(build-static-app! {:index "book.clj" :browse true})

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -121,7 +121,7 @@
 
 (defonce !eval-counter (r/atom 0))
 
-(defn notebook [{:as _doc xs :blocks :keys [toc toc-visibility]}]
+(defn notebook [{:as _doc xs :blocks :keys [bundle? toc toc-visibility]}]
   (r/with-let [local-storage-key "clerk-navbar"
                !state (r/atom {:toc (toc-items (:children toc))
                                :md-toc toc
@@ -130,6 +130,7 @@
                                :width 220
                                :mobile-width 300
                                :local-storage-key local-storage-key
+                               :set-hash? (not bundle?)
                                :open? (if-some [stored-open? (ls/get-item local-storage-key)]
                                         stored-open?
                                         (not= :collapsed toc-visibility))})

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -47,7 +47,7 @@
      (if content
        (let [title (md.transform/->text item)]
          (->> {:title title
-               :path (str "#" (uri.normalize/normalize-fragment title))
+               :path (str "#" (viewer/->slug title))
                :items (toc-items children)}
               (conj acc)
               vec))

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -6,7 +6,6 @@
             [edamame.core :as edamame]
             [goog.object]
             [goog.string :as gstring]
-            [lambdaisland.uri.normalize :as uri.normalize]
             [nextjournal.clerk.viewer :as viewer :refer [code md plotly tex table vl row col with-viewer with-viewers]]
             [nextjournal.markdown.transform :as md.transform]
             [nextjournal.ui.components.d3-require :as d3-require]

--- a/src/nextjournal/clerk/static_app.cljs
+++ b/src/nextjournal/clerk/static_app.cljs
@@ -30,7 +30,7 @@
   {:nextjournal/viewer sci-viewer/html-render
    :nextjournal/value hiccup})
 
-(defn show [{:as view-data :git/keys [sha url] :keys [doc path url->path]}]
+(defn show [{:as view-data :git/keys [sha url] :keys [bundle? doc path url->path]}]
   (let [header [:div.mb-8.text-xs.sans-serif.text-gray-400.not-prose
                 (when (not= "" path)
                   [:<>
@@ -46,7 +46,7 @@
                     " from "
                     [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
                      {:href (str url "/blob/" sha "/" (url->path path))} (url->path path) "@" [:span.tabular-nums (subs sha 0 7)]]])]]]
-    (sci-viewer/set-state {:doc (cond-> doc
+    (sci-viewer/set-state {:doc (cond-> (assoc doc :bundle? bundle?)
                                   (vector? (get-in doc [:nextjournal/value :blocks]))
                                   (update-in [:nextjournal/value :blocks] (partial into [(hiccup header)])))})
     [sci-viewer/root]))
@@ -137,7 +137,6 @@
     (reset! !state (assoc state
                           :path->doc url->doc
                           :url->path (set/map-invert path->url)))
-    (js/console.log :init state)
     (sci/alter-var-root sci-viewer/doc-url (constantly (partial doc-url @!state)))
     (if bundle?
       (let [router (rf/router (get-routes url->doc))]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -479,6 +479,12 @@
 
 #_((update-val + 1) {:nextjournal/value 41})
 
+(defn ->slug [text]
+  (apply str
+         (map (comp str/lower-case
+                    (fn [c] (case c (\space \-) \_ c))) text)))
+#_ (->slug "Hello There")
+
 (def markdown-viewers
   [{:name :nextjournal.markdown/doc :transform-fn (into-markup [:div.viewer-markdown])}
 
@@ -486,7 +492,7 @@
    {:name :nextjournal.markdown/heading
     :transform-fn (into-markup
                    (fn [{:as node :keys [heading-level]}]
-                     [(str "h" heading-level) {:id (uri.normalize/normalize-fragment (md.transform/->text node))}]))}
+                     [(str "h" heading-level) {:id (->slug (md.transform/->text node))}]))}
    {:name :nextjournal.markdown/image :transform-fn #(with-viewer :html [:img.inline (-> % ->value :attrs)])}
    {:name :nextjournal.markdown/blockquote :transform-fn (into-markup [:blockquote])}
    {:name :nextjournal.markdown/paragraph :transform-fn (into-markup [:p])}

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -13,8 +13,7 @@
                        [sci.lang]
                        [applied-science.js-interop :as j]])
             [nextjournal.markdown :as md]
-            [nextjournal.markdown.transform :as md.transform]
-            [lambdaisland.uri.normalize :as uri.normalize])
+            [nextjournal.markdown.transform :as md.transform])
   #?(:clj (:import (com.pngencoder PngEncoder)
                    (clojure.lang IDeref)
                    (java.lang Throwable)


### PR DESCRIPTION
This sets a `#heading-content` when clicking a TOC item. This works only for unbundled build as bundled builds use the `#` part of the URL to navigate to notebooks. 

* [x] Update viewers’ `nextjournal.ui.components.navbar` to be able to set URL hashes.
* [x] Activate option in Clerk only when unbundled.
* [x] Have markdown heading viewer produce nicer slugs for ids