### PR TITLE
Tools analyzer workaround, fixes issue with class redefinition + instance? checks

### DIFF
--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -106,8 +106,13 @@
   ([bindings form]
    (binding [config/*in-clerk* true]
      (try
-       (ana-jvm/analyze form (ana-jvm/empty-env) {:bindings bindings
-                                                  :passes-opts analyzer-passes-opts})
+       (let [old-deftype-hack ana-jvm/-deftype]
+         ;; NOTE: workaround for tools.analyzer `-deftype` + `eval` HACK, which redefines classes which doesn't work well with instance? checks
+         (with-redefs [ana-jvm/-deftype (fn [name class-name args interfaces]
+                                              (when-not (resolve class-name)
+                                                (old-deftype-hack name class-name args interfaces)))]
+           (ana-jvm/analyze form (ana-jvm/empty-env) {:bindings bindings
+                                                      :passes-opts analyzer-passes-opts})))
        (catch java.lang.AssertionError e
          (throw (ex-info "Failed to analyze form"
                          (-> (select-keys (meta form) [:line :col :clojure.core/eval-file])

--- a/ui_tests/playwright_tests.cljs
+++ b/ui_tests/playwright_tests.cljs
@@ -1,7 +1,6 @@
 (ns playwright-tests
   {:clj-kondo/config '{:skip-comments false}}
-  (:require ["child_process" :as cp]
-            ["playwright$default" :refer [chromium]]
+  (:require ["playwright$default" :refer [chromium]]
             [clojure.edn :as edn]
             [clojure.string :as str]
             [clojure.test :as t :refer [deftest is async use-fixtures]]
@@ -48,6 +47,7 @@
 (defn test-notebook [page link]
   (println "Visiting" link)
   (p/do (goto page link)
+        (p/delay 500)
         (p/let [loc (.locator page "div")
                 loc (.first loc)
                 visible? (.isVisible loc)]

--- a/ui_tests/yarn.lock
+++ b/ui_tests/yarn.lock
@@ -7,10 +7,10 @@ import-meta-resolve@^2.1.0:
   resolved "https://registry.yarnpkg.com/import-meta-resolve/-/import-meta-resolve-2.1.0.tgz#c8952d331ed6e9bb6ad524a7549deb3d34af41ce"
   integrity sha512-yG9pxkWJVTy4cmRsNWE3ztFdtFuYIV8G4N+cbCkO8b+qngkLyIUhxQFuZ0qJm67+0nUOxjMPT7nfksPKza1v2g==
 
-nbb@^1.0.138:
-  version "1.0.138"
-  resolved "https://registry.yarnpkg.com/nbb/-/nbb-1.0.138.tgz#e2e817bd05096e87b8f777975d0efd6c1852802a"
-  integrity sha512-c1MXkmz0j37rxgdD7Dgbmwx9dmSncfgjHbsYWijwRELTjLocVhWLRv1taiXV4XkjmpFUrm5uMeMGC44JRLzS1A==
+nbb@^1.1.147:
+  version "1.2.160"
+  resolved "https://registry.yarnpkg.com/nbb/-/nbb-1.2.160.tgz#608513b72aa407b496b940212ddfce904d983d7b"
+  integrity sha512-lguORvvjWtCM4c29a4gV6gUZdICfB9PIhjLv23FxZt0aKn3M/teV2oaKZDuAQceQl+kg98D2V3de8dttt7abBw==
   dependencies:
     import-meta-resolve "^2.1.0"
 


### PR DESCRIPTION
This is a temporary workaround until tools.analyzer.jvm provides better options to avoid the `-deftype` + `eval` hack.