### PR TITLE
Improve deps caching in github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: '11.0.7'
+          cache: 'maven'
 
       - name: 🔧 Install clojure
         uses: DeLaGuardo/setup-clojure@master
@@ -26,14 +27,13 @@ jobs:
           bb run --prn -current-branch
 
       - name: 🗝 maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.m2
             ~/.gitlibs
-          key: ${{ runner.os }}-maven-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+            ~/.deps.clj
+          key: ${{ runner.os }}-maven-build-viewer-${{ hashFiles('deps.edn') }}
 
       - name: Build and upload viewer resources
         env:
@@ -85,15 +85,13 @@ jobs:
           bb: latest
 
       - name: 🗝 maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.m2
             ~/.gitlibs
             ~/.deps.clj
-          key: ${{ runner.os }}-maven-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          key: ${{ runner.os }}-maven-test-${{ hashFiles('deps.edn') }}
 
       - name: 🧪 Run tests
         run: bb test:clj :kaocha/reporter '[kaocha.report/documentation]'
@@ -118,14 +116,13 @@ jobs:
           bb: latest
 
       - name: 🗝 maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.m2
             ~/.gitlibs
-          key: ${{ runner.os }}-maven-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+            ~/.deps.clj
+          key: ${{ runner.os }}-maven-build-${{ hashFiles('deps.edn') }}
 
       - name: 🗝 Clerk Cache
         uses: actions/cache@v2
@@ -180,14 +177,13 @@ jobs:
           cli: '1.10.3.943'
 
       - name: 🗝 maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.m2
             ~/.gitlibs
-          key: ${{ runner.os }}-maven-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+            ~/.deps.clj
+          key: ${{ runner.os }}-maven-ssr-${{ hashFiles('deps.edn') }}
 
       - name: 🎨 Setup Tailwindcss
         run: yarn global add tailwindcss @tailwindcss/typography
@@ -250,14 +246,13 @@ jobs:
           bb: latest
 
       - name: 🗝 maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.m2
             ~/.gitlibs
-          key: ${{ runner.os }}-maven-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+            ~/.deps.clj
+          key: ${{ runner.os }}-maven-deploy-${{ hashFiles('deps.edn') }}
 
       - name: Install SSH key and start ssh-agent
         uses: webfactory/ssh-agent@v0.5.3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,6 +227,16 @@ jobs:
         with:
           bb: latest
 
+      - name: 🗝 maven cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-maven-ui-tests-${{ hashFiles('deps.edn') }}
+
+
       - name: Run Playwright tests against static assets
         run: |
           bb test:static-app ${{ github.sha }}


### PR DESCRIPTION
By using a separate cache per action / deps alias and using the hash of the `deps.edn` as a cache key to keep the cache from growing unbounded.