### PR TITLE
Minor Markdown Fixes

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
         weavejester/dependency {:mvn/version "0.2.1"}
         com.nextjournal/beholder {:mvn/version "1.0.0"}
 
-        io.github.nextjournal/markdown {:mvn/version "0.4.132"}
+        io.github.nextjournal/markdown {:mvn/version "0.4.135"}
         io.github.nextjournal/dejavu {:git/sha "4980e0cc18c9b09fb220874ace94ba6b57a749ca"}
 
         com.taoensso/nippy {:mvn/version "3.2.0"}

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -633,8 +633,8 @@
    {:name :nextjournal.markdown/hashtag :transform-fn (into-markup #(vector :a {:href (str "#" (:text %))}))}
 
    ;; inlines
-   {:name :nextjournal.markdown/text :transform-fn (into-markup [:span])}
-   {:name :nextjournal.markdown/softbreak :transform-fn (fn [_] (with-viewer :html [:span " "]))}
+   {:name :nextjournal.markdown/text :transform-fn (into-markup [:<>])}
+   {:name :nextjournal.markdown/softbreak :transform-fn (fn [_] (with-viewer :html [:<> " "]))}
    #?(:clj {:name :nextjournal.markdown/inline :transform-fn (comp eval read-string md.transform/->text)})
 
    ;; formulas

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -635,7 +635,6 @@
    ;; inlines
    {:name :nextjournal.markdown/text :transform-fn (into-markup [:<>])}
    {:name :nextjournal.markdown/softbreak :transform-fn (fn [_] (with-viewer :html [:<> " "]))}
-   #?(:clj {:name :nextjournal.markdown/inline :transform-fn (comp eval read-string md.transform/->text)})
 
    ;; formulas
    {:name :nextjournal.markdown/formula

--- a/test/nextjournal/clerk/parser_test.clj
+++ b/test/nextjournal/clerk/parser_test.clj
@@ -97,8 +97,8 @@ par two"))))
                     analyze-string
                     :open-graph)))
 
-    (is (match? {:title "Doc Title" :description "first paragraph" :url "https://ogp.me"}
-                (-> ";; # Doc Title\n(ns my.ns2 {:nextjournal.clerk/open-graph {:url \"https://ogp.me\"}})\n;; ---\n;; first paragraph"
+    (is (match? {:title "Doc Title" :description "First paragraph with soft breaks." :url "https://ogp.me"}
+                (-> ";; # Doc Title\n(ns my.ns2 {:nextjournal.clerk/open-graph {:url \"https://ogp.me\"}})\n;; ---\n;; First paragraph with soft\n;; breaks."
                     analyze-string
                     :open-graph)))))
 

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -121,7 +121,7 @@
 (deftest present
   (testing "only transform-fn can select viewer"
     (is (match? {:nextjournal/value [:div.viewer-markdown
-                                     ["h1" {:id "hello-markdown!"} [:span "👋 Hello "] [:em [:span "markdown"]] [:span "!"]]]
+                                     ["h1" {:id "hello-markdown!"} [:<> "👋 Hello "] [:em [:<> "markdown"]] [:<> "!"]]]
                  :nextjournal/viewer {:name :html-}}
                 (v/present (v/with-viewer {:transform-fn (comp v/md v/->value)}
                              "# 👋 Hello _markdown_!")))))


### PR DESCRIPTION
* Drop wrapping spans for text and soft-break nodes
* Fix open graph excerpts: represent soft-breaks as spaces
* Bumps markdown library to 0.4.135