### PR TITLE
fixes inspect with nil values

### DIFF
--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-42P99ARGrVTaFXi4jtro9eyyyf6b
+2U615n6bfKpz4G9p3TMtnM8bfFDz

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -612,7 +612,7 @@
 
 (defn inspect [value]
   (r/with-let [!state (r/atom nil)]
-    (when (not= (:value @!state) value)
+    (when (not= (:value @!state ::not-found) value)
       (swap! !state assoc :value value :desc (viewer/present value)))
     [view-context/provide {:fetch-fn (fn [fetch-opts]
                                        (.then (in-process-fetch value fetch-opts)


### PR DESCRIPTION
`:desc` was not being added to `!state` for `nil` values, fixed by adding a `::not-found` arg to the keyword lookup.