### PR TITLE
Depth-first Analysis

### DIFF
--- a/notebooks/interns.clj
+++ b/notebooks/interns.clj
@@ -1,0 +1,8 @@
+;; # 🎭 Manually interned Vars
+(ns interns)
+
+(defn my-intern [x] (intern *ns* x 42))
+
+(my-intern 'the-answer)
+
+the-answer

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-2NzqBGHiqBgN4Hqj6Jjdy66mrD8G
+3Lykbet4iSZMzguXAUMXFnZkU1Hr

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-4HziXTjHE5wSgSoeDRbpuQmyEfGK
+2NzqBGHiqBgN4Hqj6Jjdy66mrD8G

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-3Lykbet4iSZMzguXAUMXFnZkU1Hr
+vTjtsbBJnR5QGTDJsKJGTc3fK5d

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-3RDDrPERrU9qGz2ZYkKhUq55e8fv
+4HziXTjHE5wSgSoeDRbpuQmyEfGK

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-vTjtsbBJnR5QGTDJsKJGTc3fK5d
+45VcpKfXQkNyPuKUsfHSxeu4zbBu

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -312,7 +312,7 @@
                                          state)
                                  foreign-deps (into #{}
                                                     (comp (filter qualified-symbol?)
-                                                          (remove (comp #{"clojure.core"} namespace)) ;; add more leaves + hash jars
+                                                          (remove (comp #{"clojure"} first #(str/split % #"\.") namespace)) ;; add more leaves + hash jars
                                                           (remove (set (keys (:->analysis-info state))))) ;; see unhashed-deps
                                                     deps)
                                  {:as state :keys [graph]} (reduce analyze-parent-doc state foreign-deps)


### PR DESCRIPTION
This is just an experiment around some possible changes in the order in which the dependency graph is built by Clerk analysis.

At present, when analyzing a single form, we collect only _immediate dependencies_ of the form. The full graph is computed only at a later time (immediately before evaluation) _and_ we don't follow/analyze dependencies which reside in jar deps.

The code in this branch changes the process in some ways:
* for each code block in the notebook, we do follow all dependencies transitively before passing to the next form
* we do parse and analyze parent documents (i.e. namespaces) residing in jars

with this in palce we can:

* eval (debatable) forms which transitively depend on `clojure.core/intern` 
* record the names of vars which have been interned during eval

to partly address #247, for instance.

There is an expected and relevant deterioration in performance here, since we do analyze (slurp/parse/analyze) foreign dependency namespaces regardless of them residing in jars. In order to mitigate this we can stop at certain forms belonging to known namespaces like `clojure.*` or `nextjournal.*` which are treaded as leaves in the tree and their jar should be hashed instead as we did before.