### PR TITLE
functional handling of resource-urls

### DIFF
--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -423,13 +423,14 @@
   Passing at least one of the above is required. When both `:paths`
   and `:paths-fn` are given, `:paths` takes precendence.
 
-  - `:bundle`      - if true results in a single self-contained html file including inlined images
-  - `:compile-css` - if true compiles css file containing only the used classes
-  - `:ssr`         - if true runs react server-side-rendering and includes the generated markup in the html
-  - `:browse`      - if true will open browser with the built file on success
-  - `:dashboard`   - if true will start a server and show a rich build report in the browser (use with `:bundle` to open browser)
-  - `:out-path`  - a relative path to a folder to contain the static pages (defaults to `\"public/build\"`)
-  - `:git/sha`, `:git/url` - when both present, each page displays a link to `(str url \"blob\" sha path-to-notebook)`
+  - `:bundle`        - if true results in a single self-contained html file including inlined images
+  - `:compile-css`   - if true compiles css file containing only the used classes
+  - `:ssr`           - if true runs react server-side-rendering and includes the generated markup in the html
+  - `:browse`        - if true will open browser with the built file on success
+  - `:dashboard`     - if true will start a server and show a rich build report in the browser (use with `:bundle` to open browser)
+  - `:out-path`      - a relative path to a folder to contain the static pages (defaults to `\"public/build\"`)
+  - `:git/sha`, `:git/url` - when both present, each page displays a link to `(str url \"blob\" sha path-to-notebook)
+  - `:resource-urls` - a map to override asset paths
   "
   {:org.babashka/cli {:spec {:paths {:desc "Paths to notebooks toc include in the build, supports glob patterns."
                                      :coerce []}

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -365,6 +365,7 @@
   * `:browse?` will open Clerk in a browser after it's been started
   * a sequence of `:watch-paths` that Clerk will watch for file system events and show any changed file
   * a `:show-filter-fn` to restrict when to re-evaluate or show a notebook as a result of file system event. Useful for e.g. pinning a notebook. Will be called with the string path of the changed file.
+  * a `:resource-urls` map to override asset paths
 
   Can be called multiple times and Clerk will happily serve you according to the latest config."
   {:org.babashka/cli {:spec {:watch-paths {:desc "Paths on which to watch for changes and show a changed document."
@@ -383,9 +384,9 @@
                (str "\n" (format-opts (-> #'serve! meta :org.babashka/cli))))
       (println (-> #'serve! meta :doc)))
     (let [{:as normalized-config
-           :keys [browse? watch-paths port show-filter-fn]
+           :keys [browse? watch-paths port show-filter-fn resource-urls]
            :or {port 7777}} (normalize-opts config)]
-      (webserver/serve! {:port port})
+      (webserver/serve! {:port port :resource-urls resource-urls})
       (reset! !show-filter-fn show-filter-fn)
       (halt-watcher!)
       (when (seq watch-paths)

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -26,11 +26,11 @@
   (delay (or (some-> (io/resource "clerk-asset-map.edn") slurp edn/read-string)
              (-> lookup-url slurp edn/read-string))))
 
-(defonce !resource->url
+(def static-resource-urls
   ;; contains asset manifest in the form:
   ;; {"/js/viewer.js" "https://..."}
-  (atom (or resource-manifest-from-props
-            @!asset-map)))
+  (or resource-manifest-from-props
+      @!asset-map))
 
 #_(swap! !resource->url assoc "/css/viewer.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvAV62HzsvhcsXEkHP33uj4cV9UvdDz7DU9qLeVRCfEP9kWLFAzaMKL77trdx898DzcVyDVejdfxvxj5XB84UpWvQ")
 #_(swap! !resource->url dissoc "/css/viewer.css")

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -1,6 +1,5 @@
 (ns nextjournal.clerk.view
-  (:require [nextjournal.clerk.config :as config]
-            [nextjournal.clerk.viewer :as v]
+  (:require [nextjournal.clerk.viewer :as v]
             [hiccup.page :as hiccup]
             [clojure.string :as str]
             [clojure.java.io :as io])
@@ -28,21 +27,21 @@
     ({index "index.clj"} path path)
     path))
 
-(defn include-viewer-css [{:as state :keys [current-path]}]
-  (if-let [css-url (@config/!resource->url "/css/viewer.css")]
+(defn include-viewer-css [{:as opts :keys [current-path resource-urls]}]
+  (if-let [css-url (resource-urls "/css/viewer.css")]
     (hiccup/include-css (cond-> css-url
-                          (and current-path (relative? css-url))
-                          (->> (str (v/relative-root-prefix-from (map-index state current-path))))))
+                                (and current-path (relative? css-url))
+                                (->> (str (v/relative-root-prefix-from (map-index opts current-path))))))
     (list (hiccup/include-js "https://cdn.tailwindcss.com?plugins=typography")
           [:script (-> (slurp (io/resource "stylesheets/tailwind.config.js"))
                        (str/replace #"^module.exports" "tailwind.config")
                        (str/replace #"require\(.*\)" ""))]
           [:style {:type "text/tailwindcss"} (slurp (io/resource "stylesheets/viewer.css"))])))
 
-(defn include-css+js [state]
+(defn include-css+js [{:as opts :keys [resource-urls]}]
   (list
-   (include-viewer-css state)
-   [:script {:type "module" :src (@config/!resource->url "/js/viewer.js")}]
+   (include-viewer-css opts)
+   [:script {:type "module" :src (resource-urls "/js/viewer.js")}]
    (hiccup/include-css "https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.css")
    [:link {:rel "preconnect" :href "https://fonts.bunny.net"}]
    (hiccup/include-css "https://fonts.bunny.net/css?family=fira-code:400,700%7Cfira-mono:400,700%7Cfira-sans:400,400i,500,500i,700,700i%7Cfira-sans-condensed:700,700i%7Cpt-serif:400,400i,700,700i")))
@@ -65,27 +64,27 @@ viewer.mount(document.getElementById('clerk'))\n"
 ws.onmessage = viewer.onmessage;
 window.ws_send = msg => ws.send(msg)")]]))
 
-(defn ->static-app [{:as state :keys [current-path html]}]
+(defn ->static-app [{:as opts :keys [current-path html]}]
   (hiccup/html5
    {:class "overflow-hidden min-h-screen"}
    [:head
-    [:title (or (and current-path (-> state :path->doc (get current-path) v/->value :title)) "Clerk")]
+    [:title (or (and current-path (-> opts :path->doc (get current-path) v/->value :title)) "Clerk")]
     [:meta {:charset "UTF-8"}]
     [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
-    (when current-path (v/open-graph-metas (-> state :path->doc (get current-path) v/->value :open-graph)))
-    (include-css+js state)]
+    (when current-path (v/open-graph-metas (-> opts :path->doc (get current-path) v/->value :open-graph)))
+    (include-css+js opts)]
    [:body
     [:div#clerk-static-app html]
     [:script {:type "module"} "let viewer = nextjournal.clerk.sci_env
 let app = nextjournal.clerk.static_app
-let opts = viewer.read_string(" (-> state v/->edn pr-str) ")
+let opts = viewer.read_string(" (-> opts v/->edn pr-str) ")
 app.init(opts)\n"]]))
 
-(defn doc->html [doc error]
-  (->html {} {:doc (doc->viewer {} doc) :error error}))
+(defn doc->html [doc state]
+  (->html {} (assoc state :doc (doc->viewer {} doc))))
 
-(defn doc->static-html [doc]
-  (->html {:conn-ws? false} {:doc (doc->viewer {:inline-results? true} doc)}))
+(defn doc->static-html [doc state]
+  (->html {:conn-ws? false} (assoc state :doc (doc->viewer {:inline-results? true} doc))))
 
 #_(let [out "test.html"]
     (spit out (doc->static-html (nextjournal.clerk.eval/eval-file "notebooks/pagination.clj")))

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -4,6 +4,7 @@
             [clojure.pprint :as pprint]
             [clojure.string :as str]
             [editscript.core :as editscript]
+            [nextjournal.clerk.config :as config]
             [nextjournal.clerk.view :as view]
             [nextjournal.clerk.viewer :as v]
             [nextjournal.markdown :as md]
@@ -117,7 +118,7 @@
     (apply swap! nextjournal.clerk.atom/my-state (eval '[update :counter inc]))
     (eval '(nextjournal.clerk/recompute!)))
 
-(defn app [{:as req :keys [uri]}]
+(defn app [{:as req :keys [uri resource-urls]}]
   (if (:websocket? req)
     (httpkit/as-channel req ws-handlers)
     (try
@@ -127,7 +128,8 @@
         "_ws" {:status 200 :body "upgrading..."}
         {:status  200
          :headers {"Content-Type" "text/html"}
-         :body    (view/doc->html @!doc @!error)})
+         :body    (view/doc->html @!doc {:error @!error
+                                         :resource-urls resource-urls})})
       (catch Throwable e
         {:status  500
          :body    (with-out-str (pprint/pprint (Throwable->map e)))}))))
@@ -181,10 +183,14 @@
 
 #_(halt!)
 
-(defn serve! [{:keys [port] :or {port 7777}}]
+(defn serve! [{:keys [port resource-urls] :or {port 7777}}]
   (halt!)
   (try
-    (reset! !server {:port port :stop-fn (httpkit/run-server #'app {:port port})})
+    (let [resource-urls (merge config/static-resource-urls resource-urls)]
+      (reset! !server {:port port :stop-fn (httpkit/run-server
+                                            (fn [req]
+                                              (#'app (assoc req :resource-urls resource-urls)))
+                                            {:port port})}))
     (println (str "Clerk webserver started on http://localhost:" port " ..."))
     (catch java.net.BindException _e
       (println "Port " port " not available, server not started!"))))


### PR DESCRIPTION
Serve and build commands accept a `:resource-urls` map which are merged into a `static-resource-urls` map (deprecating the `config/!resource->url` atom)