### PR TITLE
Simplify modifying viewers

### DIFF
--- a/notebooks/profile.clj
+++ b/notebooks/profile.clj
@@ -3,11 +3,23 @@
   (:require [clj-async-profiler.core :as prof]
             [clj-async-profiler.ui :as prof.ui]
             [nextjournal.clerk.analyzer :as analyzer]
+            [nextjournal.clerk.parser :as parser]
             [viewers.table :as table]))
 
 ;; [Go to profiler UI](http://localhost:8080)
+(def parsed
+  (parser/parse-file "notebooks/rule_30.clj"))
 
-(prof/profile (analyzer/exceeds-bounded-count-limit? table/letter->words))
+(def analyzed
+  (analyzer/analyze-doc parsed))
+
+
+
+(do (time (analyzer/build-graph analyzed)) :done)
+
+
+
+(prof/profile (analyzer/build-graph analyzed))
 
 (if-not @prof.ui/current-server
   (prof/serve-ui 8080)

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -123,8 +123,14 @@
   [viewers x]
   (v/with-viewers viewers x))
 
+(def default-viewers
+  "Clerk's default viewers."
+  v/default-viewers)
+
 (defn get-default-viewers
-  "Gets Clerk's default viewers."
+  "Gets Clerk's current set of default viewers.
+
+  Use `(reset-viewers! :default ,,,)` to change them."
   []
   (v/get-default-viewers))
 
@@ -139,14 +145,17 @@
   [viewers select-fn->update-fn]
   (v/update-viewers viewers select-fn->update-fn))
 
-
 (defn reset-viewers!
-  "Resets the viewers associated with the current `*ns*` to `viewers`."
-  [viewers] (v/reset-viewers! *ns* viewers))
+  "Resets the viewers associated with the given `scope` to `viewers`.
+
+  When no `scope` is given, resets the viewers for the current namespace.
+  Passsing `:default` resets the global default viewers in Clerk."
+  ([viewers] (v/reset-viewers! viewers))
+  ([scope viewers] (v/reset-viewers! scope viewers)))
 
 
 (defn add-viewers!
-  "Adds `viewers` to the viewers associated with the current `*ns*`."
+  "Adds `viewers` to the viewers associated with the current namespace."
   [viewers] (v/add-viewers! viewers))
 
 

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -90,6 +90,24 @@
     (is (= :full
            (:nextjournal/width (v/apply-viewers (v/table {:nextjournal.clerk/width :full} {:a [1] :b [2] :c [3]})))))))
 
+(deftest datafy-scope
+  (is (= (ns-name *ns*)
+         (v/datafy-scope *ns*)
+         (v/datafy-scope (ns-name *ns*))))
+
+  (is (= :default (v/datafy-scope :default)))
+
+  (is (thrown? clojure.lang.ExceptionInfo (v/datafy-scope :default-2)))
+  (is (thrown? clojure.lang.ExceptionInfo (v/datafy-scope :foo))) )
+
+(deftest reset-viewers!
+  (testing "namespace scope"
+    (v/reset-viewers! (find-ns 'nextjournal.clerk.viewer-test) [])
+    (is (= [] (v/get-viewers (find-ns 'nextjournal.clerk.viewer-test)))))
+
+  (testing "symbol scope"
+    (v/reset-viewers! 'nextjournal.clerk.viewer-test [{:render-fn 'foo}])
+    (is (= [{:render-fn 'foo}] (v/get-viewers 'nextjournal.clerk.viewer-test)))))
 
 (def my-test-var [:h1 "hi"])
 


### PR DESCRIPTION
By exposing the two-arity version of `reset-viewers!` in the clerk namespace. Also support symbols representing namespaces as the scope.

Closes #342.