### PR TITLE
Fix Syntax Highlighting

### DIFF
--- a/notebooks/viewer_api.clj
+++ b/notebooks/viewer_api.clj
@@ -35,6 +35,13 @@
 ;; The TeX viewer is built on [KaTeX](https://katex.org/).
 (clerk/tex "f^{\\circ n} = \\underbrace{f \\circ f \\circ \\cdots \\circ f}_{n\\text{ times}}.\\,")
 
+(clerk/tex "
+\\begin{alignedat}{2}
+  \\nabla\\cdot\\vec{E} = \\frac{\\rho}{\\varepsilon_0} & \\qquad \\text{Gauss' Law} \\\\
+  \\nabla\\cdot\\vec{B} = 0 & \\qquad \\text{Gauss' Law ($\\vec{B}$ Fields)} \\\\
+  \\nabla\\times\\vec{E} = -\\frac{\\partial \\vec{B}}{\\partial t} & \\qquad \\text{Faraday's Law} \\\\
+  \\nabla\\times\\vec{B} = \\mu_0\\vec{J}+\\mu_0\\varepsilon_0\\frac{\\partial\\vec{E}}{\\partial t} & \\qquad \\text{Ampere's Law}
+\\end{alignedat}")
 
 ;; ### 📊 Plotly
 (clerk/plotly {:data [{:z [[1 2 3] [3 2 1]] :type "surface"}]})

--- a/notebooks/viewers/code.clj
+++ b/notebooks/viewers/code.clj
@@ -9,6 +9,30 @@
 ;; Code as string
 (clerk/code "(def fib (lazy-cat [0 1] (map + fib (rest fib))))")
 
+;; Stings with line-breaks and whitespace
+(def s
+  "0000
+   0000
+
+   1111
+   1111")
+
+(def ex
+  (identity "1000
+2000
+3000
+
+4000
+
+5000
+6000
+
+7000
+8000
+9000
+
+10000"))
+
 ;; Editable code viewer
 (clerk/with-viewer
   '(fn [code-str _] [:div.viewer-code [nextjournal.clerk.render.code/editor (reagent/atom code-str)]])

--- a/notebooks/viewers/code.clj
+++ b/notebooks/viewers/code.clj
@@ -10,12 +10,6 @@
 (clerk/code "(def fib (lazy-cat [0 1] (map + fib (rest fib))))")
 
 ;; Stings with line-breaks and whitespace
-(def s
-  "0000
-   0000
-
-   1111
-   1111")
 
 (def ex
   (identity "1000

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-g7zwxva1P7Fk4wua7NvfD7ZB12H
+gztfnRQmo5qZxxoDoZHESyC61EQ

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-gztfnRQmo5qZxxoDoZHESyC61EQ
+mtXbCthGfVFTBZAoKt3XmVLZ3ND

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-3VvEA5GcoGB5Yn7DcCxUwtHtBQUh
+g7zwxva1P7Fk4wua7NvfD7ZB12H

--- a/src/nextjournal/clerk/render/code.cljs
+++ b/src/nextjournal/clerk/render/code.cljs
@@ -54,11 +54,10 @@
             (cons {:from from :to to :val val}
                   (lazy-seq (step))))))))))
 
-(defn style-markup [text style]
-  (j/let [^js {:keys [tagName class]} style]
-    [(keyword (apply str tagName (when class
-                                   (cons "." (interpose "." (str/split class #" "))))))
-     text]))
+(j/defn style->hiccup-tag [^js {:keys [tagName class]}]
+  (keyword (apply str tagName
+                  (when class
+                    (cons "." (interpose "." (str/split class #" ")))))))
 
 (j/defn intersects? [^js {:keys [from to]} range]
   (or
@@ -79,10 +78,10 @@
             (loop [pos from
                    lds (filter (partial intersects? line) (rangeset-seq decos))
                    buf ()]
-              (if-some [{:as d start :from end :to style :val} (first lds)]
+              (if-some [{start :from end :to style :val} (first lds)]
                 (recur end
                        (next lds)
-                       (concat buf (cond-> (list (style-markup (.sliceString text (max from start) (min to end)) style))
+                       (concat buf (cond-> (list [(style->hiccup-tag style) (.sliceString text (max from start) (min to end))])
                                      (< pos start)
                                      (conj (.sliceString text pos start)))))
                 (cond-> buf

--- a/src/nextjournal/clerk/render/code.cljs
+++ b/src/nextjournal/clerk/render/code.cljs
@@ -88,7 +88,6 @@
                   (< pos to)
                   (concat [(.sliceString text pos to)]))))))))
 
-
 (defn render-code [^String code]
   (let [builder (RangeSetBuilder.)
         _ (highlightTree (.. clojureLanguage -parser (parse code)) highlight-style

--- a/src/nextjournal/clerk/render/code.cljs
+++ b/src/nextjournal/clerk/render/code.cljs
@@ -54,32 +54,40 @@
             (cons {:from from :to to :val val}
                   (lazy-seq (step))))))))))
 
-(defn style-markup [^js text {:keys [from to val]}]
-  (j/let [^js {:keys [tagName class]} val]
+(defn style-markup [text style]
+  (j/let [^js {:keys [tagName class]} style]
     [(keyword (apply str tagName (when class
                                    (cons "." (interpose "." (str/split class #" "))))))
-     (.sliceString text from to)]))
+     text]))
+
+(j/defn intersects? [^js {:keys [from to]} range]
+  (or
+   (and (<= from (:from range)) (< (:from range) to))
+   (and (< from (:to range)) (<= (:to range) to))
+   (and (<= (:from range) from) (<= to (:to range)))))
 
 (defn style-line [decos ^js text i]
-  (j/let [^js {:keys [from to]} (.line text i)]
+  (j/let [^js {:as line :keys [from to length]} (.line text i)]
     ;; NOTE: these styles are partially overlapping with those for the `.viewer-code` container
     ;; but are needed to fix rendered code _outside_ of it. e.g. in Clerk results
     (into [:div.cm-line {:style {:padding "0"
                                  :line-height "1.6"
                                  :font-size "15px"
                                  :font-family "\"Fira Mono\", monospace"}}]
-          (loop [pos from
-                 lds (take-while #(<= (:to %) to) (rangeset-seq decos from))
-                 buf ()]
-            (if-some [{:as d start :from end :to} (first lds)]
-              (recur end
-                     (next lds)
-                     (concat buf (cond-> (list (style-markup text d))
-                                   (< pos start)
-                                   (conj (.sliceString text pos start)))))
-              (cond-> buf
-                (< pos to)
-                (concat [(.sliceString text pos to)])))))))
+          (if (zero? length)
+            "\n"
+            (loop [pos from
+                   lds (filter (partial intersects? line) (rangeset-seq decos))
+                   buf ()]
+              (if-some [{:as d start :from end :to style :val} (first lds)]
+                (recur end
+                       (next lds)
+                       (concat buf (cond-> (list (style-markup (.sliceString text (max from start) (min to end)) style))
+                                     (< pos start)
+                                     (conj (.sliceString text pos start)))))
+                (cond-> buf
+                  (< pos to)
+                  (concat [(.sliceString text pos to)]))))))))
 
 
 (defn render-code [^String code]


### PR DESCRIPTION
Fixes an issue with codemirror syntax highlighting which prevented multi-line strings to be displayed correctly.

Fixes #306. Regression introduced with #275.