### PR TITLE
Fix Images in slideshow viewer

### DIFF
--- a/notebooks/slideshow.clj
+++ b/notebooks/slideshow.clj
@@ -2,7 +2,9 @@
 ;; ---
 (ns slideshow
   (:require [nextjournal.clerk :as clerk]
-            [nextjournal.clerk-slideshow :as clerk-slideshow]))
+            [nextjournal.clerk-slideshow :as clerk-slideshow])
+  (:import (javax.imageio ImageIO)
+           (java.net URL)))
 
 ;; This notebook uses a [slideshow viewer](https://github.com/nextjournal/clerk-slideshow) to override its built-in default notebook viewer.
 ^{::clerk/visibility {:result :hide}}
@@ -18,7 +20,6 @@
 (clerk/plotly {:data [{:z [[1 2 3] [3 2 1]] :type "surface"}]})
 
 ;; ---
-
 ;; ## 📈 Vega Lite
 ^{::clerk/visibility {:code :hide}}
 (clerk/vl {:width 650 :height 400 :data {:url "https://vega.github.io/vega-datasets/data/us-10m.json"
@@ -26,6 +27,11 @@
            :transform [{:lookup "id" :from {:data {:url "https://vega.github.io/vega-datasets/data/unemployment.tsv"}
                                             :key "id" :fields ["rate"]}}]
            :projection {:type "albersUsa"} :mark "geoshape" :encoding {:color {:field "rate" :type "quantitative"}}})
+
+;; ---
+;; ## 🖼️ An Image
+^{::clerk/visibility {:code :hide}}
+(ImageIO/read (URL. "https://images.unsplash.com/photo-1532879311112-62b7188d28ce?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8"))
 
 ;; ---
 ;; # 👋🏻 Fin.

--- a/notebooks/slideshow.clj
+++ b/notebooks/slideshow.clj
@@ -2,9 +2,7 @@
 ;; ---
 (ns slideshow
   (:require [nextjournal.clerk :as clerk]
-            [nextjournal.clerk-slideshow :as clerk-slideshow])
-  (:import (javax.imageio ImageIO)
-           (java.net URL)))
+            [nextjournal.clerk-slideshow :as clerk-slideshow]))
 
 ;; This notebook uses a [slideshow viewer](https://github.com/nextjournal/clerk-slideshow) to override its built-in default notebook viewer.
 ^{::clerk/visibility {:result :hide}}
@@ -31,7 +29,7 @@
 ;; ---
 ;; ## 🖼️ An Image
 ^{::clerk/visibility {:code :hide}}
-(ImageIO/read (URL. "https://images.unsplash.com/photo-1532879311112-62b7188d28ce?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8"))
+(clerk/image "trees.png")
 
 ;; ---
 ;; # 👋🏻 Fin.

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -75,7 +75,7 @@
 (defn blob->presented [presented-doc]
   ;; TODO: store on doc?
   (into {}
-        (comp (filter #(and (map? %) (v/get-safe :nextjournal/blob-id) (v/get-safe :nextjournal/presented)))
+        (comp (filter #(and (map? %) (v/get-safe % :nextjournal/blob-id) (v/get-safe % :nextjournal/presented)))
               (map (juxt :nextjournal/blob-id :nextjournal/presented)))
         (tree-seq coll? seq
                   (:nextjournal/value presented-doc))))

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -75,10 +75,10 @@
 (defn blob->presented [presented-doc]
   ;; TODO: store on doc?
   (into {}
-        (comp (filter #(and (map? %) (contains? % :nextjournal/presented)))
+        (comp (filter #(and (map? %) (v/get-safe :nextjournal/blob-id) (v/get-safe :nextjournal/presented)))
               (map (juxt :nextjournal/blob-id :nextjournal/presented)))
         (tree-seq coll? seq
-                  (-> presented-doc v/->value :blocks))))
+                  (:nextjournal/value presented-doc))))
 
 #_(blob->presented (meta @!doc))
 


### PR DESCRIPTION
This deals with scenarios where the default notebook viewer is overridden to not keep a `:blocks` key in the presented document. This is the case of the slideshow viewer.