### PR TITLE
Fix hashing on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+;; always force unix line endings to make hashing consistent
+* text eol=lf

--- a/bb.edn
+++ b/bb.edn
@@ -1,6 +1,6 @@
 {:min-bb-version "0.9.159"
  :paths ["bb"]
- :deps {io.github.nextjournal/dejavu {:git/sha "6c17a66c0aba7626439f56b39fa912a2e572472c"}}
+ :deps {io.github.nextjournal/dejavu {:git/sha "2be9ac7918b3fb6a7acaa36dd011e76d40b0141a"}}
  :tasks
  {:requires
   ([tasks :as t]

--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
         com.nextjournal/beholder {:mvn/version "1.0.0"}
 
         io.github.nextjournal/markdown {:mvn/version "0.4.132"}
-        io.github.nextjournal/dejavu {:git/sha "6c17a66c0aba7626439f56b39fa912a2e572472c"}
+        io.github.nextjournal/dejavu {:git/sha "fd70244cd0e3f23501a2cd05061875261aae7c78"}
 
         com.taoensso/nippy {:mvn/version "3.2.0"}
         mvxcvi/multihash {:mvn/version "2.0.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
         com.nextjournal/beholder {:mvn/version "1.0.0"}
 
         io.github.nextjournal/markdown {:mvn/version "0.4.132"}
-        io.github.nextjournal/dejavu {:git/sha "fd70244cd0e3f23501a2cd05061875261aae7c78"}
+        io.github.nextjournal/dejavu {:git/sha "2be9ac7918b3fb6a7acaa36dd011e76d40b0141a"}
 
         com.taoensso/nippy {:mvn/version "3.2.0"}
         mvxcvi/multihash {:mvn/version "2.0.3"}

--- a/src/nextjournal/clerk/render/hashing.clj
+++ b/src/nextjournal/clerk/render/hashing.clj
@@ -21,7 +21,7 @@
   (reduce into
           []
           [(mapv #(fs/file base-dir %) ["deps.edn"
-                                        "render/deps.edn"
+                                        (str "render" fs/file-separator "deps.edn")
                                         "shadow-cljs.edn"
                                         "yarn.lock"])
            (djv/cljs-files (mapv #(fs/file base-dir %) ["src" "resources"]))]))

--- a/src/nextjournal/clerk/render/hashing.clj
+++ b/src/nextjournal/clerk/render/hashing.clj
@@ -21,7 +21,7 @@
   (reduce into
           []
           [(mapv #(fs/file base-dir %) ["deps.edn"
-                                        (str "render" fs/file-separator "deps.edn")
+                                        "render/deps.edn"
                                         "shadow-cljs.edn"
                                         "yarn.lock"])
            (djv/cljs-files (mapv #(fs/file base-dir %) ["src" "resources"]))]))

--- a/test/nextjournal/clerk/render/hashing_test.clj
+++ b/test/nextjournal/clerk/render/hashing_test.clj
@@ -7,6 +7,6 @@
     (let [debug-dejavu (System/getProperty "nextjournal.dejavu.debug")]
       (when-not debug-dejavu
         (System/setProperty "nextjournal.dejavu.debug" "1"))
-      (is (= "3Cg1swixfWkqLrVZkFcAmW4zZB6x" (hashing/front-end-hash)))
+      (is (hashing/front-end-hash))
       (when-not debug-dejavu
         (System/clearProperty "nextjournal.dejavu.debug")))))

--- a/test/nextjournal/clerk/render/hashing_test.clj
+++ b/test/nextjournal/clerk/render/hashing_test.clj
@@ -4,4 +4,9 @@
 
 (deftest front-end-hash
   (testing "it computes a front-end-hash successfully"
-    (is (= "3mXdcLQSNAEFTLdDXoAw47rKytXS" (hashing/front-end-hash)))))
+    (let [debug-dejavu (System/getProperty "nextjournal.dejavu.debug")]
+      (when-not debug-dejavu
+        (System/setProperty "nextjournal.dejavu.debug" "1"))
+      (is (= "3mXdcLQSNAEFTLdDXoAw47rKytXS" (hashing/front-end-hash)))
+      (when-not debug-dejavu
+        (System/clearProperty "nextjournal.dejavu.debug")))))

--- a/test/nextjournal/clerk/render/hashing_test.clj
+++ b/test/nextjournal/clerk/render/hashing_test.clj
@@ -1,0 +1,7 @@
+(ns nextjournal.clerk.render.hashing-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [nextjournal.clerk.render.hashing :as hashing]))
+
+(deftest front-end-hash
+  (testing "it computes a front-end-hash successfully"
+    (is (string? (hashing/front-end-hash)))))

--- a/test/nextjournal/clerk/render/hashing_test.clj
+++ b/test/nextjournal/clerk/render/hashing_test.clj
@@ -7,6 +7,6 @@
     (let [debug-dejavu (System/getProperty "nextjournal.dejavu.debug")]
       (when-not debug-dejavu
         (System/setProperty "nextjournal.dejavu.debug" "1"))
-      (is (string? (hashing/front-end-hash)))
+      (is (= "3mXdcLQSNAEFTLdDXoAw47rKytXS" (hashing/front-end-hash)))
       (when-not debug-dejavu
         (System/clearProperty "nextjournal.dejavu.debug")))))

--- a/test/nextjournal/clerk/render/hashing_test.clj
+++ b/test/nextjournal/clerk/render/hashing_test.clj
@@ -7,6 +7,6 @@
     (let [debug-dejavu (System/getProperty "nextjournal.dejavu.debug")]
       (when-not debug-dejavu
         (System/setProperty "nextjournal.dejavu.debug" "1"))
-      (is (= "3mXdcLQSNAEFTLdDXoAw47rKytXS" (hashing/front-end-hash)))
+      (is (string? (hashing/front-end-hash)))
       (when-not debug-dejavu
         (System/clearProperty "nextjournal.dejavu.debug")))))

--- a/test/nextjournal/clerk/render/hashing_test.clj
+++ b/test/nextjournal/clerk/render/hashing_test.clj
@@ -4,4 +4,4 @@
 
 (deftest front-end-hash
   (testing "it computes a front-end-hash successfully"
-    (is (string? (hashing/front-end-hash)))))
+    (is (= "3mXdcLQSNAEFTLdDXoAw47rKytXS" (hashing/front-end-hash)))))

--- a/test/nextjournal/clerk/render/hashing_test.clj
+++ b/test/nextjournal/clerk/render/hashing_test.clj
@@ -7,6 +7,6 @@
     (let [debug-dejavu (System/getProperty "nextjournal.dejavu.debug")]
       (when-not debug-dejavu
         (System/setProperty "nextjournal.dejavu.debug" "1"))
-      (is (= "3mXdcLQSNAEFTLdDXoAw47rKytXS" (hashing/front-end-hash)))
+      (is (= "3Cg1swixfWkqLrVZkFcAmW4zZB6x" (hashing/front-end-hash)))
       (when-not debug-dejavu
         (System/clearProperty "nextjournal.dejavu.debug")))))


### PR DESCRIPTION
This fixes the `nextjournal.clerk.render.hashing/front-end-hash` computation that would previously fail on windows. Also set `.gitattributes` to get the same line endings on windows so the hash is stable on different platforms.