### PR TITLE
Make following `clerk/doc-url` links usable in interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Changes can be:
 * 🌟⭐️💫 features
+* 🚨 possibly breaking
 * 🐞🐜 friendly or nasty bugs
 * 🛠 dev improvements
 
@@ -13,8 +14,14 @@ Changes can be:
 
 * 🍕 `clerk/fragment` for splicing a seq of values into the document as if it were produced by results of individual cells. Useful when programmatically generating content.
 
+* 🔗 Support following `clerk/doc-url` links in interactive mode. Previously these links would only be functional in the static build. Update the browser url accordingly and support evaluating a given doc by entering it in the browser's address bar.
+
+* 🚨 Change `nextjournal.clerk.render/clerk-eval` to not recompute the currently shown document when using the 1-arity version. Added a second arity that takes an opts map with a `:recompute?` key.
+
 * 🔌 Make websocket reconnect automatically on close to avoid having to reload the page
+
 * 💫 Cache expressions that return `nil` in memory
+
 * 🐜 Ensure custom `print-method` supporting unreadable symbols preserves metadata
 
 ## 0.13.842 (2023-03-07)

--- a/README.md
+++ b/README.md
@@ -151,4 +151,3 @@ You can use the following BibTeX citation:
   year         = 2023
 }
 ```
-

--- a/book.clj
+++ b/book.clj
@@ -457,9 +457,8 @@ v/default-viewers
 
 
 ^{::clerk/visibility {:code :fold :result :hide}}
-(do
-  (set! *print-namespace-maps* false)
-  (defn show-raw-value [x]
+(defn show-raw-value [x]
+  (binding [*print-namespace-maps* false]
     (clerk/code (with-out-str (clojure.pprint/pprint x)))))
 
 ;; Let's start with one of the simplest examples. You can see that

--- a/deps.edn
+++ b/deps.edn
@@ -24,7 +24,7 @@
 
         juji/editscript {:mvn/version "0.6.2"}}
 
- :aliases {:nextjournal/clerk {:extra-deps {org.clojure/clojure {:mvn/version "1.11.1"} ;; for `:as-alias` support in static build
+ :aliases {:nextjournal/clerk {:extra-deps {org.clojure/clojure {:mvn/version "1.12.0-alpha3"} ;; for `:as-alias` support in static build
                                             org.slf4j/slf4j-nop {:mvn/version "1.7.36"}
                                             org.babashka/cli {:mvn/version "0.6.50"}}
                                :extra-paths ["notebooks"]

--- a/notebooks/dice.clj
+++ b/notebooks/dice.clj
@@ -15,7 +15,7 @@
                      (when side
                        [:div.mt-2 {:style {:font-size "6em"}} side])
                      [:button.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
-                      {:on-click (fn [e] (nextjournal.clerk.render/clerk-eval '(roll!) {:recompute? true}))} "Roll 🎲!"]])}
+                      {:on-click (fn [e] (nextjournal.clerk.render/clerk-eval {:recompute? true} '(roll!)))} "Roll 🎲!"]])}
 @dice
 
 ;; Our roll! function `resets!` our `dice` with a random side and prints and says the result. Finally it updates the notebook.

--- a/notebooks/document_linking.clj
+++ b/notebooks/document_linking.clj
@@ -2,7 +2,7 @@
 (ns document-linking
   (:require [nextjournal.clerk :as clerk]))
 
-;; With `clerk/doc-url` is possible to reference notebooks by path. We currently support relative paths with respect to the directory which started the Clerk application.
+;; The helper `clerk/doc-url` allows to reference notebooks by path. We currently support relative paths with respect to the directory which started the Clerk application. An optional trailing hash fragment can appended to the path in order for the page to be scrolled up to the indicated identifier.
 (clerk/html
  [:ol
   [:li [:a {:href (clerk/doc-url "notebooks/viewers/html.clj")} "HTML"]]

--- a/notebooks/document_linking.clj
+++ b/notebooks/document_linking.clj
@@ -9,7 +9,7 @@
   [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
   [:li [:a {:href (clerk/doc-url "notebooks/markdown.md")} "Markdown"]]
   [:li [:a {:href (clerk/doc-url "notebooks/viewer_api.clj")} "Viewer API"]]
-  [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works.clj")} "How Clerk Works"]]])
+  [:li [:a {:href (clerk/doc-url "")} "Homepage"]]])
 
 ;; The same functionality is available in the SCI context when building render functions.
 (clerk/with-viewer

--- a/notebooks/document_linking.clj
+++ b/notebooks/document_linking.clj
@@ -7,8 +7,8 @@
  [:ol
   [:li [:a {:href (clerk/doc-url "notebooks/viewers/html.clj")} "HTML"]]
   [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
-  [:li [:a {:href (clerk/doc-url "notebooks/markdown.md#appendix")} "Markdown / Appendix"]]
-  [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works.clj#step-3:-analyzer")} "Clerk Analyzer"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/markdown.md" "appendix")} "Markdown / Appendix"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works.clj" "step-3:-analyzer")} "Clerk Analyzer"]]
   [:li [:a {:href (clerk/doc-url "book.clj")} "The 📕Book"]]
   [:li [:a {:href (clerk/doc-url "")} "Homepage"]]])
 

--- a/notebooks/document_linking.clj
+++ b/notebooks/document_linking.clj
@@ -1,0 +1,18 @@
+;; # 🖇️ Document Linking
+(ns document-linking
+  (:require [nextjournal.clerk :as clerk]))
+
+;; With `clerk/doc-url` is possible to reference notebooks by path. We currently support relative paths with respect to the directory which started the Clerk application.
+(clerk/html
+ [:ol (list [:li [:a {:href (clerk/doc-url "notebooks/viewers/html.clj")} "HTML"]]
+            [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
+            [:li [:a {:href (clerk/doc-url "notebooks/markdown.md#appendix")} "Appendix"]]
+            [:li [:a {:href (clerk/doc-url "notebooks/viewer_api.clj#tables")} "Viewer API / Tables"]]
+            [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works.clj#step-4:-evaluation")} "Clerk Evaluation"]])])
+
+;; The same functionality is available in the SCI context when building render functions.
+(clerk/with-viewer
+  '(fn [_ _]
+     [:ol (list [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewers/html.clj")} "HTML"]]
+                [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/markdown.md")} "Markdown"]]
+                [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewer_api.clj#tables")} "Viewer API / Tables"]])]) nil)

--- a/notebooks/document_linking.clj
+++ b/notebooks/document_linking.clj
@@ -9,6 +9,7 @@
   [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
   [:li [:a {:href (clerk/doc-url "notebooks/markdown.md")} "Markdown"]]
   [:li [:a {:href (clerk/doc-url "notebooks/viewer_api.clj")} "Viewer API"]]
+  [:li [:a {:href (clerk/doc-url "book.clj")} "The 📕Book"]]
   [:li [:a {:href (clerk/doc-url "")} "Homepage"]]])
 
 ;; The same functionality is available in the SCI context when building render functions.

--- a/notebooks/document_linking.clj
+++ b/notebooks/document_linking.clj
@@ -7,8 +7,8 @@
  [:ol
   [:li [:a {:href (clerk/doc-url "notebooks/viewers/html.clj")} "HTML"]]
   [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
-  [:li [:a {:href (clerk/doc-url "notebooks/markdown.md")} "Markdown"]]
-  [:li [:a {:href (clerk/doc-url "notebooks/viewer_api.clj")} "Viewer API"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/markdown.md#appendix")} "Markdown / Appendix"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works.clj#step-3:-analyzer")} "Clerk Analyzer"]]
   [:li [:a {:href (clerk/doc-url "book.clj")} "The 📕Book"]]
   [:li [:a {:href (clerk/doc-url "")} "Homepage"]]])
 

--- a/notebooks/document_linking.clj
+++ b/notebooks/document_linking.clj
@@ -4,15 +4,17 @@
 
 ;; With `clerk/doc-url` is possible to reference notebooks by path. We currently support relative paths with respect to the directory which started the Clerk application.
 (clerk/html
- [:ol (list [:li [:a {:href (clerk/doc-url "notebooks/viewers/html.clj")} "HTML"]]
-            [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
-            [:li [:a {:href (clerk/doc-url "notebooks/markdown.md#appendix")} "Appendix"]]
-            [:li [:a {:href (clerk/doc-url "notebooks/viewer_api.clj#tables")} "Viewer API / Tables"]]
-            [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works.clj#step-4:-evaluation")} "Clerk Evaluation"]])])
+ [:ol
+  [:li [:a {:href (clerk/doc-url "notebooks/viewers/html.clj")} "HTML"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/markdown.md")} "Markdown"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/viewer_api.clj")} "Viewer API"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works.clj")} "How Clerk Works"]]])
 
 ;; The same functionality is available in the SCI context when building render functions.
 (clerk/with-viewer
   '(fn [_ _]
-     [:ol (list [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewers/html.clj")} "HTML"]]
-                [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/markdown.md")} "Markdown"]]
-                [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewer_api.clj#tables")} "Viewer API / Tables"]])]) nil)
+     [:ol
+      [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewers/html.clj")} "HTML"]]
+      [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/markdown.md")} "Markdown"]]
+      [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewer_api.clj")} "Viewer API / Tables"]]]) nil)

--- a/notebooks/viewers/html.clj
+++ b/notebooks/viewers/html.clj
@@ -1,5 +1,7 @@
 ;; # HTML & Hiccup 🧙‍♀️
-(ns viewers.html (:require [nextjournal.clerk :as clerk]))
+(ns viewers.html
+  (:require [babashka.fs :as fs]
+            [nextjournal.clerk :as clerk]))
 
 (clerk/html "<h3>Ohai, HTML! 👋</h3>")
 
@@ -23,7 +25,7 @@
 
 (clerk/html
  [:ol (list [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
-            [:li [:a {:href (clerk/doc-url "notebooks/markdown.md")} "Markdown"]]
+            [:li [:a {:href (clerk/doc-url (fs/absolutize "notebooks/rule_30.clj"))} "Rule 30"]]
             [:li [:a {:href (clerk/doc-url "notebooks/markdown.md#appendix")} "Appendix"]]
             [:li [:a {:href (clerk/doc-url "notebooks/viewer_api.clj#tables")} "Viewer API / Tables"]]
             [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works.clj#step-4:-evaluation")} "Clerk Evaluation"]])])

--- a/notebooks/viewers/html.clj
+++ b/notebooks/viewers/html.clj
@@ -25,7 +25,7 @@
 
 (clerk/html
  [:ol (list [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
-            [:li [:a {:href (clerk/doc-url (fs/absolutize "notebooks/rule_30.clj"))} "Rule 30"]]
+            [:li [:a {:href (clerk/doc-url (str (fs/absolutize "notebooks/rule_30.clj")))} "Rule 30"]]
             [:li [:a {:href (clerk/doc-url "notebooks/markdown.md#appendix")} "Appendix"]]
             [:li [:a {:href (clerk/doc-url "notebooks/viewer_api.clj#tables")} "Viewer API / Tables"]]
             [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works.clj#step-4:-evaluation")} "Clerk Evaluation"]])])

--- a/notebooks/viewers/html.clj
+++ b/notebooks/viewers/html.clj
@@ -24,10 +24,10 @@
 (clerk/html
  [:ol (list [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
             [:li [:a {:href (clerk/doc-url "notebooks/markdown.md")} "Markdown"]]
-            [:li [:a {:href (clerk/doc-url "notebooks/rule_30.clj")} "Rule 30"]])])
+            [:li [:a {:href (clerk/doc-url "notebooks/viewer_api.clj#tables")} "Viewer API / Tables"]])])
 
 (clerk/with-viewer
   '(fn [_ _]
      [:ol (list [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewers/image.clj")} "Images"]]
                 [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/markdown.md")} "Markdown"]]
-                [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/rule_30.clj")} "Rule 30"]])]) nil)
+                [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewer_api.clj#tables")} "Viewer API / Tables"]])]) nil)

--- a/notebooks/viewers/html.clj
+++ b/notebooks/viewers/html.clj
@@ -17,9 +17,9 @@
 
 (clerk/with-viewer
   '(fn [_ _] [:div
-              "Go to "
-              [:a.text-lg {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewers/image.clj")} "images"]
-              " notebook."]) nil)
+             "Go to "
+             [:a.text-lg {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewers/image.clj")} "images"]
+             " notebook."]) nil)
 
 (clerk/html
  [:ol (list [:li [:a {:href (clerk/doc-url "notebooks/document_linking.clj")} "Cross Document Linking"]]

--- a/notebooks/viewers/html.clj
+++ b/notebooks/viewers/html.clj
@@ -24,4 +24,4 @@
 (clerk/html
  [:ol (list [:li [:a {:href (clerk/doc-url "notebooks/document_linking.clj")} "Cross Document Linking"]]
             [:li [:a {:href (clerk/doc-url "notebooks/rule_30.clj")} "Rule 30"]]
-            [:li [:a {:href (clerk/doc-url "notebooks/markdown.md#appendix")} "Appendix"]])])
+            [:li [:a {:href (clerk/doc-url "notebooks/markdown.md")} "Appendix"]])])

--- a/notebooks/viewers/html.clj
+++ b/notebooks/viewers/html.clj
@@ -25,7 +25,7 @@
 
 (clerk/html
  [:ol (list [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
-            [:li [:a {:href (clerk/doc-url (str (fs/absolutize "notebooks/rule_30.clj")))} "Rule 30"]]
+            [:li [:a {:href (clerk/doc-url "notebooks/rule_30.clj")} "Rule 30"]]
             [:li [:a {:href (clerk/doc-url "notebooks/markdown.md#appendix")} "Appendix"]]
             [:li [:a {:href (clerk/doc-url "notebooks/viewer_api.clj#tables")} "Viewer API / Tables"]]
             [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works.clj#step-4:-evaluation")} "Clerk Evaluation"]])])

--- a/notebooks/viewers/html.clj
+++ b/notebooks/viewers/html.clj
@@ -1,7 +1,5 @@
 ;; # HTML & Hiccup 🧙‍♀️
-(ns viewers.html
-  (:require [babashka.fs :as fs]
-            [nextjournal.clerk :as clerk]))
+(ns viewers.html (:require [nextjournal.clerk :as clerk]))
 
 (clerk/html "<h3>Ohai, HTML! 👋</h3>")
 
@@ -24,14 +22,6 @@
               " notebook."]) nil)
 
 (clerk/html
- [:ol (list [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
+ [:ol (list [:li [:a {:href (clerk/doc-url "notebooks/document_linking.clj")} "Cross Document Linking"]]
             [:li [:a {:href (clerk/doc-url "notebooks/rule_30.clj")} "Rule 30"]]
-            [:li [:a {:href (clerk/doc-url "notebooks/markdown.md#appendix")} "Appendix"]]
-            [:li [:a {:href (clerk/doc-url "notebooks/viewer_api.clj#tables")} "Viewer API / Tables"]]
-            [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works.clj#step-4:-evaluation")} "Clerk Evaluation"]])])
-
-(clerk/with-viewer
-  '(fn [_ _]
-     [:ol (list [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewers/image.clj")} "Images"]]
-                [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/markdown.md")} "Markdown"]]
-                [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewer_api.clj#tables")} "Viewer API / Tables"]])]) nil)
+            [:li [:a {:href (clerk/doc-url "notebooks/markdown.md#appendix")} "Appendix"]])])

--- a/notebooks/viewers/html.clj
+++ b/notebooks/viewers/html.clj
@@ -24,7 +24,9 @@
 (clerk/html
  [:ol (list [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
             [:li [:a {:href (clerk/doc-url "notebooks/markdown.md")} "Markdown"]]
-            [:li [:a {:href (clerk/doc-url "notebooks/viewer_api.clj#tables")} "Viewer API / Tables"]])])
+            [:li [:a {:href (clerk/doc-url "notebooks/markdown.md#appendix")} "Appendix"]]
+            [:li [:a {:href (clerk/doc-url "notebooks/viewer_api.clj#tables")} "Viewer API / Tables"]]
+            [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works.clj#step-4:-evaluation")} "Clerk Evaluation"]])])
 
 (clerk/with-viewer
   '(fn [_ _]

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -52,7 +52,11 @@
             doc (try (parser/parse-file {:doc? true} file)
                      (catch java.io.FileNotFoundException _e
                        (throw (ex-info (str "`nextjournal.clerk/show!` could not find the file: `" (pr-str file-or-ns) "`")
-                                       {:file-or-ns file-or-ns}))))
+                                       {:file-or-ns file-or-ns})))
+                     (catch Exception e
+                       (throw (ex-info (str "`nextjournal.clerk/show!` could not not parse the file: `" (pr-str file-or-ns) "`")
+                                       {::doc {:file file-or-ns}}
+                                       e))))
             _ (reset! !last-file file)
             {:keys [blob->result]} @webserver/!doc
             {:keys [result time-ms]} (try (eval/time-ms (eval/+eval-results blob->result (assoc doc :set-status-fn webserver/set-status!)))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -59,7 +59,7 @@
         (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
         (webserver/update-doc! result))
       (catch Exception e
-        (webserver/show-error! e)
+        (webserver/reset+broadcast-error! e)
         (throw e)))))
 
 #_(show! "notebooks/exec_status.clj")

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -54,9 +54,10 @@
                        (throw (ex-info (str "`nextjournal.clerk/show!` could not find the file: `" (pr-str file-or-ns) "`")
                                        {:file-or-ns file-or-ns}))))
             _ (reset! !last-file file)
-            {:keys [blob->result]} @webserver/!doc]
-        (webserver/update-doc!
-         (eval/eval-doc blob->result (assoc doc :set-status-fn webserver/set-status!))))
+            {:keys [blob->result]} @webserver/!doc
+            {:keys [result time-ms]} (eval/time-ms (eval/+eval-results blob->result (assoc doc :set-status-fn webserver/set-status!)))]
+        (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
+        (webserver/update-doc! result))
       (catch Exception e
         (webserver/show-error! e)
         (throw e)))))
@@ -348,8 +349,9 @@
 
 (defn eval-cljs-str
   "Evaluates the given ClojureScript `code-string` in the browser."
-  [code-string]
-  (v/eval-cljs-str code-string))
+  ([code-string] (eval-cljs-str code-string nil))
+  ([opts code-string]
+   (v/eval-cljs-str opts code-string)))
 
 (defn eval-cljs
   "Evaluates the given ClojureScript forms in the browser."

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -63,7 +63,7 @@
                                           (catch Exception e
                                             (throw (ex-info (str "`nextjournal.clerk/show!` encountered an eval error with: `" (pr-str file-or-ns) "`") {::doc doc} e))))]
         (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
-        (webserver/update-doc! result))
+        (webserver/update-doc! (assoc result :nav-path (webserver/->nav-path file-or-ns))))
       (catch Exception e
         (webserver/update-doc! (assoc (-> e ex-data ::doc) :error e))
         (throw e)))))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -59,7 +59,7 @@
         (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
         (webserver/update-doc! result))
       (catch Exception e
-        (webserver/reset+broadcast-error! e)
+        (webserver/update-error! e)
         (throw e)))))
 
 #_(show! "notebooks/exec_status.clj")

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -30,37 +30,38 @@
   (nextjournal.clerk/show! \"https://raw.githubusercontent.com/nextjournal/clerk-demo/main/notebooks/rule_30.clj\")
   (nextjournal.clerk/show! (java.io.StringReader. \";; # Notebook from String 👋\n(+ 41 1)\"))
   "
-  [file-or-ns]
-  (if config/*in-clerk*
-    ::ignored
-    (try
-      (webserver/set-status! {:progress 0 :status "Parsing…"})
-      (let [file (cond
-                   (nil? file-or-ns)
-                   (throw (ex-info (str "`nextjournal.clerk/show!` cannot show `nil`.")
-                                   {:file-or-ns file-or-ns}))
+  ([file-or-ns] (show! file-or-ns {}))
+  ([file-or-ns opts]
+   (if config/*in-clerk*
+     ::ignored
+     (try
+       (webserver/set-status! {:progress 0 :status "Parsing…"})
+       (let [file (cond
+                    (nil? file-or-ns)
+                    (throw (ex-info (str "`nextjournal.clerk/show!` cannot show `nil`.")
+                                    {:file-or-ns file-or-ns}))
 
-                   (or (symbol? file-or-ns) (instance? clojure.lang.Namespace file-or-ns))
-                   (or (some (fn [ext]
-                               (io/resource (str (str/replace (namespace-munge file-or-ns) "." "/") ext)))
-                             [".clj" ".cljc"])
-                       (throw (ex-info (str "`nextjournal.clerk/show!` could not find a resource on the classpath for: `" (pr-str file-or-ns) "`")
-                                       {:file-or-ns file-or-ns})))
+                    (or (symbol? file-or-ns) (instance? clojure.lang.Namespace file-or-ns))
+                    (or (some (fn [ext]
+                                (io/resource (str (str/replace (namespace-munge file-or-ns) "." "/") ext)))
+                              [".clj" ".cljc"])
+                        (throw (ex-info (str "`nextjournal.clerk/show!` could not find a resource on the classpath for: `" (pr-str file-or-ns) "`")
+                                        {:file-or-ns file-or-ns})))
 
-                   :else
-                   file-or-ns)
-            doc (try (parser/parse-file {:doc? true} file)
-                     (catch java.io.FileNotFoundException _e
-                       (throw (ex-info (str "`nextjournal.clerk/show!` could not find the file: `" (pr-str file-or-ns) "`")
-                                       {:file-or-ns file-or-ns}))))
-            _ (reset! !last-file file)
-            {:keys [blob->result]} @webserver/!doc
-            {:keys [result time-ms]} (eval/time-ms (eval/+eval-results blob->result (assoc doc :set-status-fn webserver/set-status!)))]
-        (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
-        (webserver/update-doc! result))
-      (catch Exception e
-        (webserver/show-error! e)
-        (throw e)))))
+                    :else
+                    file-or-ns)
+             doc (try (parser/parse-file {:doc? true} file)
+                      (catch java.io.FileNotFoundException _e
+                        (throw (ex-info (str "`nextjournal.clerk/show!` could not find the file: `" (pr-str file-or-ns) "`")
+                                        {:file-or-ns file-or-ns}))))
+             _ (reset! !last-file file)
+             {:keys [blob->result]} @webserver/!doc
+             {:keys [result time-ms]} (eval/time-ms (eval/+eval-results blob->result (assoc doc :set-status-fn webserver/set-status!)))]
+         (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
+         (webserver/update-doc! (merge result (select-keys opts [:skip-history?]))))
+       (catch Exception e
+         (webserver/show-error! e)
+         (throw e))))))
 
 #_(show! "notebooks/exec_status.clj")
 #_(clear-cache!)

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -30,43 +30,46 @@
   (nextjournal.clerk/show! \"https://raw.githubusercontent.com/nextjournal/clerk-demo/main/notebooks/rule_30.clj\")
   (nextjournal.clerk/show! (java.io.StringReader. \";; # Notebook from String 👋\n(+ 41 1)\"))
   "
-  [file-or-ns]
-  (if config/*in-clerk*
-    ::ignored
-    (try
-      (webserver/set-status! {:progress 0 :status "Parsing…"})
-      (let [file (cond
-                   (nil? file-or-ns)
-                   (throw (ex-info (str "`nextjournal.clerk/show!` cannot show `nil`.")
-                                   {:file-or-ns file-or-ns}))
+  ([file-or-ns] (show! {} file-or-ns))
+  ([opts file-or-ns]
+   (if config/*in-clerk*
+     ::ignored
+     (try
+       (webserver/set-status! {:progress 0 :status "Parsing…"})
+       (let [file (cond
+                    (nil? file-or-ns)
+                    (throw (ex-info (str "`nextjournal.clerk/show!` cannot show `nil`.")
+                                    {:file-or-ns file-or-ns}))
 
-                   (or (symbol? file-or-ns) (instance? clojure.lang.Namespace file-or-ns))
-                   (or (some (fn [ext]
-                               (io/resource (str (str/replace (namespace-munge file-or-ns) "." "/") ext)))
-                             [".clj" ".cljc"])
-                       (throw (ex-info (str "`nextjournal.clerk/show!` could not find a resource on the classpath for: `" (pr-str file-or-ns) "`")
-                                       {:file-or-ns file-or-ns})))
+                    (or (symbol? file-or-ns) (instance? clojure.lang.Namespace file-or-ns))
+                    (or (some (fn [ext]
+                                (io/resource (str (str/replace (namespace-munge file-or-ns) "." "/") ext)))
+                              [".clj" ".cljc"])
+                        (throw (ex-info (str "`nextjournal.clerk/show!` could not find a resource on the classpath for: `" (pr-str file-or-ns) "`")
+                                        {:file-or-ns file-or-ns})))
 
-                   :else
-                   file-or-ns)
-            doc (try (assoc (parser/parse-file {:doc? true} file) :nav-path (webserver/->nav-path file-or-ns))
-                     (catch java.io.FileNotFoundException _e
-                       (throw (ex-info (str "`nextjournal.clerk/show!` could not find the file: `" (pr-str file-or-ns) "`")
-                                       {:file-or-ns file-or-ns})))
-                     (catch Exception e
-                       (throw (ex-info (str "`nextjournal.clerk/show!` could not not parse the file: `" (pr-str file-or-ns) "`")
-                                       {::doc {:file file-or-ns}}
-                                       e))))
-            _ (reset! !last-file file)
-            {:keys [blob->result]} @webserver/!doc
-            {:keys [result time-ms]} (try (eval/time-ms (eval/+eval-results blob->result (assoc doc :set-status-fn webserver/set-status!)))
-                                          (catch Exception e
-                                            (throw (ex-info (str "`nextjournal.clerk/show!` encountered an eval error with: `" (pr-str file-or-ns) "`") {::doc doc} e))))]
-        (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
-        (webserver/update-doc! result))
-      (catch Exception e
-        (webserver/update-doc! (assoc (-> e ex-data ::doc) :error e))
-        (throw e)))))
+                    :else
+                    file-or-ns)
+             doc (try (merge opts
+                             {:nav-path (webserver/->nav-path file-or-ns)}
+                             (parser/parse-file {:doc? true} file))
+                      (catch java.io.FileNotFoundException _e
+                        (throw (ex-info (str "`nextjournal.clerk/show!` could not find the file: `" (pr-str file-or-ns) "`")
+                                        {:file-or-ns file-or-ns})))
+                      (catch Exception e
+                        (throw (ex-info (str "`nextjournal.clerk/show!` could not not parse the file: `" (pr-str file-or-ns) "`")
+                                        {::doc {:file file-or-ns}}
+                                        e))))
+             _ (reset! !last-file file)
+             {:keys [blob->result]} @webserver/!doc
+             {:keys [result time-ms]} (try (eval/time-ms (eval/+eval-results blob->result (assoc doc :set-status-fn webserver/set-status!)))
+                                           (catch Exception e
+                                             (throw (ex-info (str "`nextjournal.clerk/show!` encountered an eval error with: `" (pr-str file-or-ns) "`") {::doc doc} e))))]
+         (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
+         (webserver/update-doc! result))
+       (catch Exception e
+         (webserver/update-doc! (assoc (-> e ex-data ::doc) :error e))
+         (throw e))))))
 
 #_(show! "notebooks/exec_status.clj")
 #_(clear-cache!)

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -373,7 +373,7 @@
   "Experimental notebook viewer. You probably should not use this."
   (partial with-viewer (:name v/notebook-viewer)))
 
-(defn doc-url [path] (v/doc-url path))
+(defn doc-url [& args] (apply v/doc-url args))
 
 (defmacro example
   "Evaluates the expressions in `body` showing code next to results in Clerk.

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -54,10 +54,9 @@
                        (throw (ex-info (str "`nextjournal.clerk/show!` could not find the file: `" (pr-str file-or-ns) "`")
                                        {:file-or-ns file-or-ns}))))
             _ (reset! !last-file file)
-            {:keys [blob->result]} @webserver/!doc
-            {:keys [result time-ms]} (eval/time-ms (eval/+eval-results blob->result (assoc doc :set-status-fn webserver/set-status!)))]
-        (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
-        (webserver/update-doc! result))
+            {:keys [blob->result]} @webserver/!doc]
+        (webserver/update-doc!
+         (eval/eval-doc blob->result (assoc doc :set-status-fn webserver/set-status!))))
       (catch Exception e
         (webserver/show-error! e)
         (throw e)))))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -49,7 +49,7 @@
 
                    :else
                    file-or-ns)
-            doc (try (parser/parse-file {:doc? true} file)
+            doc (try (assoc (parser/parse-file {:doc? true} file) :nav-path (webserver/->nav-path file-or-ns))
                      (catch java.io.FileNotFoundException _e
                        (throw (ex-info (str "`nextjournal.clerk/show!` could not find the file: `" (pr-str file-or-ns) "`")
                                        {:file-or-ns file-or-ns})))
@@ -63,7 +63,7 @@
                                           (catch Exception e
                                             (throw (ex-info (str "`nextjournal.clerk/show!` encountered an eval error with: `" (pr-str file-or-ns) "`") {::doc doc} e))))]
         (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
-        (webserver/update-doc! (assoc result :nav-path (webserver/->nav-path file-or-ns))))
+        (webserver/update-doc! result))
       (catch Exception e
         (webserver/update-doc! (assoc (-> e ex-data ::doc) :error e))
         (throw e)))))

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -12,7 +12,8 @@
             [nextjournal.clerk.view :as view]
             [nextjournal.clerk.viewer :as viewer]
             [nextjournal.clerk.webserver :as webserver]
-            [nextjournal.clerk.config :as config]))
+            [nextjournal.clerk.config :as config])
+  (:import (java.net URI)))
 
 (def clerk-docs
   (into ["CHANGELOG.md"
@@ -283,11 +284,17 @@
       (fs/delete-tree tw-folder)
       (update opts :resource->url assoc "/css/viewer.css" url))))
 
+(defn path+fragment [path]
+  (let [uri (URI. path)] {:path (.getPath uri) :fragment (.getFragment uri)}))
+
 (defn doc-url [{:as opts :keys [bundle?]} docs file path]
-  (let [url (get (build-path->url opts docs) path)]
+  (assert (string? path))
+  (let [{:keys [path fragment]} (path+fragment path)
+        url (get (build-path->url opts docs) path)]
     (if bundle?
       (str "#/" url)
-      (str (viewer/relative-root-prefix-from (viewer/map-index opts file)) url))))
+      (str (viewer/relative-root-prefix-from (viewer/map-index opts file))
+           url (when fragment (str "#" fragment))))))
 
 (defn build-static-app! [{:as opts :keys [bundle?]}]
   (let [{:as opts :keys [download-cache-fn upload-cache-fn report-fn compile-css? expanded-paths error]}

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -12,8 +12,7 @@
             [nextjournal.clerk.view :as view]
             [nextjournal.clerk.viewer :as viewer]
             [nextjournal.clerk.webserver :as webserver]
-            [nextjournal.clerk.config :as config])
-  (:import (java.net URI)))
+            [nextjournal.clerk.config :as config]))
 
 (def clerk-docs
   (into ["CHANGELOG.md"
@@ -285,17 +284,14 @@
       (fs/delete-tree tw-folder)
       (update opts :resource->url assoc "/css/viewer.css" url))))
 
-(defn path+fragment [path]
-  (let [uri (URI. path)] {:path (.getPath uri) :fragment (.getFragment uri)}))
-
-(defn doc-url [{:as opts :keys [bundle?]} docs file path]
-  (assert (string? path))
-  (let [{:keys [path fragment]} (path+fragment path)
-        url (get (build-path->url opts docs) path)]
-    (if bundle?
-      (str "#/" url)
-      (str (viewer/relative-root-prefix-from (viewer/map-index opts file))
-           url (when fragment (str "#" fragment))))))
+(defn doc-url
+  ([opts doc file path] (doc-url opts doc file path nil))
+  ([{:as opts :keys [bundle?]} docs file path fragment]
+   (let [url (get (build-path->url opts docs) path)]
+     (if bundle?
+       (str "#/" url)
+       (str (viewer/relative-root-prefix-from (viewer/map-index opts file))
+            url (when fragment (str "#" fragment)))))))
 
 (defn build-static-app! [{:as opts :keys [bundle?]}]
   (let [{:as opts :keys [download-cache-fn upload-cache-fn report-fn compile-css? expanded-paths error]}

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -252,7 +252,10 @@
 (defn eval-doc
   "Evaluates the given `doc`."
   ([doc] (eval-doc {} doc))
-  ([in-memory-cache doc] (+eval-results in-memory-cache doc)))
+  ([in-memory-cache {:as doc :keys [file]}]
+   (let [{:keys [result time-ms]} (time-ms (+eval-results in-memory-cache doc))]
+     (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
+     result)))
 
 (defn eval-file
   "Reads given `file` (using `slurp`) and evaluates it."

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -252,10 +252,7 @@
 (defn eval-doc
   "Evaluates the given `doc`."
   ([doc] (eval-doc {} doc))
-  ([in-memory-cache {:as doc :keys [file]}]
-   (let [{:keys [result time-ms]} (time-ms (+eval-results in-memory-cache doc))]
-     (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
-     result)))
+  ([in-memory-cache doc] (+eval-results in-memory-cache doc)))
 
 (defn eval-file
   "Reads given `file` (using `slurp`) and evaluates it."

--- a/src/nextjournal/clerk/home.clj
+++ b/src/nextjournal/clerk/home.clj
@@ -27,9 +27,9 @@
       [:span "The newest version is " [:a {:href "#"} "v0.12.707"] ". " [:a {:href "#"} "What’s changed?"]]]]
   [:div.rounded-lg.border-2.border-amber-100.bg-amber-50.px-8.pt-3.pb-4.mx-auto.text-center.font-sans.mt-6.md:mt-4
    [:div.font-medium
-    "Call " [:span.font-mono.text-sm.bg-white.bg-opacity-80.mx-1.font-bold "nextjournal.clerk/show"]
+    "Call " [:span.font-mono.text-sm.bg-white.bg-opacity-80.mx-1.font-bold "nextjournal.clerk/show!"]
     " from your REPL to make a notebook appear!"]
-   [:div.mt-2.text-sm "⚡️ This works best when you " [:a {:href "#"} "set up your editor to use a key binding for this!"]]]
+   [:div.mt-2.text-sm "⚡️ This works best when you " [:a {:href "https://book.clerk.vision/#editor-integration"} "set up your editor to use a key binding for this!"]]]
   [:div.rounded-lg.border-2.border-indigo-100.bg-indigo-50.px-8.pt-3.pb-4.mt-6.text-center.font-sans
    [:div.font-medium "📖 New to Clerk? Learn all about it in " [:a {:href "https://book.clerk.vision"} "The Book of Clerk"] "."]
    #_

--- a/src/nextjournal/clerk/home.clj
+++ b/src/nextjournal/clerk/home.clj
@@ -1,0 +1,37 @@
+(ns nextjournal.clerk.home
+  {:nextjournal.clerk/visibility {:code :hide :result :hide}}
+  (:require [clojure.string :as str]
+            [clojure.java.io :as io]
+            [nextjournal.clerk :as clerk]))
+
+{::clerk/visibility {:result :show}}
+
+^{::clerk/css-class ["w-full" "m-0"]}
+(clerk/html
+ [:div.max-w-prose.px-8.mx-auto
+  [:div.md:flex.md:justify-between.px-8.text-center.md:text-left
+   [:h1 "👋 Welcome to Clerk!"]
+   [:div.text-sm.md:text-xs.font-sans.md:text-right.mt-1
+    [:span.font-bold.block
+     "You’re running Clerk " [:a {:href "#"} "v0.12.707"] "."]
+    [:span "The newest version is " [:a {:href "#"} "v0.12.707"] ". " [:a {:href "#"} "What’s changed?"]]]]
+  [:div.rounded-lg.border-2.border-amber-100.bg-amber-50.px-8.pt-3.pb-4.mx-auto.text-center.font-sans.mt-6.md:mt-4
+   [:div.font-medium
+    "Call " [:span.font-mono.text-sm.bg-white.bg-opacity-80.mx-1.font-bold "nextjournal.clerk/show"]
+    " from your REPL to make a notebook appear!"]
+   [:div.mt-2.text-sm "⚡️ This works best when you " [:a {:href "#"} "set up your editor to use a key binding for this!"]]]
+  [:div.rounded-lg.border-2.border-indigo-100.bg-indigo-50.px-8.pt-3.pb-4.mt-6.text-center.font-sans
+   [:div.font-medium "📖 New with Clerk? Learn all about it in " [:a {:href "#"} "The Book of Clerk"] "."]
+   [:div.mt-2.text-sm
+    "Here are some handy links:"
+    [:a.ml-3 {:href "#"} "🚀 Getting Started"]
+    [:a.ml-3 {:href "#"} "🔍 Viewers"]
+    [:a.ml-3 {:href "#"} "🙈 Controlling Visibility"]]]
+  [:h4 "Your notebooks"]
+  (into
+   [:div.md:columns-3.gap-8.font-sans.text-sm
+    ]
+   (map (fn [file-name]
+          [:div
+           [:a {:href file-name} file-name]]))
+   (filter #(str/ends-with? % ".clj") (map #(.getName %) (file-seq (io/file "notebooks")))))])

--- a/src/nextjournal/clerk/home.clj
+++ b/src/nextjournal/clerk/home.clj
@@ -31,7 +31,8 @@
     " from your REPL to make a notebook appear!"]
    [:div.mt-2.text-sm "⚡️ This works best when you " [:a {:href "#"} "set up your editor to use a key binding for this!"]]]
   [:div.rounded-lg.border-2.border-indigo-100.bg-indigo-50.px-8.pt-3.pb-4.mt-6.text-center.font-sans
-   [:div.font-medium "📖 New with Clerk? Learn all about it in " [:a {:href "#"} "The Book of Clerk"] "."]
+   [:div.font-medium "📖 New to Clerk? Learn all about it in " [:a {:href "https://book.clerk.vision"} "The Book of Clerk"] "."]
+   #_
    [:div.mt-2.text-sm
     "Here are some handy links:"
     [:a.ml-3 {:href "#"} "🚀 Getting Started"]

--- a/src/nextjournal/clerk/home.clj
+++ b/src/nextjournal/clerk/home.clj
@@ -2,7 +2,6 @@
   {:nextjournal.clerk/visibility {:code :hide :result :hide}}
   (:require [clojure.string :as str]
             [babashka.fs :as fs]
-            [clojure.java.io :as io]
             [nextjournal.clerk :as clerk]))
 
 (defn glob-notebooks []

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -146,7 +146,7 @@
     (when (= (.-search url) "?clerk/show!")
       (.preventDefault e)
       (clerk-eval (list 'nextjournal.clerk.webserver/navigate!
-                        (cond-> {:path (subs (.-pathname url) 1)}
+                        (cond-> {:nav-path (subs (.-pathname url) 1)}
                           (seq (.-hash url))
                           (assoc :fragment (subs (.-hash url) 1))))))))
 
@@ -159,7 +159,7 @@
 (defn handle-history-popstate [^js e]
   (when-some [notebook-path (some-> e .-state .-clerk_show)]
     (.preventDefault e)
-    (clerk-eval (list 'nextjournal.clerk.webserver/navigate! {:path notebook-path
+    (clerk-eval (list 'nextjournal.clerk.webserver/navigate! {:nav-path notebook-path
                                                               :skip-history? true}))))
 
 (defn handle-initial-load [_]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -149,9 +149,9 @@
                              (when el
                                (setup-dark-mode! !state)
                                (when-some [heading (when (and (exists? js/location) (not bundle?))
-                                                     (try (some-> js/location .-hash not-empty js/decodeURI js/document.querySelector)
+                                                     (try (some-> js/location .-hash not-empty js/decodeURI (subs 1) js/document.getElementById)
                                                           (catch js/Error _
-                                                            (js/console.warn (str "Clerk render-notebook, invalid selector: "
+                                                            (js/console.warn (str "Clerk render-notebook, invalid hash: "
                                                                                   (.-hash js/location))))))]
                                  (js/requestAnimationFrame #(.scrollIntoViewIfNeeded heading)))))]
     (let [{:keys [md-toc mobile? open? visibility]} @!state

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -664,10 +664,6 @@
   (let [re-eval (fn [{:keys [form]}] (viewer/->viewer-fn form))]
     (w/postwalk (fn [x] (cond-> x (viewer/viewer-fn? x) re-eval)) doc)))
 
-(defn set-browser-url! [{:keys [title path]}]
-  (when (exists? js/history)
-    (js/history.replaceState #js {} title path)))
-
 (defn ^:export set-state! [{:as state :keys [doc error]}]
   (when (contains? state :doc)
     (reset! !doc doc))

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -142,7 +142,8 @@
   (js/URL. href))
 
 (defn handle-anchor-click [^js e]
-  (let [url (some-> e .-target closest-anchor-parent .-href ->URL)]
+  (when-some [url (some-> e .-target closest-anchor-parent .-href ->URL)]
+    (js/console.log :url url  )
     (when-let [show-path (and (= (.-search url) "?clerk/show!")
                               (subs (.-pathname url) 1))]
       (.preventDefault e)

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -147,7 +147,8 @@
   (js/history.pushState #js {:clerk_show path} nil (str "/" path)))
 
 (defn handle-history-popstate [^js e]
-  (when-some [notebook-path (.. e -state -clerk_show)]
+  (when-some [notebook-path (some-> e .-state .-clerk_show)]
+    (.preventDefault e)
     (clerk-eval (list 'nextjournal.clerk/show! notebook-path {:skip-history? true}))))
 
 (defn render-notebook [{:as _doc xs :blocks :keys [bundle? css-class sidenotes? toc toc-visibility]} opts]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -148,8 +148,7 @@
 
 (defn handle-history-popstate [^js e]
   (when-some [notebook-path (.. e -state -clerk_show)]
-    (.preventDefault e)
-    (clerk-eval (list 'nextjournal.clerk/show! notebook-path))))
+    (clerk-eval (list 'nextjournal.clerk/show! notebook-path {:skip-history? true}))))
 
 (defn render-notebook [{:as _doc xs :blocks :keys [bundle? css-class sidenotes? toc toc-visibility]} opts]
   (r/with-let [local-storage-key "clerk-navbar"

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -150,10 +150,11 @@
                           (seq (.-hash url))
                           (assoc :fragment (subs (.-hash url) 1))))))))
 
-(defn history-push-state [{:keys [path fragment]}]
+(defn history-push-state [{:keys [path fragment replace?]}]
   (when (not= path (some-> js/history .-state .-clerk_show))
-    (js/history.pushState #js {:clerk_show path} nil
-                          (str "/" path (when fragment (str "#" fragment))))))
+    (j/call js/history
+            (if replace? :replaceState :pushState)
+            #js {:clerk_show path} nil (str "/" path (when fragment (str "#" fragment))))))
 
 (defn handle-history-popstate [^js e]
   (when-some [notebook-path (some-> e .-state .-clerk_show)]
@@ -162,7 +163,7 @@
                                                               :skip-history? true}))))
 
 (defn handle-initial-load [_]
-  (history-push-state {:path (subs js/location.pathname 1)}))
+  (history-push-state {:path (subs js/location.pathname 1) :replace? true}))
 
 (when (exists? js/addEventListener)
   ;; We need to push an initial history state when the document is first loaded via a hard request

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -137,11 +137,16 @@
         (recur (.-parentNode el))))))
 
 (declare clerk-eval)
-(defn ->URL [s] (new js/URL s))
+
+(defn ->URL [href]
+  (js/URL. href))
+
 (defn handle-anchor-click [^js e]
-  (when-some [notebook-path (some-> e .-target closest-anchor-parent .-href ->URL .-searchParams (.get "clerk-show"))]
-    (.preventDefault e)
-    (clerk-eval (list 'nextjournal.clerk/show! notebook-path))))
+  (let [url (some-> e .-target closest-anchor-parent .-href ->URL)]
+    (when-let [show-path (and (= (.-search url) "?clerk/show!")
+                              (subs (.-pathname url) 1))]
+      (.preventDefault e)
+      (clerk-eval (list 'nextjournal.clerk/show! show-path)))))
 
 (defn history-push-state [path]
   (js/history.pushState #js {:clerk_show path} nil (str "/" path)))

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -151,6 +151,7 @@
                           (assoc :fragment (subs (.-hash url) 1))))))))
 
 (defn history-push-state [{:keys [path fragment replace?]}]
+  (prn :history-push-state path :replace? replace?)
   (when (not= path (some-> js/history .-state .-clerk_show))
     (j/call js/history
             (if replace? :replaceState :pushState)

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -148,7 +148,7 @@
       (clerk-eval (list 'nextjournal.clerk.webserver/navigate! {:path (subs (.-pathname url) 1)})))))
 
 (defn history-push-state [path]
-  (when-not (not= path (some-> js/history .-state .-clerk_show))
+  (when (not= path (some-> js/history .-state .-clerk_show))
     (js/history.pushState #js {:clerk_show path} nil (str "/" path))))
 
 (defn handle-history-popstate [^js e]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -151,7 +151,6 @@
                           (assoc :fragment (subs (.-hash url) 1))))))))
 
 (defn history-push-state [{:keys [path fragment replace?]}]
-  (prn :history-push-state path :replace? replace?)
   (when (not= path (some-> js/history .-state .-clerk_show))
     (j/call js/history
             (if replace? :replaceState :pushState)

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -143,11 +143,9 @@
 
 (defn handle-anchor-click [^js e]
   (when-some [url (some-> e .-target closest-anchor-parent .-href ->URL)]
-    (js/console.log :url url  )
-    (when-some [show-path (when (= (.-search url) "?clerk/show!")
-                            (not-empty (subs (.-pathname url) 1)))]
+    (when (= (.-search url) "?clerk/show!")
       (.preventDefault e)
-      (clerk-eval (list 'nextjournal.clerk.webserver/navigate! {:path show-path})))))
+      (clerk-eval (list 'nextjournal.clerk.webserver/navigate! {:path (subs (.-pathname url) 1)})))))
 
 (defn history-push-state [path]
   (js/history.pushState #js {:clerk_show path} nil (str "/" path)))

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -740,12 +740,12 @@
   (atom {}))
 
 (defn clerk-eval
-  ([form] (clerk-eval form {}))
-  ([form {:keys [recompute?] :or {recompute? false}}]
+  ([form] (clerk-eval {} form))
+  ([{:keys [recompute?]} form]
    (let [eval-id (gensym)
          promise (js/Promise. (fn [resolve reject]
                                 (swap! !pending-clerk-eval-replies assoc eval-id {:resolve resolve :reject reject})))]
-     (ws-send! {:type :eval :form form :eval-id eval-id :recompute? recompute?})
+     (ws-send! {:type :eval :form form :eval-id eval-id :recompute? (boolean recompute?)})
      promise)))
 
 (defn process-eval-reply! [{:keys [eval-id reply error]}]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -715,6 +715,9 @@
 
 (defn ^:export set-state! [{:as state :keys [doc error]}]
   (when (contains? state :doc)
+    (when (exists? js/window)
+      ;; TODO: can we restore the scroll position when navigating back?
+      (.scrollTo js/window #js {:top 0}))
     (reset! !doc doc))
   (when (remount? doc)
     (swap! !eval-counter inc))

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -719,6 +719,8 @@
       ;; TODO: can we restore the scroll position when navigating back?
       (.scrollTo js/window #js {:top 0}))
     (reset! !doc doc))
+  (when (and error (contains? @!doc :status))
+    (swap! !doc dissoc :status))
   (when (remount? doc)
     (swap! !eval-counter inc))
   (reset! !error error)

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -144,10 +144,10 @@
 (defn handle-anchor-click [^js e]
   (when-some [url (some-> e .-target closest-anchor-parent .-href ->URL)]
     (js/console.log :url url  )
-    (when-let [show-path (and (= (.-search url) "?clerk/show!")
-                              (subs (.-pathname url) 1))]
+    (when-some [show-path (when (= (.-search url) "?clerk/show!")
+                            (not-empty (subs (.-pathname url) 1)))]
       (.preventDefault e)
-      (clerk-eval (list 'nextjournal.clerk/show! show-path)))))
+      (clerk-eval (list 'nextjournal.clerk.webserver/navigate! {:path show-path})))))
 
 (defn history-push-state [path]
   (js/history.pushState #js {:clerk_show path} nil (str "/" path)))
@@ -155,7 +155,8 @@
 (defn handle-history-popstate [^js e]
   (when-some [notebook-path (some-> e .-state .-clerk_show)]
     (.preventDefault e)
-    (clerk-eval (list 'nextjournal.clerk/show! notebook-path {:skip-history? true}))))
+    (clerk-eval (list 'nextjournal.clerk.webserver/navigate! {:path notebook-path
+                                                              :skip-history? true}))))
 
 (defn handle-initial-load [_]
   (history-push-state (subs js/location.pathname 1)))

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -318,12 +318,12 @@
 
 (defn fetch! [{:keys [blob-id]} opts]
   #_(js/console.log :fetch! blob-id opts)
-  (-> (js/fetch (str "_blob/" blob-id (when (seq opts)
-                                        (str "?" (opts->query opts)))))
+  (-> (js/fetch (str "/_blob/" blob-id (when (seq opts)
+                                         (str "?" (opts->query opts)))))
       (.then #(.text %))
       (.then #(try (read-string %)
                    (catch js/Error e
-                     (js/console.error #js {:message "sci read error" :blob-id blob-id :code-string % :error e })
+                     (js/console.error #js {:message "sci read error" :blob-id blob-id :code-string % :error e})
                      (render-unreadable-edn %))))))
 
 (defn ->expanded-at [auto-expand? presented]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -148,7 +148,8 @@
       (clerk-eval (list 'nextjournal.clerk.webserver/navigate! {:path (subs (.-pathname url) 1)})))))
 
 (defn history-push-state [path]
-  (js/history.pushState #js {:clerk_show path} nil (str "/" path)))
+  (when-not (not= path (some-> js/history .-state .-clerk_show))
+    (js/history.pushState #js {:clerk_show path} nil (str "/" path))))
 
 (defn handle-history-popstate [^js e]
   (when-some [notebook-path (some-> e .-state .-clerk_show)]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1620,7 +1620,12 @@
    content
    (html [:figcaption.text-xs.text-slate-500.text-center.mt-1 text])))
 
-(defn ^:dynamic doc-url [path] (str "/" path "?clerk/show!"))
+(defn ^:dynamic doc-url [path]
+  (let [[path fragment] (str/split path #"#")]
+    (str "/" path "?clerk/show!" (when fragment (str "#" fragment)))))
+
+#_(doc-url "notebooks/rule_30.clj#board")
+#_(doc-url "notebooks/rule_30.clj")
 
 (defn print-hide-result-deprecation-warning []
   #?(:clj (binding [*out* *err*]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1620,7 +1620,7 @@
    content
    (html [:figcaption.text-xs.text-slate-500.text-center.mt-1 text])))
 
-(defn ^:dynamic doc-url [path] (str "/?clerk-show=" path))
+(defn ^:dynamic doc-url [path] (str "/" path "?clerk/show!"))
 
 (defn print-hide-result-deprecation-warning []
   #?(:clj (binding [*out* *err*]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1620,9 +1620,10 @@
    content
    (html [:figcaption.text-xs.text-slate-500.text-center.mt-1 text])))
 
-(defn ^:dynamic doc-url [path]
-  (let [[path fragment] (str/split path #"#")]
-    (str "/" path "?clerk/show!" (when fragment (str "#" fragment)))))
+(defn ^:dynamic doc-url
+  ([path] (doc-url path nil))
+  ([path fragment]
+   (str "/" path "?clerk/show!" (when fragment (str "#" fragment)))))
 
 #_(doc-url "notebooks/rule_30.clj#board")
 #_(doc-url "notebooks/rule_30.clj")

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1613,7 +1613,8 @@
    content
    (html [:figcaption.text-xs.text-slate-500.text-center.mt-1 text])))
 
-(defn ^:dynamic doc-url [path] (str "/" path))
+(defn ^:dynamic doc-url [path] (str (when-not (str/starts-with? path "/") "/")
+                                    path))
 
 (defn print-hide-result-deprecation-warning []
   #?(:clj (binding [*out* *err*]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -536,7 +536,7 @@
                                    (store+get-cas-url! (assoc doc :ext (fs/extension src))
                                                        (fs/read-all-bytes src)))
              bundle? (data-uri-base64-encode (fs/read-all-bytes src) (Files/probeContentType (fs/path src)))
-             :else (str "_fs/" src))))
+             :else (str "/_fs/" src))))
 
 #?(:clj
    (defn read-image [image-or-url]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1613,7 +1613,7 @@
    content
    (html [:figcaption.text-xs.text-slate-500.text-center.mt-1 text])))
 
-(defn ^:dynamic doc-url [path] (str "?clerk-show=" path))
+(defn ^:dynamic doc-url [path] (str "/?clerk-show=" path))
 
 (defn print-hide-result-deprecation-warning []
   #?(:clj (binding [*out* *err*]

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -153,12 +153,9 @@
 (declare present+reset! set-status!)
 
 (defn eval-file [file]
-  (let [doc (parser/parse-file {:doc? true} file)
-        {:keys [result time-ms]} (eval/time-ms
-                                  (eval/eval-doc (:blob->result @!doc)
-                                                 (assoc doc :set-status-fn set-status!)))]
-    (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
-    result))
+  (-> (parser/parse-file {:doc? true} file)
+      (assoc :set-status-fn set-status!)
+      eval/eval-doc))
 
 (defn app [{:as req :keys [uri]}]
   (if (:websocket? req)

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -196,7 +196,7 @@
     (reset! !doc (with-meta doc presented))
     presented))
 
-(defn update-doc! [{:as doc :keys [file skip-history?]}]
+(defn update-doc! [{:as doc :keys [file fragment skip-history?]}]
   (reset! !error nil)
   (broadcast! (if (= (:ns @!doc) (:ns doc))
                 {:type :patch-state! :patch (editscript/get-edits (editscript/diff (meta @!doc) (present+reset! doc) {:algo :quick}))}
@@ -209,7 +209,8 @@
                                                   (cond->> file
                                                     (fs/absolute? file)
                                                     (fs/relativize (fs/cwd))))) (catch Exception _))]
-                              [(v/->ViewerEval (list 'nextjournal.clerk.render/history-push-state path))]))})))
+                              [(v/->ViewerEval (list 'nextjournal.clerk.render/history-push-state
+                                                     (cond-> {:path path} fragment (assoc :fragment fragment))))]))})))
 
 #_(update-doc! (help-doc))
 

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -201,12 +201,13 @@
                 {:type :patch-state! :patch (editscript/get-edits (editscript/diff (meta @!doc) (present+reset! doc) {:algo :quick}))}
                 {:type :set-state!
                  :doc (present+reset! doc)
-                 :effects [(v/->ViewerEval (list 'js/history.replaceState nil title
-                                                 (str "/" (try
-                                                            (when (fs/exists? file)
-                                                              (cond->> file
-                                                                (fs/absolute? file)
-                                                                (fs/relativize (fs/cwd)))) (catch Exception _)))))]})))
+                 :effects (when-some [path (try
+                                             (when (fs/exists? file)
+                                               (str
+                                                (cond->> file
+                                                  (fs/absolute? file)
+                                                  (fs/relativize (fs/cwd))))) (catch Exception _))]
+                            [(v/->ViewerEval (list 'nextjournal.clerk.render/history-push-state path))])})))
 
 #_(update-doc! (help-doc))
 

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -1,7 +1,6 @@
 (ns nextjournal.clerk.webserver
   (:require [babashka.fs :as fs]
             [clojure.edn :as edn]
-            [clojure.main :as main]
             [clojure.pprint :as pprint]
             [clojure.set :as set]
             [clojure.string :as str]
@@ -154,10 +153,9 @@
 (declare present+reset! set-status!)
 
 (defn eval-file [file]
-  (main/with-bindings
-    (-> (parser/parse-file {:doc? true} file)
-        (assoc :set-status-fn set-status!)
-        eval/eval-doc)))
+  (-> (parser/parse-file {:doc? true} file)
+      (assoc :set-status-fn set-status!)
+      eval/eval-doc))
 
 (defn guard [p x] (when (p x) x))
 (defn existing-notebook-path [uri]

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -183,7 +183,7 @@
 (declare present+reset!)
 (defn serve-notebook [uri]
   (let [path (subs uri 1)]
-    (try ((resolve 'nextjournal.clerk/show!) path)
+    (try ((resolve 'nextjournal.clerk/show!) (if (= path "") 'nextjournal.clerk.home path))
          (catch Exception _))
     {:status 200
      :headers {"Content-Type" "text/html" "Cache-Control" "no-store"}

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -186,6 +186,7 @@
         ("build" "js" "css") (serve-file uri (str "public" uri))
         ("_fs") (serve-file uri (str/replace uri "/_fs/" ""))
         "_ws" {:status 200 :body "upgrading..."}
+        "favicon.ico" {:status 404}
         (serve-notebook uri))
       (catch Throwable e
         {:status  500

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -159,7 +159,7 @@
         ("_fs") (serve-file uri (str/replace uri "/_fs/" ""))
         "_ws" {:status 200 :body "upgrading..."}
         {:status 200
-         :headers {"Content-Type" "text/html"}
+         :headers {"Content-Type" "text/html" "Cache-Control" "no-store"}
          :body (view/doc->html {:error @!error
                                 :doc (or (let [path (subs uri 1)]
                                            (when (and (fs/exists? path) (fs/regular-file? path))

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -125,7 +125,7 @@
     presented))
 
 (defn update-doc! [{:as doc :keys [file fragment skip-history?]}]
-  (broadcast! (if (= (:ns @!doc) (:ns doc))
+  (broadcast! (if (and (:ns @!doc) (= (:ns @!doc) (:ns doc)))
                 {:type :patch-state! :patch (editscript/get-edits (editscript/diff (meta @!doc) (present+reset! doc) {:algo :quick}))}
                 {:type :set-state!
                  :doc (present+reset! doc)

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -211,7 +211,8 @@
                               [(v/->ViewerEval (list 'nextjournal.clerk.render/history-push-state path))]))})))
 
 (defn navigate! [{:as opts :keys [path]}]
-  (update-doc! (merge (eval/eval-file (:blob->result @!doc) path) opts)))
+  (update-doc! (merge (or (when (seq path) (eval/eval-file (:blob->result @!doc) path))
+                          (help-doc)) opts)))
 
 #_(update-doc! (help-doc))
 

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -210,6 +210,9 @@
                                                     (fs/relativize (fs/cwd))))) (catch Exception _))]
                               [(v/->ViewerEval (list 'nextjournal.clerk.render/history-push-state path))]))})))
 
+(defn navigate! [{:as opts :keys [path]}]
+  (update-doc! (merge (eval/eval-file (:blob->result @!doc) path) opts)))
+
 #_(update-doc! (help-doc))
 
 (defn broadcast-status! [status]

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -235,10 +235,11 @@
                             (vary-meta update ::!send-status-future broadcast-status-debounced! status)))))
 
 (defn navigate! [{:as opts :keys [nav-path]}]
-  (update-doc! (merge (or (when (seq nav-path)
-                            (eval/eval-doc (:blob->result @!doc)
-                                           (assoc (parser/parse-file {:doc? true} nav-path) :set-status-fn set-status!)))
-                          (help-doc)) opts)))
+  ;; TODO: unify with clerk/show!
+  (update-doc! (merge (eval/eval-doc (:blob->result @!doc)
+                                     (assoc (parser/parse-file {:doc? true}
+                                                               (or (not-empty nav-path) "src/nextjournal/clerk/home.clj"))
+                                            :set-status-fn set-status!)) opts)))
 
 #_(clojure.java.browse/browse-url "http://localhost:7777")
 

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -181,13 +181,18 @@
     (eval '(nextjournal.clerk/recompute!)))
 
 (declare present+reset!)
+
+(defn ->file-or-ns [path]
+  (cond (= path "") 'nextjournal.clerk.home
+        (str/starts-with? path "'") (symbol (subs path 1)) 
+        :else path))
+
 (defn serve-notebook [uri]
-  (let [path (subs uri 1)]
-    (try ((resolve 'nextjournal.clerk/show!) (if (= path "") 'nextjournal.clerk.home path))
-         (catch Exception _))
-    {:status 200
-     :headers {"Content-Type" "text/html" "Cache-Control" "no-store"}
-     :body (view/doc->html {:doc @!doc})}))
+  (try ((resolve 'nextjournal.clerk/show!) (->file-or-ns (subs uri 1)))
+       (catch Exception _))
+  {:status 200
+   :headers {"Content-Type" "text/html" "Cache-Control" "no-store"}
+   :body (view/doc->html {:doc @!doc})})
 
 (defn app [{:as req :keys [uri]}]
   (if (:websocket? req)

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -192,15 +192,15 @@
   (cond (str/starts-with? nav-path "'") (symbol (subs nav-path 1))
         :else nav-path))
 
-(defn show! [file-or-ns]
-  ((resolve 'nextjournal.clerk/show!) file-or-ns))
+(defn show! [opts file-or-ns]
+  ((resolve 'nextjournal.clerk/show!) opts file-or-ns))
 
 (defn navigate! [{:as opts :keys [nav-path]}]
-  (show! (router nav-path nav-path)))
+  (show! opts (router nav-path nav-path)))
 
 (defn serve-notebook [uri]
-  (try (show! (->file-or-ns (let [nav-path (subs uri 1)]
-                              (router nav-path nav-path))))
+  (try (show! {} (->file-or-ns (let [nav-path (subs uri 1)]
+                                 (router nav-path nav-path))))
        (catch Exception _))
   {:status 200
    :headers {"Content-Type" "text/html" "Cache-Control" "no-store"}

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -7,8 +7,6 @@
             [editscript.core :as editscript]
             [nextjournal.clerk.view :as view]
             [nextjournal.clerk.viewer :as v]
-            [nextjournal.clerk.eval :as eval]
-            [nextjournal.clerk.parser :as parser]
             [org.httpkit.server :as httpkit])
   (:import (java.nio.file Files)))
 
@@ -151,18 +149,6 @@
     (apply swap! nextjournal.clerk.atom/my-state (eval '[update :counter inc]))
     (eval '(nextjournal.clerk/recompute!)))
 
-(declare present+reset! set-status!)
-
-(defn eval-file [file]
-  (-> (parser/parse-file {:doc? true} file)
-      (assoc :set-status-fn set-status!)
-      eval/eval-doc))
-
-(defn guard [p x] (when (p x) x))
-(defn existing-notebook-path [uri]
-  (when-some [ex (or (guard fs/exists? uri) (guard fs/exists? (subs uri 1)))]
-    (guard fs/regular-file? ex)))
-
 (defn serve-notebook [uri]
   (let [path (subs uri 1)]
     (when-not (= "" path)
@@ -175,7 +161,6 @@
                             :doc (if (= "" path)
                                    (help-doc)
                                    @!doc)})}))
-
 
 (defn app [{:as req :keys [uri]}]
   (if (:websocket? req)

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -156,7 +156,7 @@
     {:status 200
      :headers {"Content-Type" "text/html" "Cache-Control" "no-store"}
      :body (view/doc->html {:error @!error
-                            :doc (or (and (= "" path) (help-doc))
+                            :doc (or (and (= "" path) (doto (help-doc) present+reset!))
                                      (when (and (fs/exists? path) (fs/regular-file? path))
                                        (doto (eval/eval-file (:blob->result @!doc) path)
                                          present+reset!))

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -1,6 +1,7 @@
 (ns nextjournal.clerk.webserver
   (:require [babashka.fs :as fs]
             [clojure.edn :as edn]
+            [clojure.main :as main]
             [clojure.pprint :as pprint]
             [clojure.set :as set]
             [clojure.string :as str]
@@ -153,9 +154,10 @@
 (declare present+reset! set-status!)
 
 (defn eval-file [file]
-  (-> (parser/parse-file {:doc? true} file)
-      (assoc :set-status-fn set-status!)
-      eval/eval-doc))
+  (main/with-bindings
+    (-> (parser/parse-file {:doc? true} file)
+        (assoc :set-status-fn set-status!)
+        eval/eval-doc)))
 
 (defn guard [p x] (when (p x) x))
 (defn existing-notebook-path [uri]

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -194,11 +194,10 @@
                 {:type :patch-state! :patch (editscript/get-edits (editscript/diff (meta @!doc) (present+reset! doc) {:algo :quick}))}
                 {:type :set-state!
                  :doc (present+reset! doc)
-                 :effects [(v/->ViewerEval (list 'nextjournal.clerk.render/set-browser-url!
-                                                 {:title title
-                                                  :path (str "/" (cond->> file
-                                                                   (fs/absolute? file)
-                                                                   (fs/relativize (fs/cwd))))}))]})))
+                 :effects [(v/->ViewerEval (list 'js/history.replaceState nil title
+                                                 (str "/" (cond->> file
+                                                            (fs/absolute? file)
+                                                            (fs/relativize (fs/cwd))))))]})))
 
 #_(update-doc! (help-doc))
 

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -162,6 +162,20 @@
   (when-some [ex (or (guard fs/exists? uri) (guard fs/exists? (subs uri 1)))]
     (guard fs/regular-file? ex)))
 
+(defn serve-notebook [uri]
+  (let [path (subs uri 1)]
+    (when-not (= "" path)
+      (future (@(resolve 'nextjournal.clerk/show!) (if (str/starts-with? path "'")
+                                                     (read-string (subs path 1))
+                                                     path))))
+    {:status 200
+     :headers {"Content-Type" "text/html" "Cache-Control" "no-store"}
+     :body (view/doc->html {:error @!error
+                            :doc (if (= "" path)
+                                   (help-doc)
+                                   @!doc)})}))
+
+
 (defn app [{:as req :keys [uri]}]
   (if (:websocket? req)
     (httpkit/as-channel req ws-handlers)
@@ -171,13 +185,7 @@
         ("build" "js" "css") (serve-file uri (str "public" uri))
         ("_fs") (serve-file uri (str/replace uri "/_fs/" ""))
         "_ws" {:status 200 :body "upgrading..."}
-        {:status 200
-         :headers {"Content-Type" "text/html" "Cache-Control" "no-store"}
-         :body (view/doc->html {:error @!error
-                                :doc (or (when-some [file (existing-notebook-path uri)]
-                                           (doto (eval-file file) present+reset!))
-                                         @!doc
-                                         (help-doc))})})
+        (serve-notebook uri))
       (catch Throwable e
         {:status  500
          :body    (with-out-str (pprint/pprint (Throwable->map e)))}))))

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -203,9 +203,11 @@
                 {:type :set-state!
                  :doc (present+reset! doc)
                  :effects [(v/->ViewerEval (list 'js/history.replaceState nil title
-                                                 (str "/" (cond->> file
-                                                            (fs/absolute? file)
-                                                            (fs/relativize (fs/cwd))))))]})))
+                                                 (str "/" (try
+                                                            (when (fs/exists? file)
+                                                              (cond->> file
+                                                                (fs/absolute? file)
+                                                                (fs/relativize (fs/cwd)))) (catch Exception _)))))]})))
 
 #_(update-doc! (help-doc))
 

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -195,19 +195,20 @@
     (reset! !doc (with-meta doc presented))
     presented))
 
-(defn update-doc! [{:as doc :keys [file title]}]
+(defn update-doc! [{:as doc :keys [file skip-history?]}]
   (reset! !error nil)
   (broadcast! (if (= (:ns @!doc) (:ns doc))
                 {:type :patch-state! :patch (editscript/get-edits (editscript/diff (meta @!doc) (present+reset! doc) {:algo :quick}))}
                 {:type :set-state!
                  :doc (present+reset! doc)
-                 :effects (when-some [path (try
-                                             (when (fs/exists? file)
-                                               (str
-                                                (cond->> file
-                                                  (fs/absolute? file)
-                                                  (fs/relativize (fs/cwd))))) (catch Exception _))]
-                            [(v/->ViewerEval (list 'nextjournal.clerk.render/history-push-state path))])})))
+                 :effects (when-not skip-history?
+                            (when-some [path (try
+                                               (when (fs/exists? file)
+                                                 (str
+                                                  (cond->> file
+                                                    (fs/absolute? file)
+                                                    (fs/relativize (fs/cwd))))) (catch Exception _))]
+                              [(v/->ViewerEval (list 'nextjournal.clerk.render/history-push-state path))]))})))
 
 #_(update-doc! (help-doc))
 

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -187,7 +187,7 @@
 
 (defn ->file-or-ns [path]
   (cond (= path "") 'nextjournal.clerk.home
-        (str/starts-with? path "'") (symbol (subs path 1)) 
+        (str/starts-with? path "'") (symbol (subs path 1))
         :else path))
 
 (defn serve-notebook [uri]
@@ -234,10 +234,10 @@
                             (vary-meta assoc :status status)
                             (vary-meta update ::!send-status-future broadcast-status-debounced! status)))))
 
-(defn navigate! [{:as opts :keys [path]}]
-  (update-doc! (merge (or (when (seq path)
+(defn navigate! [{:as opts :keys [nav-path]}]
+  (update-doc! (merge (or (when (seq nav-path)
                             (eval/eval-doc (:blob->result @!doc)
-                                           (assoc (parser/parse-file {:doc? true} path) :set-status-fn set-status!)))
+                                           (assoc (parser/parse-file {:doc? true} nav-path) :set-status-fn set-status!)))
                           (help-doc)) opts)))
 
 #_(clojure.java.browse/browse-url "http://localhost:7777")

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -149,7 +149,9 @@
 #_(do
     (apply swap! nextjournal.clerk.atom/my-state (eval '[update :counter inc]))
     (eval '(nextjournal.clerk/recompute!)))
-(declare present+reset!)
+
+(declare present+reset! set-status!)
+
 (defn app [{:as req :keys [uri]}]
   (if (:websocket? req)
     (httpkit/as-channel req ws-handlers)
@@ -165,7 +167,9 @@
                                 :doc (or (let [file (subs uri 1)]
                                            (when (and (fs/exists? file) (fs/regular-file? file))
                                              (let [doc (parser/parse-file {:doc? true} file)
-                                                   {:keys [result time-ms]} (eval/time-ms (eval/eval-doc (:blob->result @!doc) (assoc doc :set-status-fn set-status!)))]
+                                                   {:keys [result time-ms]} (eval/time-ms
+                                                                             (eval/eval-doc (:blob->result @!doc)
+                                                                                            (assoc doc :set-status-fn set-status!)))]
                                                (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
                                                (doto result present+reset!))))
                                          @!doc

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -203,12 +203,12 @@
                 {:type :set-state!
                  :doc (present+reset! doc)
                  :effects (when-not skip-history?
-                            (when-some [path (try
-                                               (when (fs/exists? file)
-                                                 (str
-                                                  (cond->> file
-                                                    (fs/absolute? file)
-                                                    (fs/relativize (fs/cwd))))) (catch Exception _))]
+                            (when-some [path (or (when (nil? file) "")
+                                                 (try
+                                                   (when (fs/exists? file)
+                                                     (str (cond->> file
+                                                            (fs/absolute? file)
+                                                            (fs/relativize (fs/cwd))))) (catch Exception _)))]
                               [(v/->ViewerEval (list 'nextjournal.clerk.render/history-push-state
                                                      (cond-> {:path path} fragment (assoc :fragment fragment))))]))})))
 

--- a/test/nextjournal/clerk/webserver_test.clj
+++ b/test/nextjournal/clerk/webserver_test.clj
@@ -4,6 +4,11 @@
             [nextjournal.clerk.view :as view]
             [nextjournal.clerk.webserver :as webserver]))
 
+(deftest ->file-or-ns
+  (is (= 'nextjournal.clerk.home (webserver/->file-or-ns "")))
+  (is (= 'nextjournal.clerk.tap (webserver/->file-or-ns "'nextjournal.clerk.tap")))
+  (is (= "notebooks/rule_30.clj" (webserver/->file-or-ns "notebooks/rule_30.clj"))))
+
 (deftest serve-blob
   (testing "lazy loading of simple range"
     (let [doc (let [doc (eval/eval-string "(range 100)")]

--- a/test/nextjournal/clerk/webserver_test.clj
+++ b/test/nextjournal/clerk/webserver_test.clj
@@ -5,7 +5,6 @@
             [nextjournal.clerk.webserver :as webserver]))
 
 (deftest ->file-or-ns
-  (is (= 'nextjournal.clerk.home (webserver/->file-or-ns "")))
   (is (= 'nextjournal.clerk.tap (webserver/->file-or-ns "'nextjournal.clerk.tap")))
   (is (= "notebooks/rule_30.clj" (webserver/->file-or-ns "notebooks/rule_30.clj"))))
 


### PR DESCRIPTION
Allow notebooks to be shown by visiting their path in the browser e.g http://localhost:7777/notebooks/viewers/html.clj

* Make links to a valid notebook path functional in interactive mode
* push URL history in the client when clerk shows a document 

Closes #142.

The above link has examples of links built using `doc-url` for pointing at other notebooks.

Note: this changes the behaviour of `n.c.render/clerk-eval` to not recompute the current notebook by default. Recompute can be opted in via `(clerk-eval form {:recompute? true})`.
