### PR TITLE
Fix typo in comment block comment

### DIFF
--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -523,7 +523,7 @@
 #_(defcached my-expansive-thing
     (do (Thread/sleep 4200) 42))
 
-;; And, as is the culture of our people, a commend block containing
+;; And, as is the culture of our people, a comment block containing
 ;; pieces of code with which to pilot the system during development.
 (comment
   (def watcher


### PR DESCRIPTION
Just a typo being polished. Nothing to see here.