### PR TITLE
Fix var-from-def

### DIFF
--- a/notebooks/viewers/control_lab.clj
+++ b/notebooks/viewers/control_lab.clj
@@ -10,7 +10,7 @@
 
 (def viewer-eval-viewer
   {:pred viewer/viewer-eval?
-   :nextjournal.clerk/var-from-def true
+   :var-from-def? true
    :transform-fn (comp viewer/mark-presented
                        (viewer/update-val
                         (fn [x]

--- a/notebooks/viewers/var_from_def.clj
+++ b/notebooks/viewers/var_from_def.clj
@@ -1,0 +1,23 @@
+;; # Vars from definitions
+(ns viewers.var-from-def
+  {:nextjournal.clerk/no-cache true}
+  (:require [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.viewer :as v]))
+
+;; By default, for def-like expressions we're showing the underlying var value.
+(def d1 "def1")
+
+(defonce d2 "def2")
+
+^{::clerk/viewer {:render-fn '(fn [x] [:pre (pr-str x)])}}
+(def d3 "def3")
+
+;; We can opt-out of the default behavour and obtain a var wraapped in a map with: `{::clerk/var-from-def my-var}` like so:
+
+^{::clerk/viewer {:var-from-def? true
+                  :render-fn '(fn [x] [:pre (pr-str x)])}}
+(def ^{:foo 'bar} d4 "def4")
+
+^{::clerk/viewer {:var-from-def? true
+                  :transform-fn (v/update-val (comp meta ::clerk/var-from-def))}}
+(def ^{:foo 'bar} d5 "def5")

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-3qpLvPwx18MsC4zPMtYMe6inft8f
+2QJ3RAK8uf4ZFnJKg8dxChXuYD2r

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -51,6 +51,7 @@
          "viewers/plotly"
          "viewers/table"
          "viewers/tex"
+         "viewers/var_from_def"
          "viewers/vega"]))
 
 

--- a/src/nextjournal/clerk/tap.clj
+++ b/src/nextjournal/clerk/tap.clj
@@ -7,7 +7,7 @@
   (:import (java.time Instant LocalTime ZoneId)))
 
 (def switch-view
-  {::clerk/var-from-def true
+  {:var-from-def? true
    :transform-fn (comp clerk/mark-presented
                        (clerk/update-val (fn [{::clerk/keys [var-from-def]}]
                                            {:var-name (symbol var-from-def) :value @@var-from-def})))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -325,11 +325,13 @@
 
 #_((update-val + 1) {:nextjournal/value 41})
 
-(def var-from-def?
-  (get-safe :nextjournal.clerk/var-from-def))
+(defn guard [p x] (when (p x) x))
+
+(defn var-from-def? [x] (guard var? (get-safe x :nextjournal.clerk/var-from-def)))
 
 (def var-from-def-viewer
-  {:pred var-from-def? :transform-fn (update-val (comp deref :nextjournal.clerk/var-from-def))})
+  {:pred var-from-def?
+   :transform-fn (update-val (comp deref :nextjournal.clerk/var-from-def))})
 
 (defn apply-viewer-unwrapping-var-from-def
   "Applies the `viewer` (if set) to the given result `result`. In case
@@ -343,7 +345,7 @@
                           :nextjournal/viewer (normalize-viewer viewer)})
           {unwrap-var :transform-fn var-from-def? :pred} var-from-def-viewer]
       (assoc result :nextjournal/value (cond-> value+viewer
-                                         (and (var-from-def? value) (not (var-from-def? (->viewer value+viewer))))
+                                         (and (var-from-def? value) (not (:var-from-def? (->viewer value+viewer))))
                                          unwrap-var)))
     result))
 

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -93,7 +93,7 @@
     (testing "leaves var wrapped when viewer opts out"
       (is (= {:nextjournal.clerk/var-from-def #'my-test-var}
              (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var}
-                               :nextjournal/viewer (assoc v/html-viewer :nextjournal.clerk/var-from-def true)}))))))
+                               :nextjournal/viewer (assoc v/html-viewer :var-from-def? true)}))))))
 
 
 (deftest resolve-aliases
@@ -183,4 +183,3 @@
                                                       :bundle? false
                                                       :out-path builder/default-out-path} test-doc)
                                    #"_data/.+\.png"))))))
-


### PR DESCRIPTION
* Fix showing viewer maps with ::clerk/var-from-def keys
* Use unqualified key `:var-from-def?` in viewer maps to opt-out of extracting values from defined vars
