### PR TITLE
Simplify elision handling with continuation

### DIFF
--- a/notebooks/pagination.clj
+++ b/notebooks/pagination.clj
@@ -1,6 +1,7 @@
 ;; # Pagination
 (ns notebooks.pagination
-  (:require [babashka.fs :as fs]))
+  (:require [babashka.fs :as fs]
+            [nextjournal.clerk :as clerk]))
 
 #_(nextjournal.clerk/show! "notebooks/pagination.clj")
 
@@ -63,3 +64,12 @@
                     (for [x (range 1 5)]
                       {:id x :parent (dec x) :name (format "item-%d" x)}))]
   (flat->nested (-> (filter #(= (:parent %) nil) items) first) items))
+
+
+(clerk/with-viewer {} {::clerk/budget 5}
+  (reduce (fn [acc i] (vector i acc)) :fin (range 15 0 -1)))
+
+
+(clerk/html [:div
+             [:h3 "Nesting Images inside " [:span.font-mono "clerk/html"]]
+             (clerk/image "trees.png")])

--- a/notebooks/viewer_normalization.clj
+++ b/notebooks/viewer_normalization.clj
@@ -2,31 +2,31 @@
 (ns viewer-normalization
   (:require [nextjournal.clerk :as clerk]))
 
-(clerk/with-viewer '(fn [v] (v/html [:span "The answer is " v "."]))
+(clerk/with-viewer '(fn [v] [:span "The answer is " v "."])
   42)
 
-^{::clerk/viewer '#(v/html [:span "The answer is " % "."])}
+^{::clerk/viewer '#(vector :span "The answer is " % ".")}
 (do 42)
 
-^{::clerk/viewer {:render-fn '(fn [v] (v/html [:span "The answer is " v "."]))}}
+^{::clerk/viewer {:render-fn '(fn [v] [:span "The answer is " v "."])}}
 (do 42)
 
 
-(clerk/with-viewer {:render-fn '(fn [v] (v/html [:span "The answer is " v "."]))}
+(clerk/with-viewer {:render-fn '(fn [v] [:span "The answer is " v "."])}
   42)
 
-(clerk/with-viewer {:render-fn '(fn [v] (v/html [:span "The answer is " v "."])) :transform-fn (comp inc clerk/->value)}
+(clerk/with-viewer {:render-fn '(fn [v] [:span "The answer is " v "."]) :transform-fn (comp inc clerk/->value)}
   41)
 
-^{::clerk/viewer {:render-fn '#(v/html [:span "The answer is " % "."]) :transform-fn (comp inc clerk/->value)}}
+^{::clerk/viewer {:render-fn '#(vector :span "The answer is " % ".") :transform-fn (comp inc clerk/->value)}}
 (do 41)
 
-(clerk/with-viewers [{:pred (constantly true) :render-fn '(fn [v] (v/html [:span "The answer is " v "."])) :transform-fn (comp inc clerk/->value)}]
+(clerk/with-viewers [{:pred (constantly true) :render-fn '(fn [v] [:span "The answer is " v "."]) :transform-fn (comp inc clerk/->value)}]
   41)
 
-^{::clerk/viewer {:render-fn '#(v/html [:span "The answer is " % "."]) :transform-fn (comp inc clerk/->value)}}
+^{::clerk/viewer {:render-fn '#(vector :span "The answer is " % ".") :transform-fn (comp inc clerk/->value)}}
 (do 41)
 
 
-^{::clerk/viewers [{:pred (constantly true) :render-fn '(fn [v] (v/html [:span "The answer is " v "."])) :transform-fn (comp inc clerk/->value)}]}
+^{::clerk/viewers [{:pred (constantly true) :render-fn '(fn [v] [:span "The answer is " v "."]) :transform-fn (comp inc clerk/->value)}]}
 (do 41)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1453,14 +1453,16 @@
   "Returns a subset of a given `value`."
   ([x] (present x {}))
   ([x opts]
-   (-> (ensure-wrapped-with-viewers x)
-       (merge {:budget (->budget opts)
-               :!path->present-fn (atom {})
-               :path (:path opts [])}
-              (make-!budget-opts opts)
-              opts)
-       present*
-       assign-closing-parens)))
+   (let [opts' (cond-> opts
+                 (wrapped-value? x) (merge (->opts x)))]
+     (-> (ensure-wrapped-with-viewers x)
+         (merge {:budget (->budget opts')
+                 :!path->present-fn (atom {})
+                 :path (:path opts' [])}
+                (make-!budget-opts opts')
+                opts)
+         present*
+         assign-closing-parens))))
 
 (comment
   (present [\a \b])
@@ -1473,7 +1475,6 @@
   (present {:viewers [{:pred sequential? :render-fn pr-str}]} (range 100))
   (present (map vector (range)))
   (present (subs (slurp "/usr/share/dict/words") 0 1000))
-  #_:clj-kondo/ignore ;; remove when clj-kondo is released
   (present (plotly {:data [{:z [[1 2 3] [3 2 1]] :type "surface"}]}))
   (present [(with-viewer `html-viewer [:h1 "hi"])])
   (present (with-viewer `html-viewer [:ul (for [x (range 3)] [:li x])]))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1369,7 +1369,7 @@
     #_(prn :xs xs :type (type xs) :path path)
     (when (and !budget (not presented?))
       (swap! !budget #(max (dec %) 0)))
-    (-> (merge (->opts wrapped-value)
+    (-> (merge (->opts wrapped-value-applied)
                (when (empty? path) (select-keys wrapped-value [:present-elision-fn]))
                (with-viewer (->viewer wrapped-value-applied)
                  (cond presented?

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1346,9 +1346,9 @@
                            :nextjournal/keys [viewers]}]
   (when (empty? viewers)
     (throw (ex-info "cannot present* with empty viewers" {:wrapped-value wrapped-value})))
-  (when (and !path->present-fn)
+  (when !path->present-fn
     (swap! !path->present-fn assoc path (fn [fetch-opts] (present* (merge wrapped-value fetch-opts)))))
-  (let [{:as wrapped-value :nextjournal/keys [viewers presented?]} (apply-viewers* wrapped-value)
+  (let [{:as wrapped-value :nextjournal/keys [presented?]} (apply-viewers* wrapped-value)
         xs (->value wrapped-value)]
     #_(prn :xs xs :type (type xs) :path path)
     (when (and !budget (not presented?))

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -81,7 +81,7 @@
                                 (v/get-viewers ns result)
                                 (v/->value result))) ;; TODO understand why this unwrapping fixes lazy loaded table viewers
           present-fn (get-in (meta root-desc) [:path->present-fn (:path fetch-opts)])
-          desc (present-fn (assoc fetch-opts :!budget (atom 200)))] ;; TODO: parametrize budget
+          desc (present-fn fetch-opts)]
       (if (contains? desc :nextjournal/content-type)
         {:body (v/->value desc)
          :content-type (:nextjournal/content-type desc)}

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -77,10 +77,12 @@
     (throw (ex-info "namespace must be set" {:doc doc})))
   (if (contains? blob->result blob-id)
     (let [result (v/apply-viewer-unwrapping-var-from-def (blob->result blob-id))
-          desc (v/present (v/ensure-wrapped-with-viewers
-                           (v/get-viewers ns result)
-                           (v/->value result)) ;; TODO understand why this unwrapping fixes lazy loaded table viewers
-                          fetch-opts)]
+          root-desc (v/present (v/ensure-wrapped-with-viewers
+                                (v/get-viewers ns result)
+                                (v/->value result)) ;; TODO understand why this unwrapping fixes lazy loaded table viewers
+                               )
+          present-fn (get-in (meta root-desc) [:path->present-fn (:path fetch-opts)])
+          desc (present-fn fetch-opts)]
       (if (contains? desc :nextjournal/content-type)
         {:body (v/->value desc)
          :content-type (:nextjournal/content-type desc)}

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -79,10 +79,9 @@
     (let [result (v/apply-viewer-unwrapping-var-from-def (blob->result blob-id))
           root-desc (v/present (v/ensure-wrapped-with-viewers
                                 (v/get-viewers ns result)
-                                (v/->value result)) ;; TODO understand why this unwrapping fixes lazy loaded table viewers
-                               )
+                                (v/->value result))) ;; TODO understand why this unwrapping fixes lazy loaded table viewers
           present-fn (get-in (meta root-desc) [:path->present-fn (:path fetch-opts)])
-          desc (present-fn fetch-opts)]
+          desc (present-fn (assoc fetch-opts :!budget (atom 200)))] ;; TODO: parametrize budget
       (if (contains? desc :nextjournal/content-type)
         {:body (v/->value desc)
          :content-type (:nextjournal/content-type desc)}

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -80,8 +80,8 @@
           root-desc (v/present (v/ensure-wrapped-with-viewers
                                 (v/get-viewers ns result)
                                 (v/->value result))) ;; TODO understand why this unwrapping fixes lazy loaded table viewers
-          present-fn (get-in (meta root-desc) [:path->present-fn (:path fetch-opts)])
-          desc (present-fn fetch-opts)]
+          {:keys [present-elision-fn]} (meta root-desc)
+          desc (present-elision-fn fetch-opts)]
       (if (contains? desc :nextjournal/content-type)
         {:body (v/->value desc)
          :content-type (:nextjournal/content-type desc)}

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -56,26 +56,26 @@
 
   (testing "deep vector"
     (let [value (reduce (fn [acc _i] (vector acc)) :fin (range 30 0 -1))]
-      (is (= value (present+fetch {:budget 21} value)))))
+      (is (= value (present+fetch {:nextjournal/budget 21} value)))))
 
   (testing "deep vector with element before"
     (let [value (reduce (fn [acc i] (vector i acc)) :fin (range 15 0 -1))]
-      (is (= value (present+fetch {:budget 21} value)))))
+      (is (= value (present+fetch {:nextjournal/budget 21} value)))))
 
   (testing "deep vector with element after"
     (let [value (reduce (fn [acc i] (vector acc i)) :fin (range 20 0 -1))]
-      (is (= value (present+fetch {:budget 21} value)))))
+      (is (= value (present+fetch {:nextjournal/budget 21} value)))))
 
   (testing "deep vector with elements around"
     (let [value (reduce (fn [acc i] (vector i acc (inc i))) :fin (range 10 0 -1))]
-      (is (= value (present+fetch {:budget 21} value)))))
+      (is (= value (present+fetch {:nextjournal/budget 21} value)))))
 
   ;; TODO: fit table viewer into v/desc->values
   (testing "table"
     (let [value {:a (range 30) :b (range 30)}]
       (is (= (vec (vals (v/normalize-table-data value)))
              (present+fetch (v/table value))))))
-
+  
   (testing "resolving multiple elisions"))
 
 (deftest apply-viewers
@@ -178,7 +178,16 @@
 
       (let [presented (v/present (v/table {:col1 [1 2] :col2 '[a b]}))]
         (is (= {:num-cols 2 :number-col? #{0}} (:nextjournal/opts presented)))
-        (is (= 1 (count-opts presented)))))))
+        (is (= 1 (count-opts presented))))))
+
+  (testing "viewer opts are normalized"
+    (is (= (v/desc->values (v/present (range 10) {:nextjournal/budget 3}))
+           (v/desc->values (v/present (range 10) {:nextjournal.clerk/budget 3}))
+           (v/desc->values (v/present {:nextjournal/value (range 10) :nextjournal/budget 3}))
+           (v/desc->values (v/present {:nextjournal/value (range 10) :nextjournal.clerk/budget 3}))
+           (v/desc->values (v/present (v/with-viewer {} {:nextjournal.clerk/budget 3} (range 10))))
+           (v/desc->values (v/present {:nextjournal/budget 3, :nextjournal/value (range 10)}))
+           (v/desc->values (v/present {:nextjournal/budget 3, :nextjournal/value (range 10)}))))))
 
 (deftest assign-closing-parens
   (testing "closing parenthesis are moved to right-most children in the tree"

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -16,7 +16,7 @@
    (let [root-desc (v/present value opts)
          elision (v/find-elision root-desc)
          present-at (get-in (meta root-desc) [:path->present-fn (:path elision)])
-         more (present-at (assoc elision :!budget (atom (:budget opts 200))))]
+         more (present-at elision)]
      (v/desc->values (v/merge-presentations root-desc more elision)))))
 
 (deftest normalize-table-data

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -75,8 +75,10 @@
     (let [value {:a (range 30) :b (range 30)}]
       (is (= (vec (vals (v/normalize-table-data value)))
              (present+fetch (v/table value))))))
-  
-  (testing "resolving multiple elisions"))
+
+  (testing "resolving multiple elisions"
+    (let [value (reduce (fn [acc i] (vector i acc)) :fin (range 15 0 -1))]
+      (is (= value (v/desc->values (-> (v/present value {:nextjournal/budget 11}) resolve-elision resolve-elision)))))))
 
 (deftest apply-viewers
   (testing "selects number viewer"

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -18,9 +18,8 @@
         more (present-elision-fn elision)]
     (v/merge-presentations desc more elision)))
 
-(defn present+fetch
-  ([value] (present+fetch {} value))
-  ([opts value] (v/desc->values (resolve-elision (v/present value opts)))))
+(defn present+fetch [value]
+  (v/desc->values (resolve-elision (v/present value))))
 
 (deftest normalize-table-data
   (testing "works with sorted-map"
@@ -56,19 +55,19 @@
 
   (testing "deep vector"
     (let [value (reduce (fn [acc _i] (vector acc)) :fin (range 30 0 -1))]
-      (is (= value (present+fetch {:nextjournal/budget 21} value)))))
+      (is (= value (present+fetch {:nextjournal/budget 21 :nextjournal/value value})))))
 
   (testing "deep vector with element before"
     (let [value (reduce (fn [acc i] (vector i acc)) :fin (range 15 0 -1))]
-      (is (= value (present+fetch {:nextjournal/budget 21} value)))))
+      (is (= value (present+fetch {:nextjournal/budget 21 :nextjournal/value value})))))
 
   (testing "deep vector with element after"
     (let [value (reduce (fn [acc i] (vector acc i)) :fin (range 20 0 -1))]
-      (is (= value (present+fetch {:nextjournal/budget 21} value)))))
+      (is (= value (present+fetch {:nextjournal/budget 21 :nextjournal/value value})))))
 
   (testing "deep vector with elements around"
     (let [value (reduce (fn [acc i] (vector i acc (inc i))) :fin (range 10 0 -1))]
-      (is (= value (present+fetch {:nextjournal/budget 21} value)))))
+      (is (= value (present+fetch {:nextjournal/budget 21 :nextjournal/value value})))))
 
   ;; TODO: fit table viewer into v/desc->values
   (testing "table"
@@ -78,7 +77,7 @@
 
   (testing "resolving multiple elisions"
     (let [value (reduce (fn [acc i] (vector i acc)) :fin (range 15 0 -1))]
-      (is (= value (v/desc->values (-> (v/present value {:nextjournal/budget 11}) resolve-elision resolve-elision)))))))
+      (is (= value (v/desc->values (-> (v/present {:nextjournal/budget 11 :nextjournal/value value}) resolve-elision resolve-elision)))))))
 
 (deftest apply-viewers
   (testing "selects number viewer"
@@ -183,9 +182,7 @@
         (is (= 1 (count-opts presented))))))
 
   (testing "viewer opts are normalized"
-    (is (= (v/desc->values (v/present (range 10) {:nextjournal/budget 3}))
-           (v/desc->values (v/present (range 10) {:nextjournal.clerk/budget 3}))
-           (v/desc->values (v/present {:nextjournal/value (range 10) :nextjournal/budget 3}))
+    (is (= (v/desc->values (v/present {:nextjournal/value (range 10) :nextjournal/budget 3}))
            (v/desc->values (v/present {:nextjournal/value (range 10) :nextjournal.clerk/budget 3}))
            (v/desc->values (v/present (v/with-viewer {} {:nextjournal.clerk/budget 3} (range 10))))
            (v/desc->values (v/present {:nextjournal/budget 3, :nextjournal/value (range 10)}))

--- a/test/nextjournal/clerk/webserver_test.clj
+++ b/test/nextjournal/clerk/webserver_test.clj
@@ -6,7 +6,8 @@
 
 (deftest serve-blob
   (testing "lazy loading of simple range"
-    (let [doc (eval/eval-string "(range 100)")
+    (let [doc (let [doc (eval/eval-string "(range 100)")]
+                (with-meta doc (view/doc->viewer doc)))
           {:nextjournal/keys [presented fetch-opts]} (-> doc view/doc->viewer :nextjournal/value :blocks second :nextjournal/value)
           {:nextjournal/keys [value]} presented
           {elision-viewer :nextjournal/viewer elision-fetch-opts :nextjournal/value} (peek value)


### PR DESCRIPTION
Until now `present*` took a `:path` and `:current-path` argument would have a code path to descend into the nested data structure when resolving an elision. This drops this code path and uses a continuation function for a path instead.

We also add support for customizing the per-result budget using the `:nextjournal.clerk/budget` param and support using images inside `clerk/html`, fixing #118.

- [x] Update `:path->present-fn` when resolving elision to fix error when resolving multiple depth elisions
- [x] Fix lazy loading of multiple depth elisions by reusing presentation in `serve-blob`
- [x] Namespace `:budget` param