### PR TITLE
Fix UI test: isVisible returns promise

### DIFF
--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-3vkMk6BhZP3pxoaLwanGN17fkucv
+3kthWVUaRQtwhqCvUMw45SSDDTuT

--- a/ui_tests/playwright_tests.cljs
+++ b/ui_tests/playwright_tests.cljs
@@ -69,6 +69,7 @@
                                (.isVisible #js {:timeout 10000})))
                      links (-> (.locator page "text=/.*\\.clj$/i")
                                (.allInnerTexts))
+                     _ (is (pos? (count links)))
                      links (map (fn [link]
                                   (str @!index "#/" link)) links)]
                (p/run! #(test-notebook page %) links)

--- a/ui_tests/playwright_tests.cljs
+++ b/ui_tests/playwright_tests.cljs
@@ -48,8 +48,10 @@
 (defn test-notebook [page link]
   (println "Visiting" link)
   (p/do (goto page link)
-        (is (-> (.locator page "div.viewer:has-text(\"Hello, Clerk\")")
-                (.isVisible)))))
+        (p/let [loc (.locator page "div")
+                loc (.first loc)
+                visible? (.isVisible loc)]
+          (is visible?))))
 
 (def console-errors (atom []))
 


### PR DESCRIPTION
Previously ui tests could wrongly report success in case the index page would not load.