### PR TITLE
Move render deps to separate deps root

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -31,19 +31,13 @@
                                :main-opts ["-m" "babashka.cli.exec"]
                                :jvm-opts ["-Dclojure.main.report=stdout"]
                                :nextjournal.clerk/aliases [:demo]}
-           :sci {:extra-deps {applied-science/js-interop {:mvn/version "0.3.3"}
-                              org.babashka/sci {:git/url "https://github.com/babashka/sci"
-                                                :git/sha "a766b73f668e8ba59855ce229fad1aee08038922"}
-                              reagent/reagent {:mvn/version "1.1.1"}
-                              io.github.babashka/sci.configs {:git/sha "fcd367c6a6115c5c4e41f3a08ee5a8d5b3387a18"}
-                              io.github.nextjournal/viewers {:git/sha "1aaedea7709611cbb393add4c85c7a2dd551260e"}
-                              metosin/reitit-frontend {:mvn/version "0.5.15"}}}
+
+           :sci {:extra-deps {io.github.nextjournal/clerk.render {:local/root "render"}}}
 
            :dev {:extra-deps {org.clojure/clojure {:mvn/version "1.11.1"} ;; for `:as-alias` support but only in dev
                               arrowic/arrowic {:mvn/version "0.1.1"}
                               binaryage/devtools {:mvn/version "1.0.3"}
                               cider/cider-nrepl {:mvn/version "0.28.3"}
-                              thheller/shadow-cljs {:mvn/version "2.20.7"}
                               org.slf4j/slf4j-nop {:mvn/version "1.7.36"}
                               org.babashka/cli {:mvn/version "0.5.40"}}
                  :extra-paths ["dev" "notebooks"]

--- a/render/deps.edn
+++ b/render/deps.edn
@@ -1,0 +1,11 @@
+{:deps {applied-science/js-interop {:mvn/version "0.3.3"}
+        binaryage/devtools {:mvn/version "1.0.3"}
+        cider/cider-nrepl {:mvn/version "0.28.3"}
+        org.babashka/sci {:mvn/version "0.5.34"
+                          #_#_#_#_:git/url "https://github.com/babashka/sci"
+                                  :git/sha "a766b73f668e8ba59855ce229fad1aee08038922"}
+        reagent/reagent {:mvn/version "1.1.1"}
+        io.github.babashka/sci.configs {:git/sha "b5335b79c237344d003f16358321197a0b0a2ac6"}
+        io.github.nextjournal/viewers {:git/sha "1aaedea7709611cbb393add4c85c7a2dd551260e"}
+        metosin/reitit-frontend {:mvn/version "0.5.15"}
+        thheller/shadow-cljs {:mvn/version "2.20.7"}}}

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-31Pp77XziPMgRPJmdo8bSKTkPN3D
+abJdytpWGMj1QK5kpp8BHevz36P


### PR DESCRIPTION
To support getting to the deps via `:deps/root` for folks wanting to take over the cljs build of clerk in order to support additional namespaces.