### PR TITLE
Add emoji-regex

### DIFF
--- a/render/deps.cljs
+++ b/render/deps.cljs
@@ -14,6 +14,7 @@
             "@nextjournal/lang-clojure" "1.0.0"
             "@nextjournal/lezer-clojure" "1.0.0"
             "d3-require" "^1.2.4"
+            "emoji-regex" "10.2.1"
             "framer-motion" "7.6.19"
             "katex" "^0.12.0"
             "react" "18.2.0"


### PR DESCRIPTION
Without this I get

```
found 0 vulnerabilities
[:clerk] Compiling ...
The required JS dependency "emoji-regex" is not available, it was required by "nextjournal/clerk/render/navbar.cljs".

Dependency Trace:
	nextjournal/clerk/static_app.cljs
	nextjournal/clerk/render.cljs
	nextjournal/clerk/render/navbar.cljs

Searched for npm packages in:
	/Users/sritchie/code/clj/mathbox.cljs/node_modules
```