### PR TITLE
Fix uberjar usage

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -4,7 +4,7 @@
    [clojure.string :as str]
    [clojure.tools.build.api :as b]
    [nextjournal.cas :as cas]
-   [nextjournal.clerk.render.hashing :refer [get-lookup-url]]
+   [nextjournal.clerk.render.hashing]
    [shared]))
 
 (def lib 'io.github.nextjournal/clerk)
@@ -16,9 +16,11 @@
 (def version (shared/version))
 (def jar-file (format "target/%s-%s.jar" (name lib) version))
 
-(defn package-asset-map [_]
-  (let [asset-map (slurp (get-lookup-url))]
-    (spit "target/classes/clerk-asset-map.edn" asset-map)))
+(defn package-clerk-asset-map [{:as opts :keys [target-dir]}]
+  (when-not target-dir
+    (throw (ex-info "target dir must be set" {:opts opts})))
+  (let [asset-map (slurp (nextjournal.clerk.render.hashing/get-lookup-url))]
+    (spit (str target-dir java.io.File/separator "clerk-asset-map.edn") asset-map)))
 
 (defn jar [_]
   (b/delete {:path "target"})
@@ -35,7 +37,7 @@
   (b/copy-dir {:src-dirs ["src" "resources"]
                :target-dir class-dir
                :replace {}})
-  (package-asset-map {})
+  (package-clerk-asset-map {:target-dir class-dir})
   (b/jar {:class-dir class-dir
           :jar-file jar-file}))
 

--- a/build.clj
+++ b/build.clj
@@ -4,7 +4,7 @@
    [clojure.string :as str]
    [clojure.tools.build.api :as b]
    [nextjournal.cas :as cas]
-   [nextjournal.clerk.render.hashing :refer [lookup-url]]
+   [nextjournal.clerk.render.hashing :refer [get-lookup-url]]
    [shared]))
 
 (def lib 'io.github.nextjournal/clerk)
@@ -17,7 +17,7 @@
 (def jar-file (format "target/%s-%s.jar" (name lib) version))
 
 (defn package-asset-map [_]
-  (let [asset-map (slurp lookup-url)]
+  (let [asset-map (slurp (get-lookup-url))]
     (spit "target/classes/clerk-asset-map.edn" asset-map)))
 
 (defn jar [_]

--- a/src/nextjournal/clerk/render/hashing.clj
+++ b/src/nextjournal/clerk/render/hashing.clj
@@ -26,6 +26,8 @@
                                         "yarn.lock"])
            (djv/cljs-files (mapv #(fs/file base-dir %) ["src" "resources"]))]))
 
+
+#_(file-set (fs/file "."))
 #_(System/setProperty "nextjournal.dejavu.debug" "1")
 
 (defn front-end-hash []
@@ -47,7 +49,7 @@
 (defn get-lookup-url []
   (str storage-base-url "/lookup/" (front-end-hash)))
 
-#_(lookup-url)
+#_(get-lookup-url)
 
 (defn read-dynamic-asset-map!
   "Computes a hash for Clerk's cljs bundle and tries to load the asset manifest for it.


### PR DESCRIPTION
Fixes an error when Clerk is part of an uberjar because the `render.hashing` assumed it was being consumed as a git dep.

When packaging Clerk as an uberjar, you need the following `build.clj` task as part of your build:
```clojure
(defn package-clerk-asset-map [{:as opts :keys [target-dir]}]
  (when-not target-dir
    (throw (ex-info "target dir must be set" {:opts opts})))
  (let [asset-map (slurp (nextjournal.clerk.render.hashing/get-lookup-url))]
    (spit (str target-dir java.io.File/separator "clerk-asset-map.edn") asset-map)))
```

Closes #351.