### PR TITLE
Show execution progress

### DIFF
--- a/notebooks/exec_status.clj
+++ b/notebooks/exec_status.clj
@@ -4,17 +4,14 @@
 
 (def progress-viewer
   {:pred (every-pred map? #(contains? % :progress))
-   :render-fn '(fn exec-status [{:keys [progress status]}]
-                 [:div.w-full.bg-purple-200 {:class "h-0.5"}
-                  [:div.bg-purple-600 {:class "h-0.5" :style {:width (str (* progress 100) "%")}}]
-                  [:div.absolute.text-purple-600.text-xs.font-sans {:style {:font-size "0.5rem"}} status]])
+   :render-fn 'nextjournal.clerk.render/exec-status
    :transform-fn (fn [wrapped-value]
                    (-> wrapped-value
                        clerk/mark-presented
                        (assoc :nextjournal/width :full)))})
 
-(def first-sleepy-cell
-  (Thread/sleep (+ 2003 @!rand)))
+#_(def first-sleepy-cell
+    (Thread/sleep (+ 2003 @!rand)))
 
 (clerk/add-viewers! [progress-viewer])
 
@@ -24,11 +21,12 @@
 
 {:progress 0.55 :status "Evaluating…"}
 
+{:progress 0.95 :status "Presenting…"}
+
 (defonce !rand
   (atom 0))
 
 ^::clerk/no-cache (reset! !rand (rand-int 100))
-
 (Thread/sleep (+ 2000 @!rand))
 
 (def sleepy-cell

--- a/notebooks/exec_status.clj
+++ b/notebooks/exec_status.clj
@@ -1,0 +1,18 @@
+;; # 💈 Execution Status
+(ns exec-status
+  (:require [nextjournal.clerk :as clerk]))
+
+(defn exec-status [{:keys [progress status]}]
+  [:div.w-full.bg-purple-200 {:class "h-0.5"}
+   [:div.bg-purple-600 {:class "h-0.5" :style {:width (str (* progress 100) "%")}}]
+   [:div.absolute.text-purple-600.text-xs.font-sans {:style {:font-size "0.5rem"}} status]])
+
+
+^{::clerk/width :full ::clerk/viewer clerk/html}
+(exec-status {:progress 0 :status "Parsing…"})
+
+^{::clerk/width :full ::clerk/viewer clerk/html}
+(exec-status {:progress 0.15 :status "Analyzing…"})
+
+^{::clerk/width :full ::clerk/viewer clerk/html}
+(exec-status {:progress 0.55 :status "Evaluating…"})

--- a/notebooks/exec_status.clj
+++ b/notebooks/exec_status.clj
@@ -4,7 +4,10 @@
 
 (def progress-viewer
   {:pred (every-pred map? #(contains? % :progress))
-   :render-fn 'nextjournal.clerk.render/exec-status
+   :render-fn '(fn exec-status [{:keys [progress status]}]
+                 [:div.w-full.bg-purple-200 {:class "h-0.5"}
+                  [:div.bg-purple-600 {:class "h-0.5" :style {:width (str (* progress 100) "%")}}]
+                  [:div.absolute.text-purple-600.text-xs.font-sans {:style {:font-size "0.5rem"}} status]])
    :transform-fn (fn [wrapped-value]
                    (-> wrapped-value
                        clerk/mark-presented
@@ -17,3 +20,6 @@
 {:progress 0.15 :status "Analyzing…"}
 
 {:progress 0.55 :status "Evaluating…"}
+
+(do
+  (Thread/sleep 1000))

--- a/notebooks/exec_status.clj
+++ b/notebooks/exec_status.clj
@@ -1,5 +1,6 @@
 ;; # 💈 Execution Status
 (ns exec-status
+  {:nextjournal.clerk/toc true}
   (:require [nextjournal.clerk :as clerk]))
 
 ;; To see what's going on while waiting for a long-running

--- a/notebooks/exec_status.clj
+++ b/notebooks/exec_status.clj
@@ -13,6 +13,9 @@
                        clerk/mark-presented
                        (assoc :nextjournal/width :full)))})
 
+(def first-sleepy-cell
+  (Thread/sleep (+ 2003 @!rand)))
+
 (clerk/add-viewers! [progress-viewer])
 
 {:progress 0 :status "Parsing…"}
@@ -21,5 +24,17 @@
 
 {:progress 0.55 :status "Evaluating…"}
 
-(do
-  (Thread/sleep 1000))
+(defonce !rand
+  (atom 0))
+
+^::clerk/no-cache (reset! !rand (rand-int 100))
+
+(Thread/sleep (+ 2000 @!rand))
+
+(def sleepy-cell
+  (Thread/sleep (+ 2001 @!rand)))
+
+(Thread/sleep (+ 2002 @!rand))
+
+(def sleepy-cell-2
+  (Thread/sleep (+ 2003 @!rand)))

--- a/notebooks/exec_status.clj
+++ b/notebooks/exec_status.clj
@@ -2,17 +2,18 @@
 (ns exec-status
   (:require [nextjournal.clerk :as clerk]))
 
-(defn exec-status [{:keys [progress status]}]
-  [:div.w-full.bg-purple-200 {:class "h-0.5"}
-   [:div.bg-purple-600 {:class "h-0.5" :style {:width (str (* progress 100) "%")}}]
-   [:div.absolute.text-purple-600.text-xs.font-sans {:style {:font-size "0.5rem"}} status]])
+(def progress-viewer
+  {:pred (every-pred map? #(contains? % :progress))
+   :render-fn 'nextjournal.clerk.render/exec-status
+   :transform-fn (fn [wrapped-value]
+                   (-> wrapped-value
+                       clerk/mark-presented
+                       (assoc :nextjournal/width :full)))})
 
+(clerk/add-viewers! [progress-viewer])
 
-^{::clerk/width :full ::clerk/viewer clerk/html}
-(exec-status {:progress 0 :status "Parsing…"})
+{:progress 0 :status "Parsing…"}
 
-^{::clerk/width :full ::clerk/viewer clerk/html}
-(exec-status {:progress 0.15 :status "Analyzing…"})
+{:progress 0.15 :status "Analyzing…"}
 
-^{::clerk/width :full ::clerk/viewer clerk/html}
-(exec-status {:progress 0.55 :status "Evaluating…"})
+{:progress 0.55 :status "Evaluating…"}

--- a/notebooks/exec_status.clj
+++ b/notebooks/exec_status.clj
@@ -2,6 +2,11 @@
 (ns exec-status
   (:require [nextjournal.clerk :as clerk]))
 
+;; To see what's going on while waiting for a long-running
+;; computation, Clerk will now show an execution status bar on the
+;; top. For named cells (defining a var) it will show the name of the
+;; var, for anonymous expressions, a preview of the form.
+
 (def progress-viewer
   {:pred (every-pred map? #(contains? % :progress))
    :render-fn 'nextjournal.clerk.render/exec-status

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -19,7 +19,6 @@
 (defonce ^:private !last-file (atom nil))
 (defonce ^:private !watcher (atom nil))
 
-
 (defn show!
   "Evaluates the Clojure source in `file-or-ns` and makes Clerk show it in the browser.
 
@@ -35,6 +34,7 @@
   (if config/*in-clerk*
     ::ignored
     (try
+      (webserver/send-status! {:progress 0 :status "Parsing…"})
       (let [file (cond
                    (nil? file-or-ns)
                    (throw (ex-info (str "`nextjournal.clerk/show!` cannot show `nil`.")

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -34,7 +34,7 @@
   (if config/*in-clerk*
     ::ignored
     (try
-      (webserver/send-status! {:progress 0 :status "Parsing…"})
+      (webserver/set-status! {:progress 0 :status "Parsing…"})
       (let [file (cond
                    (nil? file-or-ns)
                    (throw (ex-info (str "`nextjournal.clerk/show!` cannot show `nil`.")
@@ -55,7 +55,7 @@
                                        {:file-or-ns file-or-ns}))))
             _ (reset! !last-file file)
             {:keys [blob->result]} @webserver/!doc
-            {:keys [result time-ms]} (eval/time-ms (eval/+eval-results blob->result (assoc doc :send-status-fn webserver/send-status!)))]
+            {:keys [result time-ms]} (eval/time-ms (eval/+eval-results blob->result (assoc doc :set-status-fn webserver/set-status!)))]
         (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
         (webserver/update-doc! result))
       (catch Exception e

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -63,6 +63,7 @@
         (throw e)))))
 
 #_(show! "notebooks/exec_status.clj")
+#_(clear-cache!)
 
 #_(show! 'nextjournal.clerk.tap)
 #_(show! (do (require 'clojure.inspector) (find-ns 'clojure.inspector)))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -55,12 +55,14 @@
                                        {:file-or-ns file-or-ns}))))
             _ (reset! !last-file file)
             {:keys [blob->result]} @webserver/!doc
-            {:keys [result time-ms]} (eval/time-ms (eval/+eval-results blob->result doc))]
+            {:keys [result time-ms]} (eval/time-ms (eval/+eval-results blob->result (assoc doc :send-status-fn webserver/send-status!)))]
         (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
         (webserver/update-doc! result))
       (catch Exception e
         (webserver/show-error! e)
         (throw e)))))
+
+#_(show! "notebooks/exec_status.clj")
 
 #_(show! 'nextjournal.clerk.tap)
 #_(show! (do (require 'clojure.inspector) (find-ns 'clojure.inspector)))

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -23,6 +23,7 @@
          "docs"
          "hello"
          "how_clerk_works"
+         "exec_status"
          "eval_cljs"
          "example"
          "hiding_clerk_metadata"

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -9,6 +9,7 @@
             [nextjournal.clerk.config :as config]
             [nextjournal.clerk.parser :as parser]
             [nextjournal.clerk.viewer :as v]
+            [nextjournal.clerk.webserver :as webserver]
             [taoensso.nippy :as nippy])
   (:import (java.awt.image BufferedImage)
            (javax.imageio ImageIO)))
@@ -197,6 +198,7 @@
 #_(blob->result @nextjournal.clerk.webserver/!doc)
 
 (defn eval-analyzed-doc [{:as analyzed-doc :keys [->hash blocks]}]
+  (webserver/send-status! {:progress 0.35 :status "Evaluating…"})
   (let [deref-forms (into #{} (filter analyzer/deref?) (keys ->hash))
         {:as evaluated-doc :keys [blob-ids]}
         (reduce (fn [state cell]
@@ -217,6 +219,7 @@
 (defn +eval-results
   "Evaluates the given `parsed-doc` using the `in-memory-cache` and augments it with the results."
   [in-memory-cache parsed-doc]
+  (webserver/send-status! {:progress 0.10 :status "Analyzing…"})
   (let [{:as analyzed-doc :keys [ns]} (analyzer/build-graph
                                        (assoc parsed-doc :blob->result in-memory-cache))]
     (binding [*ns* ns]

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -240,7 +240,7 @@
 (defn +eval-results
   "Evaluates the given `parsed-doc` using the `in-memory-cache` and augments it with the results."
   [in-memory-cache {:as parsed-doc :keys [set-status-fn]}]
-  (some-> set-status-fn {:progress 0.10 :status "Analyzing…"})
+  (when set-status-fn (set-status-fn {:progress 0.10 :status "Analyzing…"}))
   (let [{:as analyzed-doc :keys [ns]} (analyzer/build-graph
                                        (assoc parsed-doc :blob->result in-memory-cache))]
     (binding [*ns* ns]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -136,9 +136,11 @@
      [inspect-presented x]]))
 
 (defn exec-status [{:keys [progress status]}]
-  [:div.w-full.bg-purple-200.dark:bg-purple-900 {:class "h-0.5"}
+  [:div.fixed.w-full.bg-purple-200.dark:bg-purple-900.rounded.z-20 {:class "h-0.5"}
    [:div.bg-purple-600.dark:bg-purple-400 {:class "h-0.5" :style {:width (str (* progress 100) "%")}}]
-   [:div.absolute.text-purple-600.dark:text-purple-400.text-xs.font-sans.ml-2 {:style {:font-size "0.5rem"}} status]])
+   [:div.absolute.text-purple-600.dark:text-white.text-xs.font-sans.ml-1.bg-white.dark:bg-purple-900.rounded-full.shadow.z-20.font-bold.px-2.border.border-slate-300.dark:border-purple-400
+    {:style {:font-size "0.5rem"} :class "left-[35px] md:left-0 mt-[7px] md:mt-1"}
+    status]])
 
 (defn render-notebook [{:as _doc xs :blocks :keys [bundle? css-class sidenotes? toc toc-visibility]}]
   (r/with-let [local-storage-key "clerk-navbar"
@@ -586,10 +588,10 @@
 
 (defn root []
   [:<>
-   [:div.fixed.w-full
+   [inspect-presented @!doc]
+   [:div.fixed.w-full.z-20.top-0.left-0.w-full
     (when-let [status (:status @!doc)]
       [exec-status status])]
-   [inspect-presented @!doc]
    (when @!error
      [:div.fixed.top-0.left-0.w-full.h-full
       [inspect-presented @!error]])])

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -136,7 +136,7 @@
      [inspect-presented x]]))
 
 (defn exec-status [{:keys [progress status]}]
-  [:div.fixed.w-full.bg-purple-200.dark:bg-purple-900.rounded.z-20 {:class "h-0.5"}
+  [:div.w-full.bg-purple-200.dark:bg-purple-900.rounded.z-20 {:class "h-0.5"}
    [:div.bg-purple-600.dark:bg-purple-400 {:class "h-0.5" :style {:width (str (* progress 100) "%")}}]
    [:div.absolute.text-purple-600.dark:text-white.text-xs.font-sans.ml-1.bg-white.dark:bg-purple-900.rounded-full.shadow.z-20.font-bold.px-2.border.border-slate-300.dark:border-purple-400
     {:style {:font-size "0.5rem"} :class "left-[35px] md:left-0 mt-[7px] md:mt-1"}

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -546,7 +546,6 @@
     [:span.cmt-meta tag] (when space? nbsp) value]))
 
 (defonce !doc (ratom/atom nil))
-(defonce !status (ratom/atom nil))
 (defonce !error (ratom/atom nil))
 (defonce !viewers viewer/!viewers)
 
@@ -588,8 +587,8 @@
 (defn root []
   [:<>
    [:div.fixed.w-full
-    (when @!status
-      [exec-status @!status])]
+    (when-let [status (:status @!doc)]
+      [exec-status status])]
    [inspect-presented @!doc]
    (when @!error
      [:div.fixed.top-0.left-0.w-full.h-full
@@ -654,7 +653,6 @@
   (when (remount? doc)
     (swap! !eval-counter inc))
   (reset! !error error)
-  (reset! !status nil)
   (when-let [title (and (exists? js/document) (-> doc viewer/->value :title))]
     (set! (.-title js/document) title)))
 
@@ -663,7 +661,6 @@
 
 (defn patch-state! [{:keys [patch]}]
   (reset! !error nil)
-  (reset! !status nil)
   (if (remount? patch)
     (do (swap! !doc #(re-eval-viewer-fns (apply-patch % patch)))
         ;; TODO: figure out why it doesn't work without `js/setTimeout`
@@ -687,15 +684,10 @@
               error (reject error)))
     (js/console.warn :process-eval-reply!/not-found :eval-id eval-id :keys (keys @!pending-clerk-eval-replies))))
 
-(defn set-status! [{:keys [status]}]
-  (reset! !error nil)
-  (reset! !status status))
-
 (defn ^:export dispatch [{:as msg :keys [type]}]
   (let [dispatch-fn (get {:patch-state! patch-state!
                           :set-state! set-state!
-                          :eval-reply process-eval-reply!
-                          :set-status! set-status!}
+                          :eval-reply process-eval-reply!}
                          type
                          (fn [_]
                            (js/console.warn (str "no on-message dispatch for type `" type "`"))))]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -688,6 +688,7 @@
     (js/console.warn :process-eval-reply!/not-found :eval-id eval-id :keys (keys @!pending-clerk-eval-replies))))
 
 (defn set-status! [{:keys [status]}]
+  (reset! !error nil)
   (reset! !status status))
 
 (defn ^:export dispatch [{:as msg :keys [type]}]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -136,9 +136,9 @@
      [inspect-presented x]]))
 
 (defn exec-status [{:keys [progress status]}]
-  [:div.w-full.bg-purple-200 {:class "h-0.5"}
-   [:div.bg-purple-600 {:class "h-0.5" :style {:width (str (* progress 100) "%")}}]
-   [:div.absolute.text-purple-600.text-xs.font-sans {:style {:font-size "0.5rem"}} status]])
+  [:div.w-full.bg-purple-200.dark:bg-purple-900 {:class "h-0.5"}
+   [:div.bg-purple-600.dark:bg-purple-400 {:class "h-0.5" :style {:width (str (* progress 100) "%")}}]
+   [:div.absolute.text-purple-600.dark:text-purple-400.text-xs.font-sans.ml-2 {:style {:font-size "0.5rem"}} status]])
 
 (defn render-notebook [{:as _doc xs :blocks :keys [bundle? css-class sidenotes? toc toc-visibility]}]
   (r/with-let [local-storage-key "clerk-navbar"

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -135,6 +135,11 @@
                         "w-full max-w-prose px-8")]))}
      [inspect-presented x]]))
 
+(defn exec-status [{:keys [progress status]}]
+  [:div.w-full.bg-purple-200 {:class "h-0.5"}
+   [:div.bg-purple-600 {:class "h-0.5" :style {:width (str (* progress 100) "%")}}]
+   [:div.absolute.text-purple-600.text-xs.font-sans {:style {:font-size "0.5rem"}} status]])
+
 (defn render-notebook [{:as _doc xs :blocks :keys [bundle? css-class sidenotes? toc toc-visibility]}]
   (r/with-let [local-storage-key "clerk-navbar"
                navbar-width 220

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -45,6 +45,10 @@
 
 #_(broadcast! [{:random (rand-int 10000) :range (range 100)}])
 
+(defn send-status! [status]
+  (doseq [ch @!clients]
+    (httpkit/send! ch (v/->edn {:type :set-status! :status status}))))
+
 (defn update-if [m k f]
   (if (k m)
     (update m k f)

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -189,7 +189,7 @@
 #_(update-doc! (help-doc))
 
 (defn set-status! [status]
-  (swap! !doc vary-meta assoc :status status)
+  (swap! !doc (fn [doc] (vary-meta (or doc (help-doc)) assoc :status status)))
   ;; avoid editscript diff but use manual patch to just replace `:status` in doc
   (broadcast! {:type :patch-state! :patch [[[:status] :r status]]}))
 


### PR DESCRIPTION
To see what's going on while waiting for a long-running computation, Clerk will now show an execution status bar on the top. For named cells (defining a var) it will show the name of the var, for anonymous expressions, a preview of the form.

The progress indicator currently shows a fixed amount for parsing, analysis and evaluating. Evaluation progress is divided per cell.

<img width="1240" alt="Screen Shot 2023-03-09 at 10 42 01" src="https://user-images.githubusercontent.com/1187/223893548-f6d84ff2-72e6-47bb-a664-f95f75fa6aab.png">

Closes #380.