### PR TITLE
Add `clerk/resolve-aliases` and make alias resolution explicit

### DIFF
--- a/book.clj
+++ b/book.clj
@@ -584,7 +584,7 @@ v/table-viewer
    :transform-fn (comp clerk/mark-preserve-keys
                        (clerk/update-val transform-literal))
    :render-fn '(fn [label->val]
-                 (reagent/with-let [!selected-label (reagent/atom (ffirst label->val))]
+                 (reagent.core/with-let [!selected-label (reagent.core/atom (ffirst label->val))]
                    [:<> (into
                          [:div.flex.items-center.font-sans.text-xs.mb-3
                           [:span.text-slate-500.mr-2 "View-as:"]]
@@ -594,7 +594,7 @@ v/table-viewer
                                   :on-click #(reset! !selected-label label)}
                                  label]))
                          (keys label->val))
-                    [v/inspect-presented (get label->val @!selected-label)]]))})
+                    [nextjournal.clerk.render/inspect-presented (get label->val @!selected-label)]]))})
 
 ;; Now let's see if this works. Try switching to the original
 ;; representation!
@@ -685,12 +685,11 @@ v/table-viewer
 (def mermaid-viewer
   {:transform-fn clerk/mark-presented
    :render-fn '(fn [value]
-                 (v/html
-                  (when value
-                    [v/with-d3-require {:package ["mermaid@8.14/dist/mermaid.js"]}
-                     (fn [mermaid]
-                       [:div {:ref (fn [el] (when el
-                                              (.render mermaid (str (gensym)) value #(set! (.-innerHTML el) %))))}])])))})
+                 (when value
+                   [nextjournal.clerk.render/with-d3-require {:package ["mermaid@8.14/dist/mermaid.js"]}
+                    (fn [mermaid]
+                      [:div {:ref (fn [el] (when el
+                                             (.render mermaid (str (gensym)) value #(set! (.-innerHTML el) %))))}])]))})
 
 ;; We can then use  the above viewer using `with-viewer`.
 (clerk/with-viewer mermaid-viewer
@@ -758,9 +757,9 @@ v/table-viewer
 ;;
 ;;    (+ 39 3) ;; code will be hidden
 ;;    (range 25) ;; code will be hidden
-;;    
+;;
 ;;    {:nextjournal.clerk/visibility {:code :show}}
-;;    
+;;
 ;;    (range 500) ;; code will be visible
 ;;    (rand-int 42) ;; code will be visible
 ;;

--- a/deps.edn
+++ b/deps.edn
@@ -67,7 +67,7 @@
                                org.clojure/data.csv {:mvn/version "1.0.0"}
                                hickory/hickory {:mvn/version "0.7.1"}
                                sicmutils/sicmutils {:mvn/version "0.20.0"}
-                               io.github.nextjournal/clerk-slideshow {:git/sha "7963159d4e530e7981f7168702225906f55bfc01"}}}
+                               io.github.nextjournal/clerk-slideshow {:git/sha "5fe197ca0c8f28128379849dc677cd718be71524"}}}
 
            :build {:deps {io.github.nextjournal/clerk {:local/root "."}
                           io.github.clojure/tools.build {:git/tag "v0.6.1" :git/sha "515b334"}

--- a/deps.edn
+++ b/deps.edn
@@ -24,7 +24,8 @@
 
         juji/editscript {:mvn/version "0.6.2"}}
 
- :aliases {:nextjournal/clerk {:extra-deps {org.slf4j/slf4j-nop {:mvn/version "1.7.36"}
+ :aliases {:nextjournal/clerk {:extra-deps {org.clojure/clojure {:mvn/version "1.11.1"} ;; for `:as-alias` support in static build
+                                            org.slf4j/slf4j-nop {:mvn/version "1.7.36"}
                                             org.babashka/cli {:mvn/version "0.5.40"}}
                                :extra-paths ["notebooks"]
                                :exec-fn nextjournal.clerk/build!

--- a/notebooks/cards.clj
+++ b/notebooks/cards.clj
@@ -2,9 +2,11 @@
 ^{:nextjournal.clerk/toc true :nextjournal.clerk/visibility {:code :hide}}
 (ns cards
   {:nextjournal.clerk/no-cache true}
-  (:require [nextjournal.clerk :as clerk]
+  (:require [applied-science.js-interop :as-alias j]
             [cards-macro :as c]
-            [nextjournal.clerk.viewer :as v]))
+            [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.viewer :as v]
+            [reagent.core :as-alias reagent]))
 
 ;; ## Images
 (c/card
@@ -195,7 +197,7 @@
 ;; ## Parser API
 
 ^{::clerk/width :wide}
-(c/card 
+(c/card
  (as-> ";; # 👋 Hello CLJS
 ;; This is `fold`
 ;;
@@ -209,12 +211,12 @@
 (fold str \"\" (range 10))
 
 ;; ## And the usual Clerk's perks
-(v/plotly {:data [{:y (shuffle (range 10)) :name \"The Federation\"}
+(nextjournal.clerk.viewer/plotly {:data [{:y (shuffle (range 10)) :name \"The Federation\"}
                   {:y (shuffle (range 10)) :name \"The Empire\"}]})
 ;; tables
-(v/table {:a [1 2 3] :b [4 5 6]})
+(nextjournal.clerk.viewer/table {:a [1 2 3] :b [4 5 6]})
 ;; html
-(v/html [:h1 \"🧨\"])
+(nextjournal.clerk.viewer/html [:h1 \"🧨\"])
 "
      doc
    (nextjournal.clerk.parser/parse-clojure-string {:doc? true} doc)

--- a/notebooks/cards_macro.clj
+++ b/notebooks/cards_macro.clj
@@ -1,4 +1,4 @@
 (ns cards-macro
   (:require [nextjournal.clerk.viewer :as v]))
 
-(defmacro card [body] `(v/->viewer-eval '~body))
+(defmacro card [body] `(v/->viewer-eval '~(v/resolve-aliases body)))

--- a/notebooks/js_import.clj
+++ b/notebooks/js_import.clj
@@ -2,7 +2,6 @@
 (ns js-import
   (:require [clojure.data.csv :as csv]
             [nextjournal.clerk :as clerk]
-            [nextjournal.clerk]
             [nextjournal.clerk.viewer :as viewer]))
 
 ;; This example uses [Observable Plots](https://observablehq.com/plot) with data from https://allisonhorst.github.io/palmerpenguins/
@@ -17,10 +16,10 @@
        (fn [Plot]
          (let [dot-plot (.. Plot
                             (dot (clj->js data)
-                                 (j/obj :x "flipper_length_mm"
-                                        :y "body_mass_g"
-                                        :fill "species"))
-                            (plot (j/obj :grid true)))
+                                 (applied-science.js-interop/obj :x "flipper_length_mm"
+                                                                 :y "body_mass_g"
+                                                                 :fill "species"))
+                            (plot (applied-science.js-interop/obj :grid true)))
                legend (.legend dot-plot "color")]
            [:div {:ref (fn [el]
                          (if el

--- a/notebooks/jump_to_definition.clj
+++ b/notebooks/jump_to_definition.clj
@@ -1,29 +1,28 @@
 ;; # 🤾🏼 Jump to Definition
 (ns jump-to-definition
-  (:require
-   [clojure.string :as str]
-   [nextjournal.clerk :as clerk]
-   [nextjournal.clerk.render :as-alias render]
-   [nextjournal.clerk.render.hooks :as-alias hooks]
-   [nextjournal.clerk.viewer :as v]))
+  (:require [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.render :as-alias render]
+            [nextjournal.clerk.render.hooks :as-alias hooks]
+            [nextjournal.clerk.viewer :as v]))
 
 ;; Trying various ways to support jump to definition
 (def my-code-viewer
   {:render-fn 'nextjournal.clerk.render/render-code :transform-fn clerk/mark-presented})
 
 
-(v/->viewer-fn '(fn [spec] (let [plotly (hooks/use-d3-require "plotly.js-dist@2.15.1")
-                                 ref-fn (hooks/use-callback #(when % (.newPlot plotly % (clj->js spec ))) [spec plotly])]
-                             (js/console.log "dude")
-                             (when spec
-                               (if plotly
-                                 [:div.overflow-x-auto [:div.plotly {:ref ref-fn}]]
-                                 render/default-loading-view)))))
+(clerk/resolve-aliases '(fn [spec] (let [plotly (hooks/use-d3-require "plotly.js-dist@2.15.1")
+                                         ref-fn (hooks/use-callback #(when % (.newPlot plotly % (clj->js spec ))) [spec plotly])]
+                                     (js/console.log "dude")
+                                     (when spec
+                                       (if plotly
+                                         [:div.overflow-x-auto [:div.plotly {:ref ref-fn}]]
+                                         render/default-loading-view)))))
 
-(v/->viewer-eval '(fn [spec] (let [plotly (hooks/use-d3-require "plotly.js-dist@2.15.1")
-                                   ref-fn (hooks/use-callback #(when % (.newPlot plotly % (clj->js spec))) [spec plotly])]
-                               (js/console.log "dude")
-                               (when spec
-                                 (if plotly
-                                   [:div.overflow-x-auto [:div.plotly {:ref ref-fn}]]
-                                   render/default-loading-view)))))
+(v/->viewer-eval
+ (clerk/resolve-aliases '(fn [spec] (let [plotly (hooks/use-d3-require "plotly.js-dist@2.15.1")
+                                          ref-fn (hooks/use-callback #(when % (.newPlot plotly % (clj->js spec))) [spec plotly])]
+                                      (js/console.log "dude")
+                                      (when spec
+                                        (if plotly
+                                          [:div.overflow-x-auto [:div.plotly {:ref ref-fn}]]
+                                          render/default-loading-view))))))

--- a/notebooks/multiviewer.clj
+++ b/notebooks/multiviewer.clj
@@ -21,7 +21,7 @@
    :transform-fn (comp clerk/mark-preserve-keys
                        (clerk/update-val transform-literal))
    :render-fn '(fn [label->val]
-                 (reagent/with-let [!selected-label (reagent/atom (ffirst label->val))]
+                 (reagent.core/with-let [!selected-label (reagent.core/atom (ffirst label->val))]
                    [:<> (into
                          [:div.flex.items-center.font-sans.text-xs.mb-3
                           [:span.text-slate-500.mr-2 "View-as:"]]

--- a/notebooks/render_aliases.clj
+++ b/notebooks/render_aliases.clj
@@ -30,14 +30,14 @@
 
 (def plotly-viewer
   {:transform-fn clerk/mark-presented
-   :render-fn (clerk/resolve-aliases
-               '(fn [spec]
-                  (let [plotly (hooks/use-d3-require "plotly.js-dist@2.15.1")
-                        ref-fn (hooks/use-callback #(when % (.newPlot plotly % (clj->js spec))) [spec plotly])]
-                    (when spec
-                      (if plotly
-                        [:div.overflow-x-auto [:div.plotly {:ref ref-fn}]]
-                        render/default-loading-view)))))})
+   :render-fn #_clerk/resolve-aliases
+   '(fn [spec]
+      (let [plotly (hooks/use-d3-require "plotly.js-dist@2.15.1")
+            ref-fn (hooks/use-callback #(when % (.newPlot plotly % (clj->js spec))) [spec plotly])]
+        (when spec
+          (if plotly
+            [:div.overflow-x-auto [:div.plotly {:ref ref-fn}]]
+            render/default-loading-view))))})
 
 (clerk/with-viewer plotly-viewer
   {:layout {:title "A surface plot"}

--- a/notebooks/rule_30.clj
+++ b/notebooks/rule_30.clj
@@ -5,12 +5,12 @@
 
 (def viewers
   [{:pred number?
-    :render-fn '#(v/html [:div.inline-block {:style {:width 16 :height 16}
-                                             :class (if (pos? %) "bg-black" "bg-white border-solid border-2 border-black")}])}
+    :render-fn '#(vector :div.inline-block {:style {:width 16 :height 16}
+                                            :class (if (pos? %) "bg-black" "bg-white border-solid border-2 border-black")})}
    {:pred (every-pred list? (partial every? (some-fn number? vector?)))
-    :render-fn '#(v/html (into [:div.flex.flex-col] (v/inspect-children %2) %1))}
+    :render-fn '#(into [:div.flex.flex-col] (nextjournal.clerk.render/inspect-children %2) %1)}
    {:pred (every-pred vector? (complement map-entry?) (partial every? number?))
-    :render-fn '#(v/html (into [:div.flex.inline-flex] (v/inspect-children %2) %1))}])
+    :render-fn '#(into [:div.flex.inline-flex] (nextjournal.clerk.render/inspect-children %2) %1)}])
 
 (clerk/add-viewers! viewers)
 

--- a/notebooks/viewer_api.clj
+++ b/notebooks/viewer_api.clj
@@ -105,6 +105,6 @@
 
 ;; The clerk viewer api also includes `reagent` and `applied-science/js-interop`.
 (clerk/with-viewer '(fn [_]
-                      (reagent/with-let [counter (reagent/atom 0)]
+                      (reagent.core/with-let [counter (reagent.core/atom 0)]
                         [:h3.cursor-pointer {:on-click #(swap! counter inc)} "I was clicked " @counter " times."]))
   nil)

--- a/notebooks/viewers/control_lab.clj
+++ b/notebooks/viewers/control_lab.clj
@@ -1,8 +1,7 @@
 ;; # 🎛 Control Lab 🧑🏼‍🔬
 (ns viewers.control-lab
   {:nextjournal.clerk/visibility {:code :hide :result :hide}}
-  (:require [clojure.string :as str]
-            [nextjournal.clerk :as clerk]
+  (:require [nextjournal.clerk :as clerk]
             [nextjournal.clerk.viewer :as viewer]))
 
 ;; Experimenting with ways of making controls. We start with two

--- a/notebooks/viewers/errors.clj
+++ b/notebooks/viewers/errors.clj
@@ -11,13 +11,13 @@
 (clerk/with-viewer {:render-fn '(fn [x] (throw (ex-info "I blow up when called" {:some "data"})))}
   :boom)
 
-(clerk/with-viewer {:render-fn '(fn [_] (v/inspect-presented :crash))}
+(clerk/with-viewer {:render-fn '(fn [_] (nextjournal.clerk.render/inspect-presented :crash))}
   42)
 
-(clerk/with-viewer {:render-fn '(fn [_] (v/html (v/inspect-presented :crash)))}
+(clerk/with-viewer {:render-fn '(fn [_] (nextjournal.clerk.viewer/html (nextjournal.clerk.render/inspect-presented :crash)))}
   42)
 
-(clerk/with-viewer {:render-fn '(fn [_] (v/html [1 2 3]))}
+(clerk/with-viewer {:render-fn '(fn [_] (nextjournal.clerk.viewer/html [1 2 3]))}
   42)
 
 

--- a/notebooks/viewers/html.clj
+++ b/notebooks/viewers/html.clj
@@ -16,10 +16,10 @@
   " notebook."])
 
 (clerk/with-viewer
- '(fn [_ _] [:div
-             "Go to "
-             [:a.text-lg {:href (v/doc-url "notebooks/viewers/image.clj")} "images"]
-             " notebook."]) nil)
+  '(fn [_ _] [:div
+              "Go to "
+              [:a.text-lg {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewers/image.clj")} "images"]
+              " notebook."]) nil)
 
 (clerk/html
  [:ol (list [:li "One"]

--- a/notebooks/viewers/table.clj
+++ b/notebooks/viewers/table.clj
@@ -58,7 +58,7 @@
    {:rows (map (juxt identity inc) (range 100))
     :head (map format-head head-data)}))
 
-(clerk/with-viewers (clerk/add-viewers [(assoc v/image-viewer :render-fn '(fn [blob] (v/html [:img {:width "30px" :height "30px" :src (v/url-for blob)}])))])
+(clerk/with-viewers (clerk/add-viewers [(assoc v/image-viewer :render-fn '(fn [blob] [:img {:width "30px" :height "30px" :src (nextjournal.clerk.viewer/url-for blob)}]))])
   (clerk/table
    {:rows (map (juxt identity dec) (range 1 100))
     :head [(javax.imageio.ImageIO/read (java.net.URL. "https://upload.wikimedia.org/wikipedia/commons/1/17/Plus_img_364976.png"))
@@ -73,7 +73,7 @@
 (def custom-table-viewer
   (add-child-viewers v/table-viewer
                      [(assoc v/table-head-viewer :transform-fn (v/update-val (partial map (comp (partial str "Column: ") str/capitalize name))))
-                      (assoc v/table-missing-viewer :render-fn '(fn [x] (v/html [:span.red "N/A"])))]))
+                      (assoc v/table-missing-viewer :render-fn '(fn [x] [:span.red "N/A"]))]))
 
 (clerk/with-viewer custom-table-viewer
   {:col/a [1 2 3 4] :col/b [1 2 3] :col/c [1 2 3]})

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -181,6 +181,10 @@
   [wrapped-value]
   (v/mark-preserve-keys wrapped-value))
 
+(defn resolve-aliases
+  "Resolves aliases in `form` using the aliases from `*ns*`. Meant to be used on `:render-fn`s."
+  [form]
+  (v/resolve-aliases (ns-aliases *ns*) form))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; public convenience api

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -184,7 +184,7 @@
 (defn resolve-aliases
   "Resolves aliases in `form` using the aliases from `*ns*`. Meant to be used on `:render-fn`s."
   [form]
-  (v/resolve-aliases (ns-aliases *ns*) form))
+  (v/resolve-aliases form))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; public convenience api

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -109,6 +109,12 @@
              "@nextjournal/lang-clojure" lang-clojure
              "framer-motion" framer-motion
              "react" react}
+   ;; TODO: bring back aliases before the release and show a warning instead
+   #_#_
+   :aliases {'j 'applied-science.js-interop
+             'reagent 'reagent.core
+             'v 'nextjournal.clerk.viewer
+             'p 'nextjournal.clerk.parser}
    :namespaces (merge {'nextjournal.clerk.viewer viewer-namespace
                        'clojure.core {'read-string read-string
                                       'implements? (sci/copy-var implements?* core-ns)}}

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -109,10 +109,6 @@
              "@nextjournal/lang-clojure" lang-clojure
              "framer-motion" framer-motion
              "react" react}
-   :aliases {'j 'applied-science.js-interop
-             'reagent 'reagent.core
-             'v 'nextjournal.clerk.viewer
-             'p 'nextjournal.clerk.parser}
    :namespaces (merge {'nextjournal.clerk.viewer viewer-namespace
                        'clojure.core {'read-string read-string
                                       'implements? (sci/copy-var implements?* core-ns)}}

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -58,8 +58,9 @@
 
 #_(resolve-symbol-alias {'v (find-ns 'nextjournal.clerk.viewer)} 'nextjournal.clerk.render/render-code)
 
-(defn resolve-aliases [aliases form]
-  (w/postwalk #(cond->> % (qualified-symbol? %) (resolve-symbol-alias aliases)) form))
+(defn resolve-aliases
+  #?(:clj ([form] (resolve-aliases (ns-aliases *ns*) form)))
+  ([aliases form] (w/postwalk #(cond->> % (qualified-symbol? %) (resolve-symbol-alias aliases)) form)))
 
 (defn ->viewer-fn [form]
   (map->ViewerFn {:form form

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -59,16 +59,14 @@
 #_(resolve-symbol-alias {'v (find-ns 'nextjournal.clerk.viewer)} 'nextjournal.clerk.render/render-code)
 
 (defn resolve-aliases [aliases form]
-  (w/postwalk #(cond->> %
-                 (symbol? %) (resolve-symbol-alias aliases))
-              form))
+  (w/postwalk #(cond->> % (qualified-symbol? %) (resolve-symbol-alias aliases)) form))
 
 (defn ->viewer-fn [form]
-  (map->ViewerFn {:form #?(:clj (cond->> form *ns* (resolve-aliases (ns-aliases *ns*))) :cljs form)
+  (map->ViewerFn {:form form
                   #?@(:cljs [:f (*eval* form)])}))
 
 (defn ->viewer-eval [form]
-  (map->ViewerEval {:form #?(:clj (cond->> form *ns* (resolve-aliases (ns-aliases *ns*))) :cljs form)}))
+  (map->ViewerEval {:form form}))
 
 (defn open-graph-metas [open-graph-properties]
   (into (list [:meta {:name "twitter:card" :content "summary_large_image"}])


### PR DESCRIPTION
This makes the alias resolution explicit via a new `clerk/resolve-aliases` function. The recommendation is now to use the full namespace in `:render-fn`s or make the conversion explicit using `clerk/resolve-aliases`. 

I've also removed the automatic resolution from `->viewer-fn/eval` because it would depend on the evaluation context (a notebook that defines a viewer using aliases would render correctly but things could break if that viewer is being reused from another namespace that doesn't define the same aliases).

Lastly we've dropped the previously defined aliases:
```clojure
{'j 'applied-science.js-interop
 'reagent 'reagent.core
 'v 'nextjournal.clerk.viewer
 'p 'nextjournal.clerk.parser}
```

We should think about temporarily bringing them back and log a warning instead before the next release, so folks have time to migrate but I'd like to make sure all our notebooks aren't using them anymore.

<img width="989" alt="Screen Shot 2023-02-08 at 14 42 48" src="https://user-images.githubusercontent.com/1187/217546700-ddd3a4eb-7223-4186-bbe8-dfb9dc55c14c.png">
