### PR TITLE
Enable linting with clj-kondo in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
           bb: latest
           clj-kondo: latest
 
-      - name: Run Playwright tests against static assets
+      - name: Run clj-kondo linter
         run: |
           bb lint
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,8 @@ jobs:
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: '1.10.3.943'
-
-      - name: Setup Babashka
-        uses: turtlequeue/setup-babashka@v1.5.0
-        with:
-          babashka-version: 0.9.162
+          bb: latest
+          clj-kondo: latest
 
       - name: Show branch name
         run: |
@@ -48,6 +45,22 @@ jobs:
 
       - name: Build and upload viewer resources
         run: bb build+upload-viewer-resources
+
+  clj-kondo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: 🔧 Install clojure
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          bb: latest
+          clj-kondo: latest
+
+      - name: Run Playwright tests against static assets
+        run: |
+          bb lint
+
 
   test:
     runs-on: ${{matrix.sys.os}}
@@ -75,11 +88,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: '1.10.3.943'
-
-      - name: Setup Babashka
-        uses: turtlequeue/setup-babashka@v1.5.0
-        with:
-          babashka-version: 0.9.162
+          bb: latest
 
       - name: 🗝 maven cache
         uses: actions/cache@v2
@@ -112,11 +121,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: '1.10.3.943'
-
-      - name: Setup Babashka
-        uses: turtlequeue/setup-babashka@v1.5.0
-        with:
-          babashka-version: 0.9.162
+          bb: latest
 
       - name: 🗝 maven cache
         uses: actions/cache@v2
@@ -167,10 +172,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Babashka
-        uses: turtlequeue/setup-babashka@v1.5.0
+      - name: 🔧 Install clojure
+        uses: DeLaGuardo/setup-clojure@master
         with:
-          babashka-version: 0.9.162
+          bb: latest
 
       - name: Run Playwright tests against static assets
         run: |
@@ -185,10 +190,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Babashka
-        uses: turtlequeue/setup-babashka@v1.5.0
+      - name: 🔧 Install clojure
+        uses: DeLaGuardo/setup-clojure@master
         with:
-          babashka-version: 0.9.162
+          bb: latest
 
       - name: 🗝 maven cache
         uses: actions/cache@v2

--- a/bb.edn
+++ b/bb.edn
@@ -32,6 +32,9 @@
   build+upload-viewer-resources {:doc "Refreshes assets stored on CDN (google storage)"
                                  :task viewer-resources-hashing/build+upload-viewer-resources}
 
+  lint {:doc "Lints project using clj-kondo"
+        :task (shell "clj-kondo --lint src test")}
+
   release:js {:doc "Uploads the js release and updates the sha reference."
               :task (clojure "-T:build upload-to-cas :resource viewer.js")
               :depends [build:js]}

--- a/bb.edn
+++ b/bb.edn
@@ -33,7 +33,7 @@
                                  :task viewer-resources-hashing/build+upload-viewer-resources}
 
   lint {:doc "Lints project using clj-kondo"
-        :task (shell "clj-kondo --lint src test")}
+        :task (apply shell "clj-kondo --lint src test" *command-line-args*)}
 
   release:js {:doc "Uploads the js release and updates the sha reference."
               :task (clojure "-T:build upload-to-cas :resource viewer.js")

--- a/bb.edn
+++ b/bb.edn
@@ -42,6 +42,11 @@
   build:static-app {:doc "Builds a static app with default notebooks"
                     :task (apply clojure "-X:demo:nextjournal/clerk" *command-line-args*)}
 
+  -check {:depends [lint test:clj]}
+
+  check {:doc "Check to run before pushing"
+         :task (run '-check {:parallel true})}
+
   test:clj {:doc "Run clojure tests"
             :task (apply clojure "-X:test" *command-line-args*)}
 

--- a/resources/viewer-js-hash
+++ b/resources/viewer-js-hash
@@ -1,1 +1,1 @@
-3Qs9ZBmvbjPraB85aPjfHxDepJcz
+2cR9jYQN7XCvgXBtLsivJ5hzhgEN

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1377,6 +1377,7 @@
   (present {:viewers [{:pred sequential? :render-fn pr-str}]} (range 100))
   (present (map vector (range)))
   (present (subs (slurp "/usr/share/dict/words") 0 1000))
+  #_:clj-kondo/ignore ;; remove when clj-kondo is released
   (present (plotly {:data [{:z [[1 2 3] [3 2 1]] :type "surface"}]}))
   (present [(with-viewer :html [:h1 "hi"])])
   (present (with-viewer :html [:ul (for [x (range 3)] [:li x])]))
@@ -1447,7 +1448,7 @@
 
 (defn reset-viewers!
   ([viewers] (reset-viewers! *ns* viewers))
-  ([scope viewers]
+  ([scope viewers] #_:clj-kondo/ignore ;; remove when clj-kondo is released
    (assert (or (#{:default} scope)
                #?(:clj (instance? clojure.lang.Namespace scope))))
    (swap! !viewers assoc scope viewers)))


### PR DESCRIPTION
db645285fa3368421c46f73375e4e6d85b40d97d should be reverted once clj-kondo is released with https://github.com/clj-kondo/clj-kondo/commit/4a164c1605987c67b32665da31aa3a562b3d0007 and https://github.com/clj-kondo/clj-kondo/commit/27007bad6a06ee6e0edda0d213cb73b9d74eea7f.