### PR TITLE
Inline Plotly viewer

### DIFF
--- a/notebooks/viewers/plotly.clj
+++ b/notebooks/viewers/plotly.clj
@@ -2,6 +2,31 @@
 (ns viewers.plotly
   (:require [nextjournal.clerk.viewer :as v]))
 
-(v/plotly {:data [{:z [[1 2 3]
+;; ## Examples with Plotly's default options
+;; See [Plotly's JavaScript docs](https://plotly.com/javascript/) for more examples and options
+
+(v/plotly {:layout {:title "A surface plot"}
+           :data [{:z [[1 2 3]
                        [3 2 1]]
                    :type "surface"}]})
+
+(v/plotly {:layout {:title "A simple scatter plot with lines and markers"}
+           :data [{:x [1 2 3 4]
+                   :y [10 15 13 17]
+                   :mode "markers"
+                   :type "scatter"}
+                  {:x [2 3 4 5]
+                   :y [16 5 11 9]
+                   :mode "lines"
+                   :type "scatter"}
+                  {:x [1 2 3 4]
+                   :y [12 9 15 12]
+                   :mode "lines+markers"
+                   :type "scatter"}]})
+
+;; ## Example with customized options
+
+(v/plotly {:layout {:margin {:l 20 :r 0 :b 20 :t 0} :autosize false :width 300 :height 200}
+           :data [{:x ["giraffes" "orangutans" "monkeys"]
+                   :y [20 14 23]
+                   :type "bar"}]})

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-4ZdAZwg7ydXGHHZcCH31qfLYEfKa
+3rirnomW8Vs17o7Ftq8tbED6Fzqc

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -19,7 +19,6 @@
             [nextjournal.viewer.code :as code]
             [nextjournal.viewer.katex :as katex]
             [nextjournal.viewer.mathjax :as mathjax]
-            [nextjournal.viewer.plotly :as plotly]
             [reagent.core :as r]
             [reagent.dom :as rdom]
             [reagent.ratom :as ratom]

--- a/src/nextjournal/clerk/sci_viewer.cljs
+++ b/src/nextjournal/clerk/sci_viewer.cljs
@@ -644,9 +644,21 @@
               [:div.vega-lite {:ref #(when %
                                        (.appendChild % vega-el))}]])])))
 
+(defn plotly-viewer [value]
+  (when value
+    (html ^{:key value}
+          [with-d3-require {:package ["plotly.js-dist@2.15.1"]
+                            :then (fn [^js plotly]
+                                    (let [el (js/document.createElement "div")]
+                                      (.newPlot plotly el (clj->js value))
+                                      el))}
+           (j/fn [plotly-el]
+             [:div {:style {:overflow-x "auto"}}
+              [:div.plotly {:ref #(when %
+                                    (.appendChild % plotly-el))}]])])))
+
 (def mathjax-viewer (comp normalize-viewer-meta mathjax/viewer))
 (def code-viewer (comp normalize-viewer-meta code/viewer))
-(def plotly-viewer (comp normalize-viewer-meta plotly/viewer))
 
 (def expand-icon
   [:svg {:xmlns "http://www.w3.org/2000/svg" :viewBox "0 0 20 20" :fill "currentColor" :width 12 :height 12}


### PR DESCRIPTION
This re-implements the Plotly viewer without all the the custom options that are set in nextjournal/viewers. This means the margins are now plotly's defaults. More examples with different options are provided.