### PR TITLE
Fix html with odd length lists

### DIFF
--- a/notebooks/viewers/html.clj
+++ b/notebooks/viewers/html.clj
@@ -20,3 +20,9 @@
              "Go to "
              [:a.text-lg {:href (v/doc-url "notebooks/viewers/image.clj")} "images"]
              " notebook."]) nil)
+
+(clerk/html
+ [:h1 "Title"
+  (list [:div "one"]
+        [:div "two"]
+        [:div "three"])])

--- a/notebooks/viewers/html.clj
+++ b/notebooks/viewers/html.clj
@@ -22,7 +22,6 @@
              " notebook."]) nil)
 
 (clerk/html
- [:h1 "Title"
-  (list [:div "one"]
-        [:div "two"]
-        [:div "three"])])
+ [:ol (list [:li "One"]
+            [:li "Two"]
+            [:li "Three"])])

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1226,7 +1226,7 @@
 #_(process-viewer {:render-fn '#(vector :h1) :transform-fn mark-presented})
 
 (def processed-keys
-  (into [:path :offset :n :nextjournal/content-type :nextjournal/value]
+  (into [:path :offset :n :nextjournal/content-type :nextjournal/value :nextjournal/presented?]
         (-> viewer-opts-normalization vals set (disj :nextjournal/viewers))))
 
 (defn process-wrapped-value [wrapped-value]
@@ -1386,9 +1386,9 @@
       (reduce compute-expanded-at state' value)
       state')))
 
-(defn collect-expandable-paths [state {:nextjournal/keys [value] :keys [path]}]
+(defn collect-expandable-paths [state {:nextjournal/keys [value presented?] :keys [path]}]
   (let [state' (assoc-in state [:expanded-at path] false)]
-    (if (vector? value)
+    (if (and (vector? value) (not presented?))
       (reduce collect-expandable-paths state' value)
       state')))
 


### PR DESCRIPTION
Fixes #395.

The issue is due to some weird behaviour of cljs.core/reduce against vectors containing lists with an odd number of items.
https://github.com/nextjournal/clerk/blob/d387037aa45303c32e311b62580b6f85e0b72919/src/nextjournal/clerk/viewer.cljc#L1389-L1393


```clojure
(viewer/collect-expandable-paths 
 {:expanded-at {}}
 {:path [],
  :nextjournal/value [:h1 "Ahoi" (list [:div "one"] [:div "two"] [:div "three"])],
  :nextjournal/viewer {:name :html, :render-fn identity, :hash "5dqwbRQVFnHkdooT8QV8nfPHBGVWtj"}})
```

Causing: 

```
Uncaught Error: :div is not ISeqable
    at Object.cljs$core$seq [as seq] (core.cljs:1253:20)
    at Object.cljs$core$ITransientCollection$_conj_BANG_$arity$2 (core.cljs:7198:20)
    at cljs$core$_conj_BANG_ (core.cljs:803:17)
    at core.cljs:5686:36
    at core.cljs:5686:35
    at Object.cljs$core$IReduce$_reduce$arity$3 (core.cljs:5690:24)
    at Function.cljs$core$IFn$_invoke$arity$3 (core.cljs:2570:17)
    at Function.cljs$core$IFn$_invoke$arity$2 (core.cljs:5266:36)
    at Function.createAsIfByAssocComplexPath (core.cljs:7134:21)
    at Function.createAsIfByAssoc 
```

The error is actually visible in browser console and it's not reproducible on the JVM.