### PR TITLE
Augment `eval+cache!` exception with form + location info

### DIFF
--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -149,9 +149,7 @@
     (catch Throwable t
       (let [triaged (main/ex-triage (Throwable->map t))]
         (throw (ex-info (main/ex-str triaged)
-                        (assoc triaged
-                               :form form
-                               :clojure.core/eval-file file)))))))
+                        (merge triaged {:form form} (meta form))))))))
 
 (defn maybe-eval-viewers [{:as opts :nextjournal/keys [viewer viewers]}]
   (cond-> opts

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -120,7 +120,7 @@
   ([store ns name] (record-interned-symbol store ns name) (core-intern ns name))
   ([store ns name val] (record-interned-symbol store ns name) (core-intern ns name val)))
 
-(defn ^:private eval+cache! [{:keys [form var ns-effect? no-cache? freezable? file] :as _form-info} hash digest-file]
+(defn ^:private eval+cache! [{:keys [form var ns-effect? no-cache? freezable?] :as form-info} hash digest-file]
   (try
     (let [!interned-vars (atom #{})
           {:keys [result]} (time-ms (binding [config/*in-clerk* true]
@@ -149,7 +149,7 @@
     (catch Throwable t
       (let [triaged (main/ex-triage (Throwable->map t))]
         (throw (ex-info (main/ex-str triaged)
-                        (merge triaged {:form form} (meta form))))))))
+                        (merge triaged (analyzer/form->ex-data form))))))))
 
 (defn maybe-eval-viewers [{:as opts :nextjournal/keys [viewer viewers]}]
   (cond-> opts

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -120,7 +120,7 @@
   ([store ns name] (record-interned-symbol store ns name) (core-intern ns name))
   ([store ns name val] (record-interned-symbol store ns name) (core-intern ns name val)))
 
-(defn ^:private eval+cache! [{:keys [form var ns-effect? no-cache? freezable?] :as form-info} hash digest-file]
+(defn ^:private eval+cache! [{:keys [form var ns-effect? no-cache? freezable? file] :as _form-info} hash digest-file]
   (try
     (let [!interned-vars (atom #{})
           {:keys [result]} (time-ms (binding [config/*in-clerk* true]
@@ -148,7 +148,10 @@
           (assoc :nextjournal/interned @!interned-vars))))
     (catch Throwable t
       (let [triaged (main/ex-triage (Throwable->map t))]
-        (throw (ex-info (main/ex-str triaged) triaged))))))
+        (throw (ex-info (main/ex-str triaged)
+                        (assoc triaged
+                               :clerk/form form
+                               :clerk/file file)))))))
 
 (defn maybe-eval-viewers [{:as opts :nextjournal/keys [viewer viewers]}]
   (cond-> opts

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -150,8 +150,8 @@
       (let [triaged (main/ex-triage (Throwable->map t))]
         (throw (ex-info (main/ex-str triaged)
                         (assoc triaged
-                               :clerk/form form
-                               :clerk/file file)))))))
+                               :form form
+                               :clojure.core/eval-file file)))))))
 
 (defn maybe-eval-viewers [{:as opts :nextjournal/keys [viewer viewers]}]
   (cond-> opts


### PR DESCRIPTION
## before

```
  :cause
  "Execution error (PSQLException) at org.postgresql.jdbc.PgPreparedStatement/setObject (PgPreparedStatement.java:1029).\nCan't infer the SQL type to use for an instance of java.util.Date. Use setObject() with an explicit Types value to specify the type to use.\n",
  :data
  ***:clojure.error/class org.postgresql.util.PSQLException,
   :clojure.error/line 1029,
   :clojure.error/cause
   "Can't infer the SQL type to use for an instance of java.util.Date. Use setObject() with an explicit Types value to specify the type to use.",
   :clojure.error/symbol
   org.postgresql.jdbc.PgPreparedStatement/setObject,
   :clojure.error/source "PgPreparedStatement.java",
   :clojure.error/phase :execution***,
  :phase :execution***

Execution error (ExceptionInfo) at nextjournal.clerk.eval/eval+cache! (eval.clj:151).
Execution error (PSQLException) at org.postgresql.jdbc.PgPreparedStatement/setObject (PgPreparedStatement.java:1029).
Can't infer the SQL type to use for an instance of java.util.Date. Use setObject() with an explicit Types value to specify the type to use.
```

## after

```
:cause
  "Execution error (PSQLException) at org.postgresql.jdbc.PgPreparedStatement/setObject (PgPreparedStatement.java:1029).\nCan't infer the SQL type to use for an instance of java.util.Date. Use setObject() with an explicit Types value to specify the type to use.\n",
  :data
  ***:clojure.error/class org.postgresql.util.PSQLException,
   :clojure.error/line 1029,
   :clojure.error/cause
   "Can't infer the SQL type to use for an instance of java.util.Date. Use setObject() with an explicit Types value to specify the type to use.",
   :clojure.error/symbol
   org.postgresql.jdbc.PgPreparedStatement/setObject,
   :clojure.error/source "PgPreparedStatement.java",
   :clojure.error/phase :execution,
   :clerk/form
   (sort-by
    second
    (frequencies
     (map
      :DLFREKDN
      (utils/services-in-date-range start-date end-date)))),
   :clerk/file "dev/insights/billing/an_invoice.clj"***,
  :phase :execution***

Execution error (ExceptionInfo) at nextjournal.clerk.eval/eval+cache! (eval.clj:151).
Execution error (PSQLException) at org.postgresql.jdbc.PgPreparedStatement/setObject (PgPreparedStatement.java:1029).
Can't infer the SQL type to use for an instance of java.util.Date. Use setObject() with an explicit Types value to specify the type to use.
```