### PR TITLE
Make `build-graph` recur until all transitive deps are analyzed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,9 @@ notebooks/scratch*
 /target/
 .idea/
 clerk.iml
-public/girouette.css
-public/images/
+/public/girouette.css
+/public/images/
+/test/nextjournal/clerk/fixtures/
 *~
 .work
 /build

--- a/deps.edn
+++ b/deps.edn
@@ -55,6 +55,15 @@
                   :jvm-opts ["-Dclerk.resource_manifest={\"/js/viewer.js\" \"/js/viewer.js\"}"]
                   :exec-fn kaocha.runner/exec-fn}
 
+           :cognitest {:extra-paths ["test"]
+                       :extra-deps {nubank/matcher-combinators {:mvn/version "3.5.1"}
+                                    org.clojure/test.check {:mvn/version "1.1.1"}
+                                    io.github.cognitect-labs/test-runner
+                                    {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       :jvm-opts ["-Dclerk.resource_manifest={\"/js/viewer.js\" \"/js/viewer.js\"}"]
+                       :main-opts ["-m" "cognitect.test-runner"]
+                       :exec-fn cognitect.test-runner.api/test}
+
            :demo {:extra-deps {com.github.seancorfield/next.jdbc {:mvn/version "1.2.659"}
                                org.xerial/sqlite-jdbc {:mvn/version "3.34.0"}
                                org.clojure/data.csv {:mvn/version "1.0.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         org.clojure/java.classpath {:mvn/version "1.0.0"}
         org.clojure/tools.analyzer {:mvn/version "1.1.0"}
         org.clojure/tools.analyzer.jvm {:mvn/version "1.1.0"}
-        babashka/fs {:mvn/version "0.1.11"}
+        babashka/fs {:mvn/version "0.2.14"}
         borkdude/edamame {:mvn/version "1.0.0"}
         weavejester/dependency {:mvn/version "0.2.1"}
         com.nextjournal/beholder {:mvn/version "1.0.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -50,19 +50,15 @@
 
            :test {:extra-deps {nubank/matcher-combinators {:mvn/version "3.5.1"}
                                org.clojure/test.check {:mvn/version "1.1.1"}
-                               lambdaisland/kaocha {:mvn/version "1.66.1034"}}
+                               lambdaisland/kaocha {:mvn/version "1.66.1034"}
+                               io.github.cognitect-labs/test-runner
+                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
                   :extra-paths ["test"]
                   :jvm-opts ["-Dclerk.resource_manifest={\"/js/viewer.js\" \"/js/viewer.js\"}"]
-                  :exec-fn kaocha.runner/exec-fn}
-
-           :cognitest {:extra-paths ["test"]
-                       :extra-deps {nubank/matcher-combinators {:mvn/version "3.5.1"}
-                                    org.clojure/test.check {:mvn/version "1.1.1"}
-                                    io.github.cognitect-labs/test-runner
-                                    {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-                       :jvm-opts ["-Dclerk.resource_manifest={\"/js/viewer.js\" \"/js/viewer.js\"}"]
-                       :main-opts ["-m" "cognitect.test-runner"]
-                       :exec-fn cognitect.test-runner.api/test}
+                  :exec-fn kaocha.runner/exec-fn
+                  ;; Run a single test:
+                  ;; clj -M:test -v nextjournal.clerk.analyzer-test/analyze-doc
+                  :main-opts ["-m" "cognitect.test-runner"]}
 
            :demo {:extra-deps {com.github.seancorfield/next.jdbc {:mvn/version "1.2.659"}
                                org.xerial/sqlite-jdbc {:mvn/version "3.34.0"}

--- a/notebooks/viewers/custom_markdown.clj
+++ b/notebooks/viewers/custom_markdown.clj
@@ -20,7 +20,7 @@
    {:name :nextjournal.markdown/ruler
     :transform-fn (constantly
                    (v/html [:div {:style {:width "100%" :height "80px" :background-position "center" :background-size "cover"
-                                          :background-image "url(https://www.maxpixel.net/static/photo/1x/Ornamental-Separator-Decorative-Line-Art-Divider-4715969.png)"}}]))}])
+                                          :background-image "url(https://cdn.pixabay.com/photo/2019/12/24/04/49/divider-4715969_960_720.png)"}}]))}])
 
 (def viewers-with-pretty-markdown
   (v/update-viewers (v/get-default-viewers) {(comp #{:markdown} :name)

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -484,6 +484,7 @@
   * the form of an anonymous expression"
   ([]
    (swap! webserver/!doc dissoc :blob->result)
+   (reset! analyzer/!file->analysis-cache {})
    (if (fs/exists? config/cache-dir)
      (do (fs/delete-tree config/cache-dir)
          (prn :cache-dir/deleted config/cache-dir))

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -380,8 +380,9 @@
 
 #_(unhashed-deps {#'elements/fix-case {:deps #{#'rewrite-clj.node/tag}}})
 
-(defn ns->path [ns]
-  (str/replace (namespace-munge ns) "." fs/file-separator))
+(defn ns->path
+  ([ns] (ns->path fs/file-separator ns))
+  ([separator ns] (str/replace (namespace-munge ns) "." separator)))
 
 (defn ns->file [ns]
   (some (fn [dir]
@@ -393,7 +394,7 @@
         (cp/classpath-directories)))
 
 (defn ns->jar [ns]
-  (let [path (ns->path ns)]
+  (let [path (ns->path "/" ns)]
     (some #(when (or (.getJarEntry % (str path ".clj"))
                      (.getJarEntry % (str path ".cljc")))
              (.getName %))

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -473,7 +473,9 @@
       (prn :build-graph counter :analyzed-file-set analyzed-file-set)
       (if (and (seq loc->syms) (< counter 10))
         (recur (-> (reduce (fn [g [source symbols]]
-                             (prn :source source)
+                             (prn :source source :symbols symbols :ana (when (or (nil? source)
+                                                                                 (str/ends-with? source ".jar"))
+                                                                         (if source (hash-jar source) {})))
                              (if (or (nil? source)
                                      (str/ends-with? source ".jar"))
                                (update g :->analysis-info merge (into {} (map (juxt identity (constantly (if source (hash-jar source) {})))) symbols))

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -178,10 +178,6 @@
       (seq vars) (assoc :vars vars)
       var (assoc :var var))))
 
-#_(into #{} (map type) (:deps (analyze
-                               '(defprotocol MyProtocol
-                                  (-check [_])))))
-
 #_(:vars (analyze '(do (def a 41) (def b (inc a)))))
 #_(:vars (analyze '(defrecord Node [v l r])))
 #_(analyze '(defn foo [s] (str/includes? (p/parse-string-all s) "hi")))

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -289,7 +289,7 @@
    (binding [*ns* *ns*]
      (let [!id->count (atom {})]
        (cond-> (reduce (fn [{:as state notebook-ns :ns} i]
-                         (let [{:as block :keys [type text loc]} (get-in state [:blocks i])]
+                         (let [{:as block :keys [type text loc]} (get-in doc [:blocks i])]
                            (if (not= type :code)
                              state
                              (let [form (try (read-string text)

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -361,8 +361,9 @@
             (or (when-let [{:as cached-analysis :keys [file-sha]} (@!file->analysis-cache file)]
                   (when (= file-sha current-file-sha)
                     cached-analysis))
-                (swap! !file->analysis-cache assoc file (-> (analyze-doc {} (parser/parse-file {} file))
-                                                            (assoc :file-sha current-file-sha))))))
+                (let [analysis (analyze-doc {:file-sha current-file-sha} (parser/parse-file {} file))]
+                  (swap! !file->analysis-cache assoc file analysis)
+                  analysis))))
   ([state file]
    (analyze-doc state (parser/parse-file {} file))))
 
@@ -469,7 +470,6 @@
       #_(prn :build-graph counter :analyzed-file-set analyzed-file-set)
       (if (and (seq loc->syms) (< counter 10))
         (recur (-> (reduce (fn [g [source symbols]]
-                             (prn :source source :symbols symbols)
                              (if (or (nil? source)
                                      (str/ends-with? source ".jar"))
                                (update g :->analysis-info merge (into {} (map (juxt identity (constantly (if source (hash-jar source) {})))) symbols))

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -321,7 +321,7 @@
                                  (-> (reduce (partial analyze-deps analyzed) state deps)
                                      (make-deps-inherit-no-cache analyzed))
                                  state)))))
-                       (cond-> state
+                       (cond-> (update state :->hash (fnil identity {}))
                          doc? (merge doc))
                        (-> doc :blocks count range))
          doc? (-> parser/add-block-visibility

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -519,7 +519,7 @@
 (defn hash-codeblock [->hash {:as codeblock :keys [hash form id deps vars]}]
   (when (and (seq deps) (not (ifn? ->hash)))
     (throw (ex-info "`->hash` must be `ifn?`" {:->hash ->hash :codeblock codeblock})))
-  (let [hashed-deps (into #{} (comp (remove deref?) (map ->hash)) deps)]
+  (let [hashed-deps (into #{} (map ->hash) deps)]
     (when (contains? hashed-deps nil)
       (binding [*out* *err*]
         (prn :hash-codeblock/unhashed-warning (remove ->hash deps)))
@@ -529,8 +529,6 @@
     (sha1-base58 (binding [*print-length* nil]
                    (pr-str (set/union (conj hashed-deps (if form form hash))
                                       vars))))))
-
-#_(nextjournal.clerk/show! "src/nextjournal/clerk.clj")
 
 (defn hash
   ([{:as analyzed-doc :keys [graph]}] (hash analyzed-doc (dep/topo-sort graph)))

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -470,9 +470,10 @@
           loc->syms (apply dissoc
                            (group-by find-location unhashed)
                            analyzed-file-set)]
-      #_(prn :build-graph counter :analyzed-file-set analyzed-file-set)
+      (prn :build-graph counter :analyzed-file-set analyzed-file-set)
       (if (and (seq loc->syms) (< counter 10))
         (recur (-> (reduce (fn [g [source symbols]]
+                             (prn :source source)
                              (if (or (nil? source)
                                      (str/ends-with? source ".jar"))
                                (update g :->analysis-info merge (into {} (map (juxt identity (constantly (if source (hash-jar source) {})))) symbols))

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -397,7 +397,7 @@
 
 (defn normalize-filename [f]
   (if (fs/windows?)
-    (-> f fs/normalize fs/path .toUri .getPath)
+    (-> f fs/normalize fs/unixify)
     f))
 
 (defn ns->jar [ns]

--- a/src/nextjournal/clerk/graph_visualizer.clj
+++ b/src/nextjournal/clerk/graph_visualizer.clj
@@ -1,21 +1,30 @@
 (ns nextjournal.clerk.graph-visualizer
   {:no-doc true}
   (:require [arrowic.core :as arrowic]
+            [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.analyzer :as analyzer]
             [weavejester.dependency :as dep]))
 
-(defonce viewer
-  (arrowic/create-viewer (arrowic/create-graph)))
+(defn dep-svg [{:keys [graph ->analysis-info]}]
+  (clerk/html
+   (arrowic/as-svg
+    (arrowic/with-graph (arrowic/create-graph)
+      (let [vars->verticies (into {} (map (juxt identity arrowic/insert-vertex!)) (keys ->analysis-info))]
+        (doseq [var (keys ->analysis-info)]
+          (doseq [dep (dep/immediate-dependencies graph var)]
+            (when (and (vars->verticies var)
+                       (vars->verticies dep))
+              (arrowic/insert-edge! (vars->verticies var) (vars->verticies dep))))))))))
 
 
-(defn show-graph [{:keys [graph var->hash]}]
-  (arrowic/view viewer
-                (arrowic/with-graph (arrowic/create-graph)
-                  (let [vars->verticies (into {} (map (juxt identity arrowic/insert-vertex!)) (keys var->hash))]
-                    (doseq [var (keys var->hash)]
-                      (doseq [dep (dep/immediate-dependencies graph var)]
-                        (when (and (vars->verticies var)
-                                   (vars->verticies dep))
-                          (arrowic/insert-edge! (vars->verticies var) (vars->verticies dep)))))))))
+(defn graph-file [file]
+  (-> (analyzer/analyze-file {:graph (dep/graph)} file )
+      analyzer/build-graph
+      dep-svg))
 
-#_(-> "notebooks/elements.clj" nextjournal.clerk.analyzer/build-graph show-graph)
-#_(-> "src/nextjournal/clerk/analyzer.clj" nextjournal.clerk.analyzer/build-graph show-graph)
+^{::clerk/width :full}
+(graph-file "src/nextjournal/clerk/classpath.clj")
+
+
+^{::clerk/width :full}
+(graph-file "src/nextjournal/clerk/parser.cljc")

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -71,8 +71,8 @@
                   (:deps (ana/analyze '{:k-1 foo :k-2 #{bar}}))))))
 
   (testing "defprotocol :deps should all be symbols"
-    (every? symbol? (:deps (ana/analyze '(defprotocol MyProtocol
-                                           (-check [_])))))))
+    (is (every? symbol? (:deps (ana/analyze '(defprotocol MyProtocol
+                                               (-check [_]))))))))
 
 (deftest read-string-tests
   (testing "read-string should read regex's such that value equalility is preserved"

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -227,9 +227,9 @@
     (is (match? [{:form '(do) :text "(do #?@(:cljs []))"}]
                 (-> "(do #?@(:cljs []))" analyze-string :blocks)))))
 
-#_(deftest analyze-file
-    (testing "should analyze depedencies"
-      (is (-> (ana/analyze-file "src/nextjournal/clerk/classpath.clj") :->analysis-info not-empty))))
+(deftest analyze-file
+  (testing "should analyze depedencies"
+    (is (-> (ana/analyze-file "src/nextjournal/clerk/classpath.clj") :->analysis-info not-empty))))
 
 (deftest add-block-ids
   (testing "assigns block ids"

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -197,6 +197,14 @@
       ana/analyze-doc
       ana/build-graph))
 
+(deftest hash-test
+  (testing "The hash of weavejester/dependency is the same across OSes")
+  (is (match?
+       {:jar
+        #"repository/weavejester/dependency/0.2.1/dependency-0.2.1.jar",
+        :hash "5dsZiMRBpbMfWTafMoHEaNdGfEYxpx"}
+       (ana/hash-jar (ana/find-location 'weavejester.dependency/graph)))))
+
 (deftest analyze-doc
   (testing "reading a bad block shows block and file info in raised exception"
     (is (thrown-match? ExceptionInfo

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -198,12 +198,12 @@
       ana/build-graph))
 
 (deftest hash-test
-  (testing "The hash of weavejester/dependency is the same across OSes")
-  (is (match?
-       {:jar
-        #"repository/weavejester/dependency/0.2.1/dependency-0.2.1.jar",
-        :hash "5dsZiMRBpbMfWTafMoHEaNdGfEYxpx"}
-       (ana/hash-jar (ana/find-location 'weavejester.dependency/graph)))))
+  (testing "The hash of weavejester/dependency is the same across OSes"
+    (is (match?
+         {:jar
+          #"repository/weavejester/dependency/0.2.1/dependency-0.2.1.jar",
+          :hash "5dsZiMRBpbMfWTafMoHEaNdGfEYxpx"}
+         (ana/hash-jar (ana/find-location 'weavejester.dependency/graph))))))
 
 (deftest analyze-doc
   (testing "reading a bad block shows block and file info in raised exception"

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -187,10 +187,10 @@
 
 (deftest find-location
   (testing "clojure.core/inc"
-    (re-find #"clojure-1\..*\.jar" (ana/find-location 'clojure.core/inc)))
+    (is (re-find #"clojure-1\..*\.jar" (ana/find-location 'clojure.core/inc))))
 
   (testing "weavejester.dependency/graph"
-    (re-find #"dependency-.*\.jar" (ana/find-location 'weavejester.dependency/graph))))
+    (is (re-find #"dependency-.*\.jar" (ana/find-location 'weavejester.dependency/graph)))))
 
 (defn analyze-string [s]
   (-> (parser/parse-clojure-string {:doc? true} s)

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -185,6 +185,13 @@
   (testing "does not resolve jdk builtins"
     (is (not (ana/symbol->jar 'java.net.http.HttpClient/newHttpClient)))))
 
+(deftest find-location
+  (testing "clojure.core/inc"
+    (re-find #"clojure-1\..*\.jar" (ana/find-location 'clojure.core/inc)))
+
+  (testing "weavejester.dependency/graph"
+    (re-find #"dependency-.*\.jar" (ana/find-location 'weavejester.dependency/graph))))
+
 (defn analyze-string [s]
   (-> (parser/parse-clojure-string {:doc? true} s)
       ana/analyze-doc

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -102,6 +102,9 @@
     (is (match? {:deps       #{'io.methvin.watcher.hashing.FileHasher}}
                 (ana/analyze 'io.methvin.watcher.hashing.FileHasher/DEFAULT_FILE_HASHER))))
 
+  (testing "all deps are symbols"
+    (is (every? symbol? (:deps (ana/analyze '(.hashCode clojure.lang.Compiler))))))
+
   (is (match? {:ns-effect? false
                :vars '#{nextjournal.clerk.analyzer/foo}
                :deps       #{'rewrite-clj.parser/parse-string-all

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -71,7 +71,9 @@
                   (intern *ns* 'bar :bar)
                   (:deps (ana/analyze '{:k-1 foo :k-2 #{bar}}))))))
 
-  (testing "defprotocol :deps should all be symbols"
+  (testing "deps should all be symbols"
+    (is (every? symbol? (:deps (ana/analyze '(.hashCode clojure.lang.Compiler)))))
+
     (is (every? symbol? (:deps (ana/analyze '(defprotocol MyProtocol
                                                (-check [_]))))))))
 
@@ -101,9 +103,6 @@
   (testing "namespaced symbol referring to a java thing"
     (is (match? {:deps       #{'io.methvin.watcher.hashing.FileHasher}}
                 (ana/analyze 'io.methvin.watcher.hashing.FileHasher/DEFAULT_FILE_HASHER))))
-
-  (testing "all deps are symbols"
-    (is (every? symbol? (:deps (ana/analyze '(.hashCode clojure.lang.Compiler))))))
 
   (is (match? {:ns-effect? false
                :vars '#{nextjournal.clerk.analyzer/foo}

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -68,7 +68,11 @@
                 (with-ns-binding 'nextjournal.clerk.analyzer-test
                   (intern *ns* 'foo :foo)
                   (intern *ns* 'bar :bar)
-                  (:deps (ana/analyze '{:k-1 foo :k-2 #{bar}})))))))
+                  (:deps (ana/analyze '{:k-1 foo :k-2 #{bar}}))))))
+
+  (testing "defprotocol :deps should all be symbols"
+    (every? symbol? (:deps (ana/analyze '(defprotocol MyProtocol
+                                           (-check [_])))))))
 
 (deftest read-string-tests
   (testing "read-string should read regex's such that value equalility is preserved"

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -271,6 +271,7 @@ my-uuid")]
     (is (empty? (-> "(ns foo (:require [clojure.set :as set])) (set/union #{1} #{2})" analyze-string :->analysis-info ana/unhashed-deps))))
 
   (testing "should have analysis info and no unhashed deps for `dep/graph`"
+    (prn :find-location (ana/find-location 'weavejester.dependency/graph))
     (let [{:keys [->analysis-info]} (analyze-string "(ns foo (:require [weavejester.dependency :as dep])) (dep/graph)")]
       (is (empty? (ana/unhashed-deps ->analysis-info)))
       (is (match? {:jar string?} (->analysis-info 'weavejester.dependency/graph))))))

--- a/test/nextjournal/clerk/eval_test.clj
+++ b/test/nextjournal/clerk/eval_test.clj
@@ -193,7 +193,6 @@
     (intern (create-ns 'existing-var) 'foo :bar)
     (is (eval/eval-string "(in-ns 'existing-var) foo"))))
 
-#_#_#_ ;; TODO: put back
 (clerk/defcached my-expansive-thing
   (do (Thread/sleep 1 #_10000) 42))
 

--- a/test/nextjournal/clerk/eval_test.clj
+++ b/test/nextjournal/clerk/eval_test.clj
@@ -193,6 +193,7 @@
     (intern (create-ns 'existing-var) 'foo :bar)
     (is (eval/eval-string "(in-ns 'existing-var) foo"))))
 
+#_#_#_ ;; TODO: put back
 (clerk/defcached my-expansive-thing
   (do (Thread/sleep 1 #_10000) 42))
 


### PR DESCRIPTION
Until now Clerk did not analyze the full transitive dependency graph which could lead to Clerk not detecting a change properly. Analysis is now recursive which means it's taking a bit longer initially. We cache analysis results per file in memory so subsequent analysis should be fast. We will follow up with visualizing the progress of analysis & execution.

Also discovered cases where classes instead of symbols could end up in the dependency graph and introduced normalization to symbols.

This also gets rid of the `->hash must be ifn?` warning which fixes #375.