### PR TITLE
Bump sci with support for adding js libs using `sci/add-js-lib!`

### DIFF
--- a/render/deps.edn
+++ b/render/deps.edn
@@ -3,7 +3,7 @@
         binaryage/devtools {:mvn/version "1.0.3"}
         cider/cider-nrepl {:mvn/version "0.28.3"}
         org.babashka/sci {:git/url "https://github.com/babashka/sci"
-                          :git/sha "fc21c445baf49f3c8f11842d73376ea3c66836f7"}
+                          :git/sha "4b7ae2659fe036887a6069e581d535632bb5affa"}
         reagent/reagent {:mvn/version "1.1.1"}
         io.github.babashka/sci.configs {:git/sha "0702ea5a21ad92e6d7cca6d36de84271083ea68f"}
         io.github.nextjournal/clojure-mode {:git/sha "ac038ebf6e5da09dd2b8a31609e9ff4a65e36852"}

--- a/render/deps.edn
+++ b/render/deps.edn
@@ -2,7 +2,8 @@
  :deps {applied-science/js-interop {:mvn/version "0.3.3"}
         binaryage/devtools {:mvn/version "1.0.3"}
         cider/cider-nrepl {:mvn/version "0.28.3"}
-        org.babashka/sci {:mvn/version "0.6.37"}
+        org.babashka/sci {:git/url "https://github.com/babashka/sci"
+                          :git/sha "fc21c445baf49f3c8f11842d73376ea3c66836f7"}
         reagent/reagent {:mvn/version "1.1.1"}
         io.github.babashka/sci.configs {:git/sha "0702ea5a21ad92e6d7cca6d36de84271083ea68f"}
         io.github.nextjournal/clojure-mode {:git/sha "ac038ebf6e5da09dd2b8a31609e9ff4a65e36852"}

--- a/render/deps.edn
+++ b/render/deps.edn
@@ -2,8 +2,7 @@
  :deps {applied-science/js-interop {:mvn/version "0.3.3"}
         binaryage/devtools {:mvn/version "1.0.3"}
         cider/cider-nrepl {:mvn/version "0.28.3"}
-        org.babashka/sci {:git/url "https://github.com/babashka/sci"
-                          :git/sha "4b7ae2659fe036887a6069e581d535632bb5affa"}
+        org.babashka/sci {:mvn/version "0.7.38"}
         reagent/reagent {:mvn/version "1.1.1"}
         io.github.babashka/sci.configs {:git/sha "0702ea5a21ad92e6d7cca6d36de84271083ea68f"}
         io.github.nextjournal/clojure-mode {:git/sha "ac038ebf6e5da09dd2b8a31609e9ff4a65e36852"}

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -97,11 +97,17 @@
 
 (def initial-sci-opts
   {:async? true
-   #_#_:load-fn load-fn
    :disable-arity-checks true
    :classes {'js (j/assoc! goog/global "import" shadow.esm/dynamic-import)
              'framer-motion framer-motion
              :allow :all}
+   :js-libs {"@codemirror/language" codemirror-language
+             "@codemirror/state" codemirror-state
+             "@codemirror/view" codemirror-view
+             "@lezer/highlight" lezer-highlight
+             "@nextjournal/lang-clojure" lang-clojure
+             "framer-motion" framer-motion
+             "react" react}
    :aliases {'j 'applied-science.js-interop
              'reagent 'reagent.core
              'v 'nextjournal.clerk.viewer
@@ -134,15 +140,6 @@
 (def ^:export mount render/mount)
 
 (sci.ctx-store/reset-ctx! (sci/init initial-sci-opts))
-
-(run! (fn [[libname lib]] (sci/add-js-lib! (sci.ctx-store/get-ctx) libname lib))
-      {"@codemirror/language" codemirror-language
-       "@codemirror/state" codemirror-state
-       "@codemirror/view" codemirror-view
-       "@lezer/highlight" lezer-highlight
-       "@nextjournal/lang-clojure" lang-clojure
-       "framer-motion" framer-motion
-       "react" react})
 
 (sci/alter-var-root sci/print-fn (constantly *print-fn*))
 (sci/alter-var-root sci/print-err-fn (constantly *print-err-fn*))

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -112,15 +112,15 @@
   {:async? true
    :load-fn load-fn
    :disable-arity-checks true
-   :classes (into {'js (j/assoc! goog/global "import" shadow.esm/dynamic-import)
-                   'framer-motion framer-motion
-                   "@codemirror/language" codemirror-language
-                   "@codemirror/state" codemirror-state
-                   "@codemirror/view" codemirror-view
-                   "@lezer/highlight" lezer-highlight
-                   "@nextjournal/lang-clojure" lang-clojure
-                   "react" react
-                   :allow :all})
+   :classes {'js (j/assoc! goog/global "import" shadow.esm/dynamic-import)
+             'framer-motion framer-motion
+             "@codemirror/language" codemirror-language
+             "@codemirror/state" codemirror-state
+             "@codemirror/view" codemirror-view
+             "@lezer/highlight" lezer-highlight
+             "@nextjournal/lang-clojure" lang-clojure
+             "react" react
+             :allow :all}
    :aliases {'j 'applied-science.js-interop
              'reagent 'reagent.core
              'v 'nextjournal.clerk.viewer


### PR DESCRIPTION
This adds support for adding js libs to the sci context using newly added `sci/add-js-lib!` that can then be required. We can thus drop the `libname->class` map and the sci `:load-fn`.

This is an alternative to #400.