### PR TITLE
Expose `nextjournal.clerk.render/consume-view-context`

### DIFF
--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-nQiB71acGqXWn9s3qi9AzaK1ehv
+2Yw4kvEU5hCYT483hqGVpBMtz9Ln

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -723,3 +723,5 @@
     src
     (str "/_blob/" blob-id (when-let [opts (seq (dissoc src :blob-id))]
                              (str "?" (opts->query opts))))))
+
+(def consume-view-context view-context/consume)


### PR DESCRIPTION
I was getting the following for elements that used the elision viewer:
`Could not resolve symbol: nextjournal.clerk.render/consume-view-context`

![20221116_12h03m08s_grim](https://user-images.githubusercontent.com/94817/202163843-d298d506-7ecf-4c9e-87cc-1305f0911a5c.png)


This change seems to resolve it, though I don't know if it is the correct way to address it