### PR TITLE
Document that viewers can be embedded inside of hiccup code

### DIFF
--- a/book.clj
+++ b/book.clj
@@ -168,10 +168,16 @@
 ;; You can style elements, using [Tailwind CSS](https://tailwindcss.com/docs/utility-first).
 (clerk/html [:button.bg-sky-500.hover:bg-sky-700.text-white.rounded-xl.px-2.py-1 "✨ Tailwind CSS"])
 
-;; The `html` viewer is also able to display SVG, taking either a hiccup vector or a SVG string.
+;; The `html` viewer is able to display SVG, taking either a hiccup vector or a SVG string.
 (clerk/html [:svg {:width 500 :height 100}
              [:circle {:cx  25 :cy 50 :r 25 :fill "blue"}]
              [:circle {:cx 100 :cy 75 :r 25 :fill "red"}]])
+
+;; You can also embed other viewers inside of hiccup.
+
+(clerk/html [:div.flex.justify-center.space-x-6
+             [:p "a table is next to me"]
+             (clerk/table [[1 2] [3 4]])])
 
 ;; ### 🔢 Tables
 
@@ -371,6 +377,10 @@
 (clerk/col (clerk/row donut-chart donut-chart donut-chart)
            contour-plot)
 
+;; You can even embed viewers directly inside of hiccup.
+
+(clerk/html [:div.flex.justify-around donut-chart donut-chart donut-chart])
+
 ;; ### 🤹🏻 Applying Viewers
 
 ;; **Metadata Notation**
@@ -475,7 +485,7 @@ v/default-viewers
 
 ;; #### ⚙️ Transform
 
-;; When writing your own viewer, the first extention point you should reach for is `:tranform-fn`. 
+;; When writing your own viewer, the first extention point you should reach for is `:tranform-fn`.
 
 #_ "exercise: wrap this in `v/present` and call it at the REPL"
 (v/with-viewer {:transform-fn #(clerk/html [:pre (pr-str %)])}
@@ -502,7 +512,7 @@ v/default-viewers
              "James Clerk Maxwell"))
 
 
-;; **Passing modified viewers down the tree** 
+;; **Passing modified viewers down the tree**
 
 #_ "TODO: move this into clerk?"
 (defn add-child-viewers [viewer viewers]
@@ -705,7 +715,7 @@ v/table-viewer
 ;; ## 🙈 Controlling Visibility
 
 ;; Visibility for code and results can be controlled document-wide and
-;; per top-level form. By default, Clerk will always show code and 
+;; per top-level form. By default, Clerk will always show code and
 ;; results for a notebook.
 
 ;; You can use a map of the following shape to set the visibility of
@@ -736,7 +746,7 @@ v/table-viewer
 ;;
 ;;    ^{::clerk/visibility {:code :hide}} (shuffle (range 25))
 ;;
-;; This will hide the code but only show the result: 
+;; This will hide the code but only show the result:
 
 ^{::clerk/visibility {:code :hide}} (shuffle (range 25))
 


### PR DESCRIPTION
I was struggling to layout some elements using clerk, and the only way I could see to compose elements from the Book of Clerk was by using `clerk/row` and `clerk/col`. However, I wanted more control over the style. From slack, I was told that you can embed viewers directly into hiccup code!

I didn't see it documented in the Book of Clerk, so I decided to just add a couple small mentions in the hiccup and "composing viewers" sections:

in the hiccup section:
![screenshot-2023-03-18T07:56:29-07:00](https://user-images.githubusercontent.com/30749/226113655-9adcf7d1-feac-473e-abb2-23b0ef505a09.png)

in the composing viewers section:
![screenshot-2023-03-18T07:56:39-07:00](https://user-images.githubusercontent.com/30749/226113664-3182aed8-dbfe-4bd6-bf88-5d613273e806.png)
