### PR TITLE
Swap out unicode ellipsis for ...

### DIFF
--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1381,7 +1381,7 @@
   [desc]
   (let [x (->value desc)
         viewer-name (-> desc ->viewer :name)]
-    (cond (= viewer-name :elision) (with-meta '… x)
+    (cond (= viewer-name :elision) (with-meta '... x)
           (coll? x) (into (case viewer-name
                             ;; TODO: fix table viewer
                             (:map :table) {}


### PR DESCRIPTION
The unicode ellipsis is not a valid js character. If I do an `:advanced` build with

```
:pseudo-names true
:pretty-print true
```
The resulting JS fails to load, and I see

![image](https://user-images.githubusercontent.com/69635/206751159-183920b3-1071-45c6-8194-9212c68c3116.png)

in the console. Making this change fixes the error.