### PR TITLE
Tweaks to webserver websocket logic to allow for potential of serving clerk notebooks on a server 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,6 @@ jobs:
           bb: latest
           clj-kondo: latest
 
-      - name: Show branch name
-        run: |
-          bb run --prn -current-branch
-
       - name: 🗝 maven cache
         uses: actions/cache@v3
         with:

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -70,10 +70,11 @@
 (defn recompute!
   "Recomputes the currently visible doc, without parsing it."
   []
-  (binding [*ns* (:ns @webserver/!doc)]
-    (let [{:keys [result time-ms]} (eval/time-ms (eval/eval-analyzed-doc @webserver/!doc))]
-      (println (str "Clerk recomputed '" @!last-file "' in " time-ms "ms."))
-      (webserver/update-doc! result))))
+  (when-let [doc @webserver/!doc]
+    (binding [*ns* (:ns doc)]
+      (let [{:keys [result time-ms]} (eval/time-ms (eval/eval-analyzed-doc doc))]
+        (println (str "Clerk recomputed '" @!last-file "' in " time-ms "ms."))
+        (webserver/update-doc! result)))))
 
 #_(recompute!)
 

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -121,28 +121,6 @@
 
 #_(pr-str (read-msg "#viewer-eval (resolve 'clojure.core/inc)"))
 
-(defn watch-websocket-clients
-  "Sync external websocket client state into the clients that clerk tracks.
-
-  Allows these external clients to get clerk related websocket messages and broadcasts"
-  ([watched-atom send-fn] (watch-websocket-clients watched-atom send-fn identity))
-  ([watched-atom send-fn state-transform]
-   (add-watch watched-atom :connected-uids
-              (fn [_var-name _atom old-state new-state]
-                (let [new-state (state-transform new-state)
-                      old-state (state-transform old-state)]
-                (swap! !client-uid->send-fn
-                       (fn [clients] (merge
-                                       (apply dissoc
-                                              clients
-                                              (set/difference old-state new-state))
-                                       (into {}
-                                             (map (fn [uid] [uid send-fn]))
-                                             (set/difference new-state old-state))))))))))
-
-(defn unwatch-websocket-clients [watched-atom]
-  (remove-watch watched-atom :connected-uids))
-
 (defn msg->ns [{:keys [scope] :as message}]
   (cond
     scope

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -143,17 +143,17 @@
 (defn unwatch-websocket-clients [watched-atom]
   (remove-watch watched-atom :connected-uids))
 
-(defn msg->ns [{:keys [scope] :as _message}]
+(defn msg->ns [{:keys [scope] :as message}]
   (cond
-    (= scope (some-> @!doc :ns v/datafy-scope))
-    (:ns @!doc)
-
     scope
     (create-ns scope)
 
+    (:ns @!doc)
+    (:ns @!doc)
+
     :else
     (do
-      (println (str "No namespace scope found, falling back to `'user` ns"))
+      (println (str "No namespace scope found, falling back to `'user` ns: " message))
       (create-ns 'user))))
 
 (defn handle-eval [sender-ch-uid msg]

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -146,10 +146,10 @@
 (defn handle-eval [sender-ch-uid msg]
   (binding [*ns* (or (:ns @!doc)
                      (create-ns 'user))]
-    (let [send-fn (get @!client-uid->send-fn
-                       sender-ch-uid
-                       (constantly (throw (ex-info "Websocket channel not registered as a client"
-                                                   {:websocket-channel-uid sender-ch-uid :message msg}))))]
+    (let [send-fn (get @!client-uid->send-fn sender-ch-uid
+                       (fn [& _] (throw (ex-info "Channel not registered as websocket client"
+                                                 {:channel-uid sender-ch-uid
+                                                  :message msg}))))]
       (send-fn sender-ch-uid
                (merge {:type :eval-reply :eval-id (:eval-id msg)}
                       (try {:reply (eval (:form msg))}


### PR DESCRIPTION
- if `:scope` is provided in a websocket message received, use it for the `eval` `*ns*` instead of the global `!doc`'s namespace. This allows handling messages for notebooks that are served on a server and not using clerk's `show` (which sets the `!doc`)
- lift websocket handler logic into functions so users of clerk can call them directly as dispatchs for websocket communication. This means a server can do its own message encoding / handling and eventually call into clerk for the core eval/swap logic.
- also rename `!clients` to `!client->send-fn` and change it to a map from client connections to their send functions. Not needed right now but generalizes the send functionality so that other websocket libraries can also be used. I'm fine reverting this change if it feels premature.