### PR TITLE
Viewer class customization

### DIFF
--- a/notebooks/viewer_classes.clj
+++ b/notebooks/viewer_classes.clj
@@ -1,11 +1,11 @@
 (ns notebooks.viewer-classes
   {:nextjournal.clerk/visibility {:code :hide}
-   :nextjournal.clerk/class [:justify-center :bg-slate-200 :dark:bg-slate-900 :py-8 :min-h-screen]}
+   :nextjournal.clerk/css-class [:justify-center :bg-slate-200 :dark:bg-slate-900 :py-8 :min-h-screen]}
   (:require [nextjournal.clerk :as clerk]
             [clojure.string :as str]))
 
 (clerk/html
- {::clerk/class [:border :rounded-lg :shadow-lg :bg-white :p-4 :max-w-2xl :mx-auto]}
+ {::clerk/css-class [:border :rounded-lg :shadow-lg :bg-white :p-4 :max-w-2xl :mx-auto]}
  [:div
   (clerk/vl {:width 700 :height 400 :data {:url "https://vega.github.io/vega-datasets/data/us-10m.json"
                                            :format {:type "topojson" :feature "counties"}}
@@ -14,10 +14,9 @@
              :projection {:type "albersUsa"} :mark "geoshape" :encoding {:color {:field "rate" :type "quantitative"}}})])
 
 ^{::clerk/viewer clerk/table
-  ::clerk/class [:max-w-2xl :mx-auto :bg-white :p-4 :rounded-lg :shadow-lg :mt-4]}
+  ::clerk/css-class [:max-w-2xl :mx-auto :bg-white :p-4 :rounded-lg :shadow-lg :mt-4]}
 (def dataset
   (->> (slurp "/usr/share/dict/words")
        str/split-lines
        (group-by (comp keyword str/upper-case str first))
        (into (sorted-map))))
-

--- a/notebooks/viewer_classes.clj
+++ b/notebooks/viewer_classes.clj
@@ -5,7 +5,8 @@
             [clojure.string :as str]))
 
 (clerk/html
- {::clerk/css-class [:border :rounded-lg :shadow-lg :bg-white :p-4 :max-w-2xl :mx-auto]}
+ {::clerk/css-class [:border :rounded-lg :shadow-lg :bg-white :p-4 :max-w-2xl :mx-auto]
+  ::clerk/width :wide}
  [:div
   (clerk/vl {:width 700 :height 400 :data {:url "https://vega.github.io/vega-datasets/data/us-10m.json"
                                            :format {:type "topojson" :feature "counties"}}

--- a/notebooks/viewer_classes.clj
+++ b/notebooks/viewer_classes.clj
@@ -1,0 +1,16 @@
+(ns notebooks.viewer-classes
+  {:nextjournal.clerk/visibility {:code :hide}
+   :nextjournal.clerk/class "flex items-center justify-center bg-green-500 h-screen gap-4"}
+  (:require [nextjournal.clerk :as clerk]))
+
+^{::clerk/class "border-4 border-red-500 animate-bounce"}
+(clerk/html
+ [:div.bg-white {:class "w-[100px] h-[100px]"}])
+
+^{::clerk/class "border-4 border-blue-500 animate-bounce"}
+(clerk/html
+ [:div.bg-white {:class "w-[80px] h-[80px]"}])
+
+^{::clerk/class "border-4 border-yellow-500 animate-spin"}
+(clerk/html
+ [:div.bg-white {:class "w-[60px] h-[60px]"}])

--- a/notebooks/viewer_classes.clj
+++ b/notebooks/viewer_classes.clj
@@ -1,16 +1,23 @@
 (ns notebooks.viewer-classes
   {:nextjournal.clerk/visibility {:code :hide}
-   :nextjournal.clerk/class "flex items-center justify-center bg-green-500 h-screen gap-4"}
-  (:require [nextjournal.clerk :as clerk]))
+   :nextjournal.clerk/class [:justify-center :bg-slate-200 :dark:bg-slate-900 :py-8 :min-h-screen]}
+  (:require [nextjournal.clerk :as clerk]
+            [clojure.string :as str]))
 
-^{::clerk/class "border-4 border-red-500 animate-bounce"}
 (clerk/html
- [:div.bg-white {:class "w-[100px] h-[100px]"}])
+ {::clerk/class [:border :rounded-lg :shadow-lg :bg-white :p-4 :max-w-2xl :mx-auto]}
+ [:div
+  (clerk/vl {:width 700 :height 400 :data {:url "https://vega.github.io/vega-datasets/data/us-10m.json"
+                                           :format {:type "topojson" :feature "counties"}}
+             :transform [{:lookup "id" :from {:data {:url "https://vega.github.io/vega-datasets/data/unemployment.tsv"}
+                                              :key "id" :fields ["rate"]}}]
+             :projection {:type "albersUsa"} :mark "geoshape" :encoding {:color {:field "rate" :type "quantitative"}}})])
 
-^{::clerk/class "border-4 border-blue-500 animate-bounce"}
-(clerk/html
- [:div.bg-white {:class "w-[80px] h-[80px]"}])
+^{::clerk/viewer clerk/table
+  ::clerk/class [:max-w-2xl :mx-auto :bg-white :p-4 :rounded-lg :shadow-lg :mt-4]}
+(def dataset
+  (->> (slurp "/usr/share/dict/words")
+       str/split-lines
+       (group-by (comp keyword str/upper-case str first))
+       (into (sorted-map))))
 
-^{::clerk/class "border-4 border-yellow-500 animate-spin"}
-(clerk/html
- [:div.bg-white {:class "w-[60px] h-[60px]"}])

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-Sf8EiGPhctre4BshWqcNSoRVNit
+44xg5tTnwpwpyYEq8YGXBBAYHbp7

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-2R2rz95sNL7JMSv43yUNFDpxfrJq
+24Kcq9yradzYngN6mSkZur5YmTb1

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-NCUjoxuFKD2hv9nrvUFFRQ2Bmnj
+Sf8EiGPhctre4BshWqcNSoRVNit

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-44xg5tTnwpwpyYEq8YGXBBAYHbp7
+2R2rz95sNL7JMSv43yUNFDpxfrJq

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -292,7 +292,7 @@
          doc? (-> parser/add-block-visibility
                   parser/add-open-graph-metadata
                   parser/add-auto-expand-results
-                  parser/add-notebook-class))))))
+                  parser/add-css-class))))))
 
 #_(let [parsed (nextjournal.clerk.parser/parse-clojure-string "clojure.core/dec")]
     (build-graph (analyze-doc parsed)))

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -291,7 +291,8 @@
                        (-> doc :blocks count range))
          doc? (-> parser/add-block-visibility
                   parser/add-open-graph-metadata
-                  parser/add-auto-expand-results))))))
+                  parser/add-auto-expand-results
+                  parser/add-notebook-class))))))
 
 #_(let [parsed (nextjournal.clerk.parser/parse-clojure-string "clojure.core/dec")]
     (build-graph (analyze-doc parsed)))

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -154,7 +154,7 @@
                             (or (get-in blob->result [hash :nextjournal/value])
                                 (-> cas-hash ->cache-file fs/exists?)))
         opts-from-form-meta (-> (meta form)
-                                (select-keys [:nextjournal.clerk/viewer :nextjournal.clerk/viewers :nextjournal.clerk/width :nextjournal.clerk/opts])
+                                (select-keys [:nextjournal.clerk/viewer :nextjournal.clerk/viewers :nextjournal.clerk/class :nextjournal.clerk/width :nextjournal.clerk/opts])
                                 v/normalize-viewer-opts
                                 maybe-eval-viewers)]
     #_(prn :cached? (cond no-cache? :no-cache

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -154,7 +154,7 @@
                             (or (get-in blob->result [hash :nextjournal/value])
                                 (-> cas-hash ->cache-file fs/exists?)))
         opts-from-form-meta (-> (meta form)
-                                (select-keys [:nextjournal.clerk/viewer :nextjournal.clerk/viewers :nextjournal.clerk/class :nextjournal.clerk/width :nextjournal.clerk/opts])
+                                (select-keys [:nextjournal.clerk/viewer :nextjournal.clerk/viewers :nextjournal.clerk/css-class :nextjournal.clerk/width :nextjournal.clerk/opts])
                                 v/normalize-viewer-opts
                                 maybe-eval-viewers)]
     #_(prn :cached? (cond no-cache? :no-cache

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -125,6 +125,14 @@
                                            (when (ns? form) (some :nextjournal.clerk/auto-expand-results? form)))
                                          blocks)))
 
+(defn add-notebook-class [{:as doc :keys [blocks]}]
+  (prn :add-notebook-class (some (fn [{:keys [form]}]
+                                   (when (ns? form) (some :nextjournal.clerk/class form)))
+                                 blocks))
+  (assoc doc :class (some (fn [{:keys [form]}]
+                            (when (ns? form) (some :nextjournal.clerk/class form)))
+                          blocks)))
+
 #_(->doc-settings '^{:nextjournal.clerk/toc :boom} (ns foo)) ;; TODO: error
 
 (defn add-block-visibility [{:as analyzed-doc :keys [blocks]}]

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -125,13 +125,10 @@
                                            (when (ns? form) (some :nextjournal.clerk/auto-expand-results? form)))
                                          blocks)))
 
-(defn add-notebook-class [{:as doc :keys [blocks]}]
-  (prn :add-notebook-class (some (fn [{:keys [form]}]
-                                   (when (ns? form) (some :nextjournal.clerk/class form)))
-                                 blocks))
-  (assoc doc :class (some (fn [{:keys [form]}]
-                            (when (ns? form) (some :nextjournal.clerk/class form)))
-                          blocks)))
+(defn add-css-class [{:as doc :keys [blocks]}]
+  (assoc doc :css-class (some (fn [{:keys [form]}]
+                                (when (ns? form) (some :nextjournal.clerk/css-class form)))
+                              blocks)))
 
 #_(->doc-settings '^{:nextjournal.clerk/toc :boom} (ns foo)) ;; TODO: error
 

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -120,7 +120,7 @@
 
 (defonce !eval-counter (r/atom 0))
 
-(defn render-notebook [{:as _doc xs :blocks :keys [bundle? class toc toc-visibility]}]
+(defn render-notebook [{:as _doc xs :blocks :keys [bundle? css-class toc toc-visibility]}]
   (r/with-let [local-storage-key "clerk-navbar"
                !state (r/atom {:toc (toc-items (:children toc))
                                :md-toc toc
@@ -153,18 +153,18 @@
           [navbar/panel !state [navbar/navbar !state]]])
        [:div.flex-auto.h-screen.overflow-y-auto.scroll-container
         {:ref ref-fn}
-        [:div {:class (or class "flex flex-col items-center viewer-notebook flex-auto")}
+        [:div {:class (or css-class "flex flex-col items-center viewer-notebook flex-auto")}
          (doall
           (map-indexed (fn [idx x]
                          (let [{viewer-name :name} (viewer/->viewer x)
-                               viewer-class (viewer/class x)
+                               viewer-css-class (viewer/css-class x)
                                inner-viewer-name (some-> x viewer/->value viewer/->viewer :name)]
                            ^{:key (str idx "-" @!eval-counter)}
                            [:div {:class (concat
                                           [(when (:nextjournal/open-graph-image-capture (viewer/->value x)) "open-graph-image-capture")]
-                                          (if viewer-class
-                                            (cond-> viewer-class
-                                              (string? viewer-class) vector)
+                                          (if viewer-css-class
+                                            (cond-> viewer-css-class
+                                              (string? viewer-css-class) vector)
                                             ["viewer"
                                              (when viewer-name (str "viewer-" (name viewer-name)))
                                              (when inner-viewer-name (str "viewer-" (name inner-viewer-name)))

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -120,7 +120,7 @@
 
 (defonce !eval-counter (r/atom 0))
 
-(defn render-notebook [{:as _doc xs :blocks :keys [bundle? toc toc-visibility]}]
+(defn render-notebook [{:as _doc xs :blocks :keys [bundle? class toc toc-visibility]}]
   (r/with-let [local-storage-key "clerk-navbar"
                !state (r/atom {:toc (toc-items (:children toc))
                                :md-toc toc
@@ -153,20 +153,23 @@
           [navbar/panel !state [navbar/navbar !state]]])
        [:div.flex-auto.h-screen.overflow-y-auto.scroll-container
         {:ref ref-fn}
-        [:div.flex.flex-col.items-center.viewer-notebook.flex-auto
+        [:div {:class (or class "flex flex-col items-center viewer-notebook flex-auto")}
          (doall
           (map-indexed (fn [idx x]
                          (let [{viewer-name :name} (viewer/->viewer x)
+                               viewer-class (viewer/class x)
                                inner-viewer-name (some-> x viewer/->value viewer/->viewer :name)]
                            ^{:key (str idx "-" @!eval-counter)}
-                           [:div {:class ["viewer"
-                                          (when (:nextjournal/open-graph-image-capture (viewer/->value x)) "open-graph-image-capture")
-                                          (when viewer-name (str "viewer-" (name viewer-name)))
-                                          (when inner-viewer-name (str "viewer-" (name inner-viewer-name)))
-                                          (case (or (viewer/width x) (case viewer-name (:code :code-folded) :wide :prose))
-                                            :wide "w-full max-w-wide"
-                                            :full "w-full"
-                                            "w-full max-w-prose px-8")]}
+                           [:div {:class [(when (:nextjournal/open-graph-image-capture (viewer/->value x)) "open-graph-image-capture")
+                                          (when-not viewer-class "viewer")
+                                          (when (and (not viewer-class) viewer-name) (str "viewer-" (name viewer-name)))
+                                          (when (and (not viewer-class) inner-viewer-name) (str "viewer-" (name inner-viewer-name)))
+                                          viewer-class
+                                          (when-not viewer-class
+                                            (case (or (viewer/width x) (case viewer-name (:code :code-folded) :wide :prose))
+                                              :wide "w-full max-w-wide"
+                                              :full "w-full"
+                                              "w-full max-w-prose px-8"))]}
                             [inspect-presented x]]))
                        xs))]]])))
 

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -160,16 +160,18 @@
                                viewer-class (viewer/class x)
                                inner-viewer-name (some-> x viewer/->value viewer/->viewer :name)]
                            ^{:key (str idx "-" @!eval-counter)}
-                           [:div {:class [(when (:nextjournal/open-graph-image-capture (viewer/->value x)) "open-graph-image-capture")
-                                          (when-not viewer-class "viewer")
-                                          (when (and (not viewer-class) viewer-name) (str "viewer-" (name viewer-name)))
-                                          (when (and (not viewer-class) inner-viewer-name) (str "viewer-" (name inner-viewer-name)))
-                                          viewer-class
-                                          (when-not viewer-class
-                                            (case (or (viewer/width x) (case viewer-name (:code :code-folded) :wide :prose))
-                                              :wide "w-full max-w-wide"
-                                              :full "w-full"
-                                              "w-full max-w-prose px-8"))]}
+                           [:div {:class (concat
+                                          [(when (:nextjournal/open-graph-image-capture (viewer/->value x)) "open-graph-image-capture")]
+                                          (if viewer-class
+                                            (cond-> viewer-class
+                                              (string? viewer-class) vector)
+                                            ["viewer"
+                                             (when viewer-name (str "viewer-" (name viewer-name)))
+                                             (when inner-viewer-name (str "viewer-" (name inner-viewer-name)))
+                                             (case (or (viewer/width x) (case viewer-name (:code :code-folded) :wide :prose))
+                                               :wide "w-full max-w-wide"
+                                               :full "w-full"
+                                               "w-full max-w-prose px-8")]))}
                             [inspect-presented x]]))
                        xs))]]])))
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -148,6 +148,11 @@
   (when (wrapped-value? x)
     (:nextjournal/width x)))
 
+(defn class
+  "Returns the `:nextjournal/class` for a given wrapped value `x`, `nil` otherwise."
+  [x]
+  (when (wrapped-value? x)
+    (:nextjournal/class x)))
 
 (defn normalize-viewer-opts [opts]
   (when-not (map? opts)
@@ -155,7 +160,8 @@
   (set/rename-keys opts {:nextjournal.clerk/viewer :nextjournal/viewer
                          :nextjournal.clerk/viewers :nextjournal/viewers
                          :nextjournal.clerk/opts :nextjournal/opts
-                         :nextjournal.clerk/width :nextjournal/width}))
+                         :nextjournal.clerk/width :nextjournal/width
+                         :nextjournal.clerk/class :nextjournal/class}))
 
 (defn normalize-viewer [viewer]
   (cond (keyword? viewer) viewer
@@ -414,7 +420,7 @@
         presented-result (->> (present (ensure-wrapped-with-viewers (or viewers (get-viewers *ns*)) value))
                               #?(:clj (process-blobs blob-opts)))
         opts-from-form-meta (-> result
-                                (select-keys [:nextjournal/width :nextjournal/opts])
+                                (select-keys [:nextjournal/class :nextjournal/width :nextjournal/opts])
                                 (cond-> #_result
                                   (some? auto-expand-results?) (update :nextjournal/opts #(merge {:auto-expand-results? auto-expand-results?} %))))]
     (merge {:nextjournal/value (cond-> {:nextjournal/presented presented-result}
@@ -855,7 +861,7 @@
                                              (map (comp process-wrapped-value
                                                         apply-viewers*
                                                         (partial ensure-wrapped-with-viewers viewers))))))
-      (select-keys [:atom-var-name->state :auto-expand-results? :blocks :toc :toc-visibility :title :open-graph])
+      (select-keys [:atom-var-name->state :auto-expand-results? :blocks :class :toc :toc-visibility :title :open-graph])
       #?(:clj (cond-> ns (assoc :scope (datafy-scope ns))))))
 
 (def notebook-viewer
@@ -982,7 +988,7 @@
 #_(ensure-wrapped-with-viewers {:nextjournal/value 42 :nextjournal/viewers [:boo]})
 
 (defn ->opts [wrapped-value]
-  (select-keys wrapped-value [:nextjournal/width :nextjournal/opts :!budget :budget :path :current-path :offset]))
+  (select-keys wrapped-value [:nextjournal/class :nextjournal/width :nextjournal/opts :!budget :budget :path :current-path :offset]))
 
 (defn apply-viewers* [wrapped-value]
   (when (empty? (->viewers wrapped-value))
@@ -1078,7 +1084,7 @@
 
 (defn process-wrapped-value [wrapped-value]
   (-> wrapped-value
-      (select-keys [:nextjournal/viewer :nextjournal/value :nextjournal/width :nextjournal/content-type :nextjournal/opts :path :offset :n])
+      (select-keys [:nextjournal/viewer :nextjournal/value :nextjournal/class :nextjournal/width :nextjournal/content-type :nextjournal/opts :path :offset :n])
       (update :nextjournal/viewer process-viewer)))
 
 #_(process-wrapped-value (apply-viewers 42))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -148,11 +148,11 @@
   (when (wrapped-value? x)
     (:nextjournal/width x)))
 
-(defn class
-  "Returns the `:nextjournal/class` for a given wrapped value `x`, `nil` otherwise."
+(defn css-class
+  "Returns the `:nextjournal/css-class` for a given wrapped value `x`, `nil` otherwise."
   [x]
   (when (wrapped-value? x)
-    (:nextjournal/class x)))
+    (:nextjournal/css-class x)))
 
 (defn normalize-viewer-opts [opts]
   (when-not (map? opts)
@@ -161,7 +161,7 @@
                          :nextjournal.clerk/viewers :nextjournal/viewers
                          :nextjournal.clerk/opts :nextjournal/opts
                          :nextjournal.clerk/width :nextjournal/width
-                         :nextjournal.clerk/class :nextjournal/class}))
+                         :nextjournal.clerk/css-class :nextjournal/css-class}))
 
 (defn normalize-viewer [viewer]
   (cond (keyword? viewer) viewer
@@ -420,7 +420,7 @@
         presented-result (->> (present (ensure-wrapped-with-viewers (or viewers (get-viewers *ns*)) value))
                               #?(:clj (process-blobs blob-opts)))
         opts-from-form-meta (-> result
-                                (select-keys [:nextjournal/class :nextjournal/width :nextjournal/opts])
+                                (select-keys [:nextjournal/css-class :nextjournal/width :nextjournal/opts])
                                 (cond-> #_result
                                   (some? auto-expand-results?) (update :nextjournal/opts #(merge {:auto-expand-results? auto-expand-results?} %))))]
     (merge {:nextjournal/value (cond-> {:nextjournal/presented presented-result}
@@ -861,7 +861,7 @@
                                              (map (comp process-wrapped-value
                                                         apply-viewers*
                                                         (partial ensure-wrapped-with-viewers viewers))))))
-      (select-keys [:atom-var-name->state :auto-expand-results? :blocks :class :toc :toc-visibility :title :open-graph])
+      (select-keys [:atom-var-name->state :auto-expand-results? :blocks :css-class :toc :toc-visibility :title :open-graph])
       #?(:clj (cond-> ns (assoc :scope (datafy-scope ns))))))
 
 (def notebook-viewer
@@ -988,7 +988,7 @@
 #_(ensure-wrapped-with-viewers {:nextjournal/value 42 :nextjournal/viewers [:boo]})
 
 (defn ->opts [wrapped-value]
-  (select-keys wrapped-value [:nextjournal/class :nextjournal/width :nextjournal/opts :!budget :budget :path :current-path :offset]))
+  (select-keys wrapped-value [:nextjournal/css-class :nextjournal/width :nextjournal/opts :!budget :budget :path :current-path :offset]))
 
 (defn apply-viewers* [wrapped-value]
   (when (empty? (->viewers wrapped-value))
@@ -1084,7 +1084,7 @@
 
 (defn process-wrapped-value [wrapped-value]
   (-> wrapped-value
-      (select-keys [:nextjournal/viewer :nextjournal/value :nextjournal/class :nextjournal/width :nextjournal/content-type :nextjournal/opts :path :offset :n])
+      (select-keys [:nextjournal/viewer :nextjournal/value :nextjournal/css-class :nextjournal/width :nextjournal/content-type :nextjournal/opts :path :offset :n])
       (update :nextjournal/viewer process-viewer)))
 
 #_(process-wrapped-value (apply-viewers 42))


### PR DESCRIPTION
This is a first draft for providing custom classes to viewers and the notebook viewer which should allow for most use cases and does not require actually overriding the base styles. Once a `:nextjournal.clerk/css-class` is available on the viewer or in document settings, the available class will be used and no further viewer classes will be assigned.

Here are a few simple class-based customizations:

https://user-images.githubusercontent.com/1944/203326797-9cbb5a19-5823-42f9-8cc6-c64a80e0d203.mp4

<img width="1392" alt="CleanShot 2022-11-22 at 16 12 49@2x" src="https://user-images.githubusercontent.com/1944/203350367-873f5bcb-9bb5-4f18-bbbb-446ce05fe6c5.png">
