### PR TITLE
Fragments

### DIFF
--- a/notebooks/fragments.clj
+++ b/notebooks/fragments.clj
@@ -1,0 +1,71 @@
+;; # 🚰 Tap Inspector via Fragments
+;; Using fragments to implement a tap viewer
+^{:nextjournal.clerk/visibility {:code :hide}}
+(ns fragments
+  {:nextjournal.clerk/visibility {:code :hide :result :hide}
+   :nextjournal.clerk/no-cache true}
+  (:require [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.viewer :as v])
+  (:import (java.time Instant LocalTime ZoneId)))
+
+(defn inst->local-time-str [inst] (str (LocalTime/ofInstant inst (ZoneId/systemDefault))))
+
+(def switch-view
+  (assoc v/viewer-eval-viewer
+         :render-fn
+         '(fn [!view]
+            (let [choices [:stream :latest]]
+              [:div.flex.justify-between.items-center
+               (into [:div.flex.items-center.font-sans.text-xs.mb-3 [:span.text-slate-500.mr-2 "View-as:"]]
+                     (map (fn [choice]
+                            [:button.px-3.py-1.font-medium.hover:bg-indigo-50.rounded-full.hover:text-indigo-600.transition
+                             {:class (if (= @!view choice) "bg-indigo-100 text-indigo-600" "text-slate-500")
+                              :on-click #(reset! !view choice)}
+                             choice]) choices))
+               [:button.text-xs.rounded-full.px-3.py-1.border-2.font-sans.hover:bg-slate-100.cursor-pointer
+                {:on-click #(nextjournal.clerk.render/clerk-eval `(reset-taps!))} "Clear"]]))))
+
+^{::clerk/sync true ::clerk/viewer switch-view ::clerk/visibility {:result :show}}
+(defonce !view (atom :stream))
+
+(defonce !taps (atom [(clerk/html {::clerk/width :wide} [:div.w-full.border-2.border-amber-500])
+                      (clerk/plotly {::clerk/width :full} {:data [{:y [3 1 2]}]})]))
+
+(defn reset-taps! []
+  (reset! !taps [])
+  (clerk/recompute!))
+
+(defn tapped [x]
+  (swap! !taps conj {:val x :tapped-at (Instant/now) :key (str (gensym))})
+  (clerk/recompute!))
+
+(defonce tap-setup (add-tap (fn [x] ((resolve `tapped) x))))
+
+(def tap-viewer
+  {:transform-fn
+   (comp v/mark-presented
+         #(merge % (-> % :nextjournal/value :val v/->opts))
+         (clerk/update-val update :val v/present)
+         (clerk/update-val update :tapped-at inst->local-time-str)
+         #(assoc % :nextjournal/viewer
+                 {:render-fn '(fn [{:keys [val key tapped-at]} opts]
+                                (js/console.log :key key)
+                                (with-meta
+                                  [:div.border-t.relative.py-3.mt-5
+                                   [:span.absolute.rounded-full.px-2.bg-gray-300.font-mono.top-0
+                                    {:class "left-1/2 -translate-x-1/2 -translate-y-1/2 py-[1px] text-[9px]"} tapped-at]
+                                   [:div.overflow-x-auto [nextjournal.clerk.render/inspect-presented val]]]
+                                  {:key key}))}))})
+
+^{::clerk/visibility {:result :show}}
+(clerk/fragment (map (partial clerk/with-viewer tap-viewer)
+                     (cond->> (reverse @!taps) (= :latest @!view) (take 1))))
+
+(comment
+  (doseq [t @@#'clojure.core/tapset] (remove-tap t))
+  (tap> 1)
+  (tap> (clerk/html  {::clerk/width :full} [:h1.w-full.border-2.border-amber-500.bg-amber-500.h-10]))
+  (tap> (clerk/table {::clerk/width :full} [[1 2] [3 4]]))
+  (tap> (clerk/plotly {::clerk/width :full} {:data [{:y [3 1 2]}]}))
+  (tap> (clerk/html {::clerk/width :full} [:h1 "Fin. 👋"]))
+  (reset-taps!))

--- a/notebooks/fragments.clj
+++ b/notebooks/fragments.clj
@@ -1,70 +1,10 @@
-;; # 🚰 Tap Inspector via Fragments
-^{:nextjournal.clerk/visibility {:code :hide}}
+;; # 🧩Fragments
 (ns fragments
-  {:nextjournal.clerk/visibility {:code :hide :result :hide}
-   :nextjournal.clerk/no-cache true}
-  (:require [nextjournal.clerk :as clerk]
-            [nextjournal.clerk.viewer :as v])
-  (:import (java.time Instant LocalTime ZoneId)))
+  (:require [nextjournal.clerk :as clerk]))
 
-(defn inst->local-time-str [inst] (str (LocalTime/ofInstant inst (ZoneId/systemDefault))))
-(defn timestamped [x] {:val x :tapped-at (Instant/now) :key (str (gensym))})
+;; With `clerk/fragment` it's possible to embed a sequence of values into the document as if they were results of individual cells.
 
-(def switch-view
-  (assoc v/viewer-eval-viewer
-         :render-fn
-         '(fn [!view]
-            (let [choices [:stream :latest]]
-              [:div.flex.justify-between.items-center
-               (into [:div.flex.items-center.font-sans.text-xs.mb-3 [:span.text-slate-500.mr-2 "View-as:"]]
-                     (map (fn [choice]
-                            [:button.px-3.py-1.font-medium.hover:bg-indigo-50.rounded-full.hover:text-indigo-600.transition
-                             {:class (if (= @!view choice) "bg-indigo-100 text-indigo-600" "text-slate-500")
-                              :on-click #(reset! !view choice)}
-                             choice]) choices))
-               [:button.text-xs.rounded-full.px-3.py-1.border-2.font-sans.hover:bg-slate-100.cursor-pointer
-                {:on-click #(nextjournal.clerk.render/clerk-eval `(reset-taps!))} "Clear"]]))))
-
-^{::clerk/sync true ::clerk/viewer switch-view ::clerk/visibility {:result :show}}
-(defonce !view (atom :stream))
-
-
-(defonce !taps (atom (mapv timestamped
-                           [(clerk/html {::clerk/width :wide} [:h1.w-full.border-2.border-amber-500.bg-amber-500.h-10])
-                            (clerk/plotly {::clerk/width :full} {:data [{:y [3 1 2]}]})])))
-
-(defn reset-taps! []
-  (reset! !taps [])
-  (clerk/recompute!))
-
-(defn tapped [x]
-  (swap! !taps conj (timestamped x))
-  (clerk/recompute!))
-
-(defonce tap-setup (add-tap (fn [x] ((resolve `tapped) x))))
-
-(def tap-separator
-  {:render-fn '(fn [{:keys [tapped-at key]} opts]
-                 (with-meta
-                   [:div.border-t.relative.py-3.mt-2
-                    [:span.absolute.rounded-full.px-2.bg-gray-300.font-mono.top-0
-                     {:class "left-1/2 -translate-x-1/2 -translate-y-1/2 py-[1px] text-[9px]"} tapped-at]]
-                   {:key key}))
-   :transform-fn (comp clerk/mark-presented (clerk/update-val update :tapped-at inst->local-time-str))})
-
-^{::clerk/visibility {:result :show}}
-(clerk/fragment (mapcat (fn [{:as x :keys [val]}]
-                          [(clerk/with-viewer tap-separator
-                             {::clerk/css-class [:w-full :max-w-prose]}
-                             (dissoc x :val))
-                           val])
-                        (cond->> (reverse @!taps) (= :latest @!view) (take 1))))
-
-(comment
-  (doseq [t @@#'clojure.core/tapset] (remove-tap t))
-  (tap> 1)
-  (tap> (clerk/html  {::clerk/width :wide} [:h1.w-full.border-2.border-amber-500.bg-amber-500.h-10]))
-  (tap> (clerk/table {::clerk/width :full} [[1 2] [3 4]]))
-  (tap> (clerk/plotly {::clerk/width :full} {:data [{:y [3 1 2]}]}))
-  (tap> (clerk/html {::clerk/width :full} [:h1 "Fin. 👋"]))
-  (reset-taps!))
+(clerk/fragment
+ (clerk/table  [[1 2] [3 4]])
+ (clerk/image {::clerk/width :full} "https://images.freeimages.com/images/large-previews/773/koldalen-4-1384902.jpg")
+ (clerk/plotly {::clerk/width :full} {:data [{:y [1 3 2]}]}))

--- a/notebooks/fragments.clj
+++ b/notebooks/fragments.clj
@@ -42,20 +42,16 @@
 (defonce tap-setup (add-tap (fn [x] ((resolve `tapped) x))))
 
 (def tap-viewer
-  {:transform-fn
-   (comp v/mark-presented
-         #(merge % (-> % :nextjournal/value :val v/->opts))
-         (clerk/update-val update :val v/present)
-         (clerk/update-val update :tapped-at inst->local-time-str)
-         #(assoc % :nextjournal/viewer
-                 {:render-fn '(fn [{:keys [val key tapped-at]} opts]
-                                (js/console.log :key key)
-                                (with-meta
-                                  [:div.border-t.relative.py-3.mt-5
-                                   [:span.absolute.rounded-full.px-2.bg-gray-300.font-mono.top-0
-                                    {:class "left-1/2 -translate-x-1/2 -translate-y-1/2 py-[1px] text-[9px]"} tapped-at]
-                                   [:div.overflow-x-auto [nextjournal.clerk.render/inspect-presented val]]]
-                                  {:key key}))}))})
+  {:render-fn '(fn [{:keys [val tapped-at key]} opts]
+                 (with-meta
+                   [:div.border-t.relative.py-3.mt-2
+                    [:span.absolute.rounded-full.px-2.bg-gray-300.font-mono.top-0
+                     {:class "left-1/2 -translate-x-1/2 -translate-y-1/2 py-[1px] text-[9px]"} (:nextjournal/value tapped-at)]
+                    [:div.overflow-x-auto [nextjournal.clerk.render/inspect-presented val]]]
+                   {:key (:nextjournal/value key)}))
+   :transform-fn (comp clerk/mark-preserve-keys
+                       #(merge % (-> % :nextjournal/value :val v/ensure-wrapped v/->opts))
+                       (clerk/update-val update :tapped-at inst->local-time-str))})
 
 ^{::clerk/visibility {:result :show}}
 (clerk/fragment (map (partial clerk/with-viewer tap-viewer)

--- a/notebooks/fragments.clj
+++ b/notebooks/fragments.clj
@@ -9,6 +9,7 @@
   (:import (java.time Instant LocalTime ZoneId)))
 
 (defn inst->local-time-str [inst] (str (LocalTime/ofInstant inst (ZoneId/systemDefault))))
+(defn timestamped [x] {:val x :tapped-at (Instant/now) :key (str (gensym))})
 
 (def switch-view
   (assoc v/viewer-eval-viewer
@@ -28,15 +29,17 @@
 ^{::clerk/sync true ::clerk/viewer switch-view ::clerk/visibility {:result :show}}
 (defonce !view (atom :stream))
 
-(defonce !taps (atom [(clerk/html {::clerk/width :wide} [:div.w-full.border-2.border-amber-500])
-                      (clerk/plotly {::clerk/width :full} {:data [{:y [3 1 2]}]})]))
+
+(defonce !taps (atom (mapv timestamped
+                           [(clerk/html {::clerk/width :wide} [:h1.w-full.border-2.border-amber-500.bg-amber-500.h-10])
+                            (clerk/plotly {::clerk/width :full} {:data [{:y [3 1 2]}]})])))
 
 (defn reset-taps! []
   (reset! !taps [])
   (clerk/recompute!))
 
 (defn tapped [x]
-  (swap! !taps conj {:val x :tapped-at (Instant/now) :key (str (gensym))})
+  (swap! !taps conj (timestamped x))
   (clerk/recompute!))
 
 (defonce tap-setup (add-tap (fn [x] ((resolve `tapped) x))))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -324,6 +324,13 @@
   [text content]
   (v/caption text content))
 
+(defn fragment
+  "A utility function to splice the given `xs` into individual results.
+
+  Useful when prgrammatically generating content."
+  [& xs]
+  (apply v/fragment xs))
+
 (defn code
   "Displays `x` as syntax highlighted Clojure code.
 

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -25,6 +25,7 @@
          "how_clerk_works"
          "eval_cljs"
          "example"
+         "fragments"
          "hiding_clerk_metadata"
          "js_import"
          "multiviewer"

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -403,7 +403,6 @@
                 "cursor-pointer bg-indigo-200 hover:bg-indigo-300 dark:bg-gray-700 dark:hover:bg-slate-600 text-gray-900 dark:text-white"
                 "text-gray-400 dark:text-slate-300")
        :on-click #(when (fn? fetch-fn)
-                    (js/console.log :fetch fetch-opts)
                     (fetch-fn fetch-opts))} (- total offset) (when unbounded? "+") (if (fn? fetch-fn) " more…" " more elided")])])
 
 (defn render-map [xs {:as opts :keys [path viewer !expanded-at] :or {path []}}]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -403,6 +403,7 @@
                 "cursor-pointer bg-indigo-200 hover:bg-indigo-300 dark:bg-gray-700 dark:hover:bg-slate-600 text-gray-900 dark:text-white"
                 "text-gray-400 dark:text-slate-300")
        :on-click #(when (fn? fetch-fn)
+                    (js/console.log :fetch fetch-opts)
                     (fetch-fn fetch-opts))} (- total offset) (when unbounded? "+") (if (fn? fetch-fn) " more…" " more elided")])])
 
 (defn render-map [xs {:as opts :keys [path viewer !expanded-at] :or {path []}}]

--- a/src/nextjournal/clerk/tap.clj
+++ b/src/nextjournal/clerk/tap.clj
@@ -4,7 +4,10 @@
   (:require [clojure.core :as core]
             [nextjournal.clerk :as clerk]
             [nextjournal.clerk.viewer :as v])
-  (:import (java.time LocalTime ZoneId)))
+  (:import (java.time Instant LocalTime ZoneId)))
+
+(defn inst->local-time-str [inst] (str (LocalTime/ofInstant inst (ZoneId/systemDefault))))
+(defn timestamped [x] {:val x :tapped-at (Instant/now) :key (str (gensym))})
 
 (def switch-view
   (assoc v/viewer-eval-viewer
@@ -24,56 +27,36 @@
 ^{::clerk/sync true ::clerk/viewer switch-view ::clerk/visibility {:result :show}}
 (defonce !view (atom :stream))
 
-(defonce !taps (atom []))
+
+(defonce !taps (atom (mapv timestamped
+                           [(clerk/html {::clerk/width :wide} [:h1.w-full.border-2.border-amber-500.bg-amber-500.h-10])
+                            (clerk/plotly {::clerk/width :full} {:data [{:y [3 1 2]}]})])))
 
 (defn reset-taps! []
   (reset! !taps [])
   (clerk/recompute!))
 
-#_(reset-taps!)
-
-(defn inst->local-time-str [inst]
-  (str (LocalTime/ofInstant inst (ZoneId/systemDefault))))
-
-#_(inst->local-time-str (Instant/now))
-
-(def tap-viewer
-  {:name `tap-viewer
-   :render-fn '(fn [{:keys [val tapped-at key]} opts]
-                 (with-meta
-                   [:div.border-t.relative.py-3
-                    [:span.absolute.rounded-full.px-2.bg-gray-300.font-mono.top-0
-                     {:class "left-1/2 -translate-x-1/2 -translate-y-1/2 py-[1px] text-[9px]"} (:nextjournal/value tapped-at)]
-                    [:div.overflow-x-auto [nextjournal.clerk.render/inspect-presented val]]]
-                   {:key (:nextjournal/value key)}))
-   :transform-fn (comp clerk/mark-preserve-keys
-                       (clerk/update-val #(update % :tapped-at inst->local-time-str)))})
-
-(clerk/add-viewers! [tap-viewer])
-
-(def taps-viewer
-  {:render-fn '#(into [:div.flex.flex-col.pt-2] (nextjournal.clerk.render/inspect-children %2) %1)
-   :transform-fn (clerk/update-val (fn [taps]
-                                     (mapv (partial clerk/with-viewer `tap-viewer) (reverse taps))))})
-
-^{::clerk/visibility {:result :show}
-  ::clerk/viewer (cond-> taps-viewer
-                   (= :latest @!view)
-                   (update :transform-fn (fn [orig] (comp orig (clerk/update-val (partial take-last 1))))))}
-@!taps
-
 (defn tapped [x]
-  (swap! !taps conj {:val x :tapped-at (java.time.Instant/now) :key (str (gensym))})
+  (swap! !taps conj (timestamped x))
   (clerk/recompute!))
 
-#_(tapped (rand-int 1000))
+(defonce tap-setup (add-tap (fn [x] ((resolve `tapped) x))))
 
-#_(reset! @(find-var 'clojure.core/tapset) #{})
+(def tap-separator
+  {:render-fn '(fn [{:keys [tapped-at key]} opts]
+                 (with-meta
+                   [:div.border-t.relative.py-3.mt-2
+                    [:span.absolute.rounded-full.px-2.bg-gray-300.font-mono.top-0
+                     {:class "left-1/2 -translate-x-1/2 -translate-y-1/2 py-[1px] text-[9px]"} tapped-at]]
+                   {:key key}))
+   :transform-fn (comp clerk/mark-presented (clerk/update-val update :tapped-at inst->local-time-str))})
 
-(defonce setup
-  (add-tap tapped))
-
-#_ (remove-tap tapped)
+^{::clerk/visibility {:result :show}}
+(clerk/fragment (mapcat (fn [{:as x :keys [val]}]
+                          ;; remove v-padding from separator
+                          [(clerk/with-viewer tap-separator {::clerk/css-class [:w-full :max-w-prose]} (dissoc x :val))
+                           val])
+                        (cond->> (reverse @!taps) (= :latest @!view) (take 1))))
 
 
 (comment
@@ -87,6 +70,9 @@
   (tap> (v/plotly {:data [{:z [[1 2 3]
                                [3 2 1]]
                            :type "surface"}]}))
+  (tap> (clerk/html  {::clerk/width :full} [:h1.w-full.border-2.border-amber-500.bg-amber-500.h-10]))
+  (tap> (clerk/table {::clerk/width :full} [[1 2] [3 4]]))
+  (tap> (clerk/plotly {::clerk/width :full} {:data [{:y [3 1 2]}]}))
   (tap> (javax.imageio.ImageIO/read (java.net.URL. "https://images.freeimages.com/images/large-previews/773/koldalen-4-1384902.jpg")))
 
   (do (require 'rule-30)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1580,7 +1580,9 @@
 (def tex          (partial with-viewer katex-viewer))
 (def notebook     (partial with-viewer (:name notebook-viewer)))
 (def code         (partial with-viewer code-viewer))
-(defn fragment [& xs] {:nextjournal.clerk/fragment xs})
+
+(defn fragment [& xs]
+  {:nextjournal.clerk/fragment (if (and (sequential? (first xs)) (= 1 (count xs))) (first xs) xs)})
 
 (defn image
   ([image-or-url] (image {} image-or-url))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -575,8 +575,8 @@
                                      {:nextjournal/opts {:id (processed-block-id (str id "-" i "-result"))}}
                                      (-> cell (assoc ::doc doc) (assoc :result x)))))
                     (or (when-some [fgm (-> cell :result :nextjournal/value (get-safe :nextjournal.clerk/fragment))]
-                          (map #(hash-map :nextjournal/value %
-                                          :nextjournal/blob-id (-> cell :result :nextjournal/blob-id)) fgm))
+                          (map-indexed #(hash-map :nextjournal/value %2
+                                                  :nextjournal/blob-id (str (-> cell :result :nextjournal/blob-id) %1)) fgm))
                         [(:result cell)]))))))
 
 #_(:blocks (:nextjournal/value (nextjournal.clerk.view/doc->viewer @nextjournal.clerk.webserver/!doc)))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -572,7 +572,7 @@
               (or result? eval?)
               (into (map-indexed (fn [i x]
                                    (with-viewer (if result? (:name result-viewer) (assoc result-viewer :render-fn '(fn [_] [:<>])))
-                                     {:nextjournal/opts {:id (processed-block-id (str id "-" i "-result"))}}
+                                     {:nextjournal/opts {:id (processed-block-id (str id (when (pos? i) (str "-" i)) "-result"))}}
                                      (-> cell (assoc ::doc doc) (assoc :result x)))))
                     (or (when-some [fgm (-> cell :result :nextjournal/value (get-safe :nextjournal.clerk/fragment))]
                           (map-indexed #(hash-map :nextjournal/value %2

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -83,9 +83,8 @@
 (defn serve-blob [{:as doc :keys [blob->result ns]} {:keys [blob-id fetch-opts]}]
   (when-not ns
     (throw (ex-info "namespace must be set" {:doc doc})))
-  (if (contains? blob->result blob-id)
-    (let [root-desc (get (blob->presented (meta doc)) blob-id)
-          {:keys [present-elision-fn]} (meta root-desc)
+  (if-some [root-desc (get (blob->presented (meta doc)) blob-id)]
+    (let [{:keys [present-elision-fn]} (meta root-desc)
           desc (present-elision-fn fetch-opts)]
       (if (contains? desc :nextjournal/content-type)
         {:body (v/->value desc)

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -80,7 +80,7 @@
               (map (juxt :nextjournal/blob-id :nextjournal/presented)))
         (:blocks (:nextjournal/value presented-doc))))
 
-(defn serve-blob [{:as doc :keys [blob->result ns]} {:keys [blob-id fetch-opts]}]
+(defn serve-blob [{:as doc :keys [ns]} {:keys [blob-id fetch-opts]}]
   (when-not ns
     (throw (ex-info "namespace must be set" {:doc doc})))
   (if-some [root-desc (get (blob->presented (meta doc)) blob-id)]

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -272,6 +272,10 @@
                                                       :out-path builder/default-out-path} test-doc)
                                    #"_data/.+\.png"))))))
 
+(deftest fragments
+  (testing "fragment results are spliced into document blocks"
+    (is (= 8 (count (:blocks (v/->value (view/doc->viewer (eval/eval-string "1\n(nextjournal.clerk/fragment 2 3 4)\n5")))))))))
+
 (deftest ->edn
   (testing "normal symbols and keywords"
     (is (= "normal-symbol" (pr-str 'normal-symbol)))


### PR DESCRIPTION
Allow for splicing a seq of values into the document as if produced by results of individual cells. Useful when programmatically generating content. One of the advantages of using this as opposed to `clerk/col` is that the former respects widths set on wrapped values.

<img width="600" alt="CleanShot 2023-03-09 at 12 34 08@2x" src="https://user-images.githubusercontent.com/1078464/224011340-c8d87222-d2d7-4c0c-b97b-786effee8715.png">


## Todos: 
- [x] fix pagination inside fragments
- [x] make tap inspector use fragments (Closes #430)