### PR TITLE
Bump multiformats & cas-client deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: '1.10.3.943'
-          bb: '1.0.170'
+          bb: latest
           clj-kondo: latest
 
       - name: 🗝 maven cache
@@ -44,7 +44,7 @@ jobs:
       - name: 🔧 Install clojure
         uses: DeLaGuardo/setup-clojure@master
         with:
-          bb: '1.0.170'
+          bb: latest
           clj-kondo: latest
 
       - name: 🗝 maven cache
@@ -86,7 +86,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: '1.10.3.943'
-          bb: '1.0.170'
+          bb: latest
 
       - name: 🗝 maven cache
         uses: actions/cache@v3
@@ -117,7 +117,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: '1.10.3.943'
-          bb: '1.0.170'
+          bb: latest
 
       - name: 🗝 maven cache
         uses: actions/cache@v3
@@ -229,7 +229,7 @@ jobs:
       - name: 🔧 Install clojure
         uses: DeLaGuardo/setup-clojure@master
         with:
-          bb: '1.0.170'
+          bb: latest
 
       - name: 🗝 maven cache
         uses: actions/cache@v3
@@ -257,7 +257,7 @@ jobs:
       - name: 🔧 Install clojure
         uses: DeLaGuardo/setup-clojure@master
         with:
-          bb: '1.0.170'
+          bb: latest
 
       - name: 🗝 maven cache
         uses: actions/cache@v3

--- a/bb.edn
+++ b/bb.edn
@@ -1,7 +1,7 @@
 {:min-bb-version "0.9.159"
  :paths ["bb"]
  :deps {io.github.nextjournal/dejavu {:git/sha "4980e0cc18c9b09fb220874ace94ba6b57a749ca"}
-        io.github.nextjournal/cas-client {:git/sha "acef5e66687938f807d41f65b5ec0bfb4b4e9051"}}
+        io.github.nextjournal/cas-client {:git/sha "84ab35c3321c1e51a589fddbeee058aecd055bf8"}}
  :tasks
  {:requires
   ([tasks :as t]

--- a/bb.edn
+++ b/bb.edn
@@ -1,7 +1,7 @@
 {:min-bb-version "0.9.159"
  :paths ["bb"]
  :deps {io.github.nextjournal/dejavu {:git/sha "4980e0cc18c9b09fb220874ace94ba6b57a749ca"}
-        io.github.nextjournal/cas-client {:git/sha "a1199327f76ea1dc84d237fe2f32a669e4e94942"}}
+        io.github.nextjournal/cas-client {:git/sha "acef5e66687938f807d41f65b5ec0bfb4b4e9051"}}
  :tasks
  {:requires
   ([tasks :as t]

--- a/bb.edn
+++ b/bb.edn
@@ -1,7 +1,7 @@
 {:min-bb-version "0.9.159"
  :paths ["bb"]
  :deps {io.github.nextjournal/dejavu {:git/sha "4980e0cc18c9b09fb220874ace94ba6b57a749ca"}
-        io.github.nextjournal/cas-client {:git/sha "4eefd77dd981b908591d91d518ba3f43bd8c361e"}}
+        io.github.nextjournal/cas-client {:git/sha "a1199327f76ea1dc84d237fe2f32a669e4e94942"}}
  :tasks
  {:requires
   ([tasks :as t]

--- a/deps.edn
+++ b/deps.edn
@@ -41,7 +41,7 @@
                               binaryage/devtools {:mvn/version "1.0.3"}
                               cider/cider-nrepl {:mvn/version "0.29.0"}
                               com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.0.3"}
-                              io.github.nextjournal/cas-client {:git/sha "4eefd77dd981b908591d91d518ba3f43bd8c361e"
+                              io.github.nextjournal/cas-client {:git/sha "a1199327f76ea1dc84d237fe2f32a669e4e94942"
                                                                 :exclusions [mvxcvi/multiformats]}
                               org.slf4j/slf4j-nop {:mvn/version "1.7.36"}
                               org.babashka/cli {:mvn/version "0.5.40"}}
@@ -73,7 +73,7 @@
 
            :build {:deps {io.github.nextjournal/clerk {:local/root "."}
                           ;; :exclusions needed until https://github.com/greglook/clj-multiformats/pull/2 is merged
-                          io.github.nextjournal/cas-client {:git/sha "4eefd77dd981b908591d91d518ba3f43bd8c361e"
+                          io.github.nextjournal/cas-client {:git/sha "a1199327f76ea1dc84d237fe2f32a669e4e94942"
                                                             :exclusions [mvxcvi/multiformats]}
                           io.github.clojure/tools.build {:git/tag "v0.6.1" :git/sha "515b334"}
                           io.github.slipset/deps-deploy {:git/sha "b4359c5d67ca002d9ed0c4b41b710d7e5a82e3bf"}}

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,7 @@
 
         com.taoensso/nippy {:mvn/version "3.2.0"}
 
-        mvxcvi/multiformats {:mvn/version "0.3.103"}
+        mvxcvi/multiformats {:mvn/version "0.3.107"}
         com.pngencoder/pngencoder {:mvn/version "0.13.1"}
 
         http-kit/http-kit {:mvn/version "2.6.0"}
@@ -41,7 +41,7 @@
                               binaryage/devtools {:mvn/version "1.0.3"}
                               cider/cider-nrepl {:mvn/version "0.29.0"}
                               com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.0.3"}
-                              io.github.nextjournal/cas-client {:git/sha "acef5e66687938f807d41f65b5ec0bfb4b4e9051"}
+                              io.github.nextjournal/cas-client {:git/sha "84ab35c3321c1e51a589fddbeee058aecd055bf8"}
                               org.slf4j/slf4j-nop {:mvn/version "1.7.36"}
                               org.babashka/cli {:mvn/version "0.5.40"}}
                  :extra-paths ["dev" "notebooks"]
@@ -71,8 +71,7 @@
                                io.github.nextjournal/clerk-slideshow {:git/sha "5fe197ca0c8f28128379849dc677cd718be71524"}}}
 
            :build {:deps {io.github.nextjournal/clerk {:local/root "."}
-                          ;; :exclusions needed until https://github.com/greglook/clj-multiformats/pull/2 is merged
-                          io.github.nextjournal/cas-client {:git/sha "acef5e66687938f807d41f65b5ec0bfb4b4e9051"}
+                          io.github.nextjournal/cas-client {:git/sha "84ab35c3321c1e51a589fddbeee058aecd055bf8"}
                           io.github.clojure/tools.build {:git/tag "v0.6.1" :git/sha "515b334"}
                           io.github.slipset/deps-deploy {:git/sha "b4359c5d67ca002d9ed0c4b41b710d7e5a82e3bf"}}
                    :extra-paths ["bb" "src" "resources"] ;; for loading lookup-url in build

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,7 @@
 
         com.taoensso/nippy {:mvn/version "3.2.0"}
 
-        mvxcvi/multiformats {:mvn/version "0.2.1"}
+        mvxcvi/multiformats {:mvn/version "0.3.103"}
         com.pngencoder/pngencoder {:mvn/version "0.13.1"}
 
         http-kit/http-kit {:mvn/version "2.6.0"}
@@ -41,8 +41,7 @@
                               binaryage/devtools {:mvn/version "1.0.3"}
                               cider/cider-nrepl {:mvn/version "0.29.0"}
                               com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.0.3"}
-                              io.github.nextjournal/cas-client {:git/sha "a1199327f76ea1dc84d237fe2f32a669e4e94942"
-                                                                :exclusions [mvxcvi/multiformats]}
+                              io.github.nextjournal/cas-client {:git/sha "acef5e66687938f807d41f65b5ec0bfb4b4e9051"}
                               org.slf4j/slf4j-nop {:mvn/version "1.7.36"}
                               org.babashka/cli {:mvn/version "0.5.40"}}
                  :extra-paths ["dev" "notebooks"]
@@ -73,8 +72,7 @@
 
            :build {:deps {io.github.nextjournal/clerk {:local/root "."}
                           ;; :exclusions needed until https://github.com/greglook/clj-multiformats/pull/2 is merged
-                          io.github.nextjournal/cas-client {:git/sha "a1199327f76ea1dc84d237fe2f32a669e4e94942"
-                                                            :exclusions [mvxcvi/multiformats]}
+                          io.github.nextjournal/cas-client {:git/sha "acef5e66687938f807d41f65b5ec0bfb4b4e9051"}
                           io.github.clojure/tools.build {:git/tag "v0.6.1" :git/sha "515b334"}
                           io.github.slipset/deps-deploy {:git/sha "b4359c5d67ca002d9ed0c4b41b710d7e5a82e3bf"}}
                    :extra-paths ["bb" "src" "resources"] ;; for loading lookup-url in build


### PR DESCRIPTION
Also allows us to drop the exclusions since multiformats from Clojars is now babashka compatible.