### PR TITLE
🏠 Home Page Improvements

### DIFF
--- a/resources/stylesheets/viewer.css
+++ b/resources/stylesheets/viewer.css
@@ -137,7 +137,7 @@
 }
 @media (min-width: 960px){
     .notebook-viewer .code-viewer .cm-content {
-        @apply py-4 pl-12;
+        @apply pb-2 pl-12;
     }
     .notebook-viewer .code-listing {
         width: 48rem !important;
@@ -300,8 +300,6 @@
 /* Notebook Spacing */
 /* --------------------------------------------------------------- */
 
-.notebook-viewer { @apply py-16; }
-#clerk-static-app .notebook-viewer { @apply pt-[0.8rem] pb-16; }
 .markdown-viewer *:first-child:not(.code-viewer):not(li):not(h2):not(.sidenote) { @apply mt-0; }
 /*.viewer + .viewer { @apply mt-6; }*/
 .viewer + .result-viewer { @apply mt-0; }

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -11,7 +11,6 @@
             [nextjournal.clerk.config :as config]
             [nextjournal.clerk.eval :as eval]
             [nextjournal.clerk.parser :as parser]
-            [nextjournal.clerk.view :as view]
             [nextjournal.clerk.viewer :as v]
             [nextjournal.clerk.webserver :as webserver]))
 

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -393,13 +393,6 @@
     `(nextjournal.clerk/with-viewer v/examples-viewer
        (mapv (fn [form# val#] {:form form# :val val#}) ~(mapv (fn [x#] `'~x#) body) ~(vec body)))))
 
-(defn file->viewer
-  "Evaluates the given `file` and returns it's viewer representation."
-  ([file] (file->viewer {:inline-results? true} file))
-  ([opts file] (view/doc->viewer opts (eval/eval-file file))))
-
-#_(file->viewer "notebooks/rule_30.clj")
-
 (defn halt-watcher!
   "Halts the filesystem watcher when active."
   []

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -355,7 +355,8 @@
                                                                   (binding [*build-opts* opts
                                                                             viewer/doc-url (partial doc-url opts state file)]
                                                                     (let [doc (eval/eval-analyzed-doc doc)]
-                                                                      (assoc doc :viewer (view/doc->viewer (assoc opts :static-build? true) doc))))
+                                                                      (assoc doc :viewer (view/doc->viewer (assoc opts :static-build? true
+                                                                                                                  :nav-path (str file)) doc))))
                                                                   (catch Exception e
                                                                     {:error e})))]
                         (report-fn (merge {:stage :built :duration duration :idx idx}

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -334,7 +334,7 @@
                                                                 (try
                                                                   (binding [viewer/doc-url (partial doc-url opts state file)]
                                                                     (let [doc (eval/eval-analyzed-doc doc)]
-                                                                      (assoc doc :viewer (view/doc->viewer (assoc opts :inline-results? true) doc))))
+                                                                      (assoc doc :viewer (view/doc->viewer (assoc opts :static-build? true) doc))))
                                                                   (catch Exception e
                                                                     {:error e})))]
                         (report-fn (merge {:stage :built :duration duration :idx idx}

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -236,11 +236,9 @@
 
 (defn write-static-app!
   [opts docs]
-  (when-not (contains? opts :index)
-    (throw (ex-info "Build options should contain an index at this point" {:opts opts :docs docs})))
   (let [{:as opts :keys [bundle? out-path browse? ssr?]} (process-build-opts opts)
         index-html (str out-path fs/file-separator "index.html")
-        {:as static-app-opts :keys [path->url path->doc]} (build-static-app-opts (update opts :index str) docs)]
+        {:as static-app-opts :keys [path->url path->doc]} (build-static-app-opts (viewer/update-if opts :index str) docs)]
     (when-not (contains? (-> path->url vals set) "")
       (throw (ex-info "Index must have been processed at this point" {:opts opts :docs docs})))
     (when-not (fs/exists? (fs/parent index-html))

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -324,9 +324,9 @@
                       (report-fn {:stage :building :doc doc :idx idx})
                       (let [{result :result duration :time-ms} (eval/time-ms
                                                                 (try
-                                                                  (let [doc (binding [viewer/doc-url (partial doc-url opts state file)]
-                                                                              (eval/eval-analyzed-doc doc))]
-                                                                    (assoc doc :viewer (view/doc->viewer (assoc opts :inline-results? true) doc)))
+                                                                  (binding [viewer/doc-url (partial doc-url opts state file)]
+                                                                    (let [doc (eval/eval-analyzed-doc doc)]
+                                                                      (assoc doc :viewer (view/doc->viewer (assoc opts :inline-results? true) doc))))
                                                                   (catch Exception e
                                                                     {:error e})))]
                         (report-fn (merge {:stage :built :duration duration :idx idx}

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -295,7 +295,7 @@
 (defn doc-url
   ([opts doc file path] (doc-url opts doc file path nil))
   ([{:as opts :keys [bundle?]} docs file path fragment]
-   (let [url (get (build-path->url opts docs) path)]
+   (let [url (get (build-path->url (viewer/update-if opts :index str) docs) path)]
      (if bundle?
        (str "#/" url)
        (str (viewer/relative-root-prefix-from (viewer/map-index opts file))

--- a/src/nextjournal/clerk/home.clj
+++ b/src/nextjournal/clerk/home.clj
@@ -25,13 +25,18 @@
       [:span.font-bold.block
        "You’re running Clerk " [:a {:href "#"} "v0.12.707"] "."]
       [:span "The newest version is " [:a {:href "#"} "v0.12.707"] ". " [:a {:href "#"} "What’s changed?"]]]]
-  [:div.rounded-lg.border-2.border-amber-100.bg-amber-50.px-8.pt-3.pb-4.mx-auto.text-center.font-sans.mt-6.md:mt-4
+  [:div.rounded-lg.border-2.border-amber-100.bg-amber-50.dark:border-slate-600.dark:bg-slate-800.dark:text-slate-100.px-8.py-4.mx-auto.text-center.font-sans.mt-6.md:mt-4
    [:div.font-medium
-    "Call " [:span.font-mono.text-sm.bg-white.bg-opacity-80.mx-1.font-bold "nextjournal.clerk/show!"]
+    "Call "
+    [:span.font-mono.text-sm.bg-white.bg-amber-100.border.border-amber-300.relative.dark:bg-slate-900.dark:border-slate-600.rounded.font-bold
+     {:class "px-[4px] py-[1px] -top-[1px] mx-[2px]"}
+     "nextjournal.clerk/show!"]
     " from your REPL to make a notebook appear!"]
    [:div.mt-2.text-sm "⚡️ This works best when you " [:a {:href "https://book.clerk.vision/#editor-integration"} "set up your editor to use a key binding for this!"]]]
-  [:div.rounded-lg.border-2.border-indigo-100.bg-indigo-50.px-8.pt-3.pb-4.mt-6.text-center.font-sans
-   [:div.font-medium "📖 New to Clerk? Learn all about it in " [:a {:href "https://book.clerk.vision"} "The Book of Clerk"] "."]
+  [:div.rounded-lg.border-2.border-indigo-100.bg-indigo-50.dark:border-slate-600.dark:bg-slate-800.dark:text-slate-100.px-8.py-4.mt-6.text-center.font-sans
+   [:div.font-medium.md:flex.items-center.justify-center
+    [:span.text-xl.relative {:class "top-[2px] mr-2"} "📖"]
+    [:span "New to Clerk? Learn all about it in " [:a {:href "https://book.clerk.vision"} [:span.block.md:inline "The Book of Clerk."]]]]
    #_
    [:div.mt-2.text-sm
     "Here are some handy links:"

--- a/src/nextjournal/clerk/home.clj
+++ b/src/nextjournal/clerk/home.clj
@@ -19,7 +19,7 @@
 ^{::clerk/css-class ["w-full" "m-0"]}
 (clerk/html
  [:div.max-w-prose.px-8.mx-auto
-  [:div.md:flex.md:justify-between.px-8.text-center.md:text-left
+  [:div.md:flex.md:justify-between.text-center.md:text-left
    [:h1 "👋 Welcome to Clerk!"]
    #_[:div.text-sm.md:text-xs.font-sans.md:text-right.mt-1
       [:span.font-bold.block

--- a/src/nextjournal/clerk/index.clj
+++ b/src/nextjournal/clerk/index.clj
@@ -1,0 +1,57 @@
+(ns nextjournal.clerk.index
+  {:nextjournal.clerk/visibility {:code :hide :result :hide}}
+  (:require [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.viewer :as v]
+            [clojure.edn :as edn]))
+
+(defonce !paths (atom []))
+
+#_(reset! !paths nextjournal.clerk.builder/clerk-docs)
+
+(def index-item-viewer
+  {:pred string?
+   :transform-fn (clerk/update-val (fn [path]
+                                     (clerk/html
+                                      [:li.border-t.first:border-t-0.dark:border-gray-800.odd:bg-slate-50.dark:odd:bg-white
+                                       {:class "dark:odd:bg-opacity-[0.03]"}
+                                       [:a.pl-4.pr-4.py-2.flex.w-full.items-center.justify-between.hover:bg-indigo-50.dark:hover:bg-gray-700
+                                        {:href (clerk/doc-url path)}
+                                        [:span.text-sm.md:text-md.monospace.flex-auto.block.truncate path]
+                                        [:svg.h-4.w-4.flex-shrink-0 {:xmlns "http://www.w3.org/2000/svg" :fill "none" :viewBox "0 0 24 24" :stroke "currentColor"}
+                                         [:path {:stroke-linecap "round" :stroke-linejoin "round" :stroke-width "2" :d "M9 5l7 7-7 7"}]]]])))})
+
+(def index-viewer
+  {:render-fn '(fn [xs opts]
+                 [:div.not-prose
+                  [:h1.mb-4 "Clerk"]
+                  (into [:ul.border.dark:border-slate-800.rounded-md.overflow-hidden]
+                        (nextjournal.clerk.render/inspect-children opts)
+                        xs)])
+   :transform-fn (fn [wrapped-value]
+                   (update wrapped-value :nextjournal/viewers v/add-viewers [index-item-viewer]))})
+
+{::clerk/visibility {:result :show}}
+
+(clerk/with-viewer index-viewer @!paths)
+
+#_[:div.bg-gray-100.dark:bg-gray-900.flex.justify-center.overflow-y-auto.w-screen.h-screen.p-4.md:p-0
+   {:ref ref-fn}
+   [:div.fixed.top-2.left-2.md:left-auto.md:right-2.z-10
+    [render/dark-mode-toggle !state]]
+   [:div.md:my-12.w-full.md:max-w-lg
+    [:div.bg-white.dark:bg-gray-800.shadow-lg.rounded-lg.border.dark:border-gray-800.dark:text-white
+     [:div.px-4.md:px-8.py-3
+      [:h1.text-xl "Clerk"]]
+     (into [:ul]
+           (map (fn [path]
+                  [:li.border-t.dark:border-gray-900
+                   [:a.pl-4.md:pl-8.pr-4.py-2.flex.w-full.items-center.justify-between.hover:bg-indigo-50.dark:hover:bg-gray-700
+                    {:href (doc-url view-data path)}
+                    [:span.text-sm.md:text-md.monospace.flex-auto.block.truncate path]
+                    [:svg.h-4.w-4.flex-shrink-0 {:xmlns "http://www.w3.org/2000/svg" :fill "none" :viewBox "0 0 24 24" :stroke "currentColor"}
+                     [:path {:stroke-linecap "round" :stroke-linejoin "round" :stroke-width "2" :d "M9 5l7 7-7 7"}]]]]))
+           (sort paths))]
+    [:div.my-4.md:mb-0.text-xs.text-gray-400.sans-serif.px-4.md:px-8
+     [:a.hover:text-indigo-600.dark:hover:text-white
+      {:href "https://github.com/nextjournal/clerk"}
+      "Generated with Clerk."]]]]

--- a/src/nextjournal/clerk/index.clj
+++ b/src/nextjournal/clerk/index.clj
@@ -4,7 +4,6 @@
             [nextjournal.clerk.viewer :as v]
             [nextjournal.clerk.builder :as builder]
             [babashka.fs :as fs]
-            [clojure.java.io :as io]
             [clojure.edn :as edn]))
 
 (defn paths-from-deps [deps-edn]

--- a/src/nextjournal/clerk/index.clj
+++ b/src/nextjournal/clerk/index.clj
@@ -30,9 +30,9 @@
                    (update wrapped-value :nextjournal/viewers v/add-viewers [index-item-viewer]))})
 
 {::clerk/visibility {:result :show}}
-(let [{paths :ok :keys [error]} @!paths]
+(let [{:keys [paths error]} @!paths]
   (cond
-    error (clerk/html error)
+    error (clerk/md error)
     paths (clerk/with-viewer index-viewer paths)))
 
 #_[:div.bg-gray-100.dark:bg-gray-900.flex.justify-center.overflow-y-auto.w-screen.h-screen.p-4.md:p-0

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -169,7 +169,7 @@
   ;; We need to push an initial history state when the document is first loaded via a hard request
   (js/addEventListener "load" handle-initial-load))
 
-(defn render-notebook [{:as _doc xs :blocks :keys [bundle? css-class sidenotes? toc toc-visibility]} opts]
+(defn render-notebook [{:as _doc xs :blocks :keys [bundle? css-class sidenotes? toc toc-visibility header footer]} opts]
   (r/with-let [local-storage-key "clerk-navbar"
                navbar-width 220
                !state (r/atom {:toc (toc-items (:children toc))
@@ -224,6 +224,7 @@
              {:class "text-[12px]"} "ToC"]]
            {:class "z-10 fixed right-2 top-2 md:right-auto md:left-3 md:top-[7px] text-slate-400 font-sans text-xs hover:underline cursor-pointer flex items-center bg-white dark:bg-gray-900 py-1 px-3 md:p-0 rounded-full md:rounded-none border md:border-0 border-slate-200 dark:border-gray-500 shadow md:shadow-none dark:text-slate-400 dark:hover:text-white"}]
           [navbar/panel !state [navbar/navbar !state]]])
+       (prn :header header)
        [:div.flex-auto.w-screen.scroll-container
         (into
          [:> (.-div motion)
@@ -233,11 +234,10 @@
            :transition navbar/spring
            :class (str (or css-class "flex flex-col items-center notebook-viewer flex-auto ")
                        (when sidenotes? "sidenotes-layout"))}]
-
          ;; TODO: restore react keys via block-id
          ;; ^{:key (str processed-block-id "@" @!eval-counter)}
 
-         (inspect-children opts) xs)]])))
+         (inspect-children opts) (concat (when header [header]) xs (when footer [footer])))]])))
 
 (defn opts->query [opts]
   (->> opts

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -9,6 +9,7 @@
             [clojure.string :as str]
             [clojure.walk :as w]
             [editscript.core :as editscript]
+            [goog.events :as gevents]
             [goog.object]
             [goog.string :as gstring]
             [nextjournal.clerk.render.code :as code]
@@ -24,6 +25,7 @@
             [sci.core :as sci]
             [sci.ctx-store]
             [shadow.cljs.modern :refer [defclass]]))
+
 
 (r/set-default-compiler! (r/create-compiler {:function-components true}))
 
@@ -142,6 +144,7 @@
   (js/URL. href))
 
 (defn handle-anchor-click [^js e]
+  (prn :handle-anchor-click e)
   (when-some [url (some-> e .-target closest-anchor-parent .-href ->URL)]
     (when (= (.-search url) "?clerk/show!")
       (.preventDefault e)
@@ -157,17 +160,11 @@
             #js {:clerk_show path} nil (str "/" path (when fragment (str "#" fragment))))))
 
 (defn handle-history-popstate [^js e]
+  (prn :handle-history-popstate e)
   (when-some [notebook-path (some-> e .-state .-clerk_show)]
     (.preventDefault e)
     (clerk-eval (list 'nextjournal.clerk.webserver/navigate! {:nav-path notebook-path
                                                               :skip-history? true}))))
-
-(defn handle-initial-load [_]
-  (history-push-state {:path (subs js/location.pathname 1) :replace? true}))
-
-(when (exists? js/addEventListener)
-  ;; We need to push an initial history state when the document is first loaded via a hard request
-  (js/addEventListener "load" handle-initial-load))
 
 (defn render-notebook [{:as _doc xs :blocks :keys [bundle? css-class sidenotes? toc toc-visibility header footer]} opts]
   (r/with-let [local-storage-key "clerk-navbar"
@@ -187,20 +184,14 @@
                                         stored-open?
                                         (not= :collapsed toc-visibility))})
                root-ref-fn (fn [el]
-                             (if el
-                               (when (exists? js/document)
-                                 (js/document.addEventListener "click" handle-anchor-click)
-                                 (js/addEventListener "popstate" handle-history-popstate)
-                                 (setup-dark-mode! !state)
-                                 (when-some [heading (when (and (exists? js/location) (not bundle?))
-                                                       (try (some-> js/location .-hash not-empty js/decodeURI (subs 1) js/document.getElementById)
-                                                            (catch js/Error _
-                                                              (js/console.warn (str "Clerk render-notebook, invalid hash: "
-                                                                                    (.-hash js/location))))))]
-                                   (js/requestAnimationFrame #(.scrollIntoViewIfNeeded heading))))
-                               (when (exists? js/document)
-                                 (js/document.removeEventListener "click" handle-anchor-click)
-                                 (js/removeEventListener "popstate" handle-history-popstate))))]
+                             (when (and el (exists? js/document))
+                               (setup-dark-mode! !state)
+                               (when-some [heading (when (and (exists? js/location) (not bundle?))
+                                                     (try (some-> js/location .-hash not-empty js/decodeURI (subs 1) js/document.getElementById)
+                                                          (catch js/Error _
+                                                            (js/console.warn (str "Clerk render-notebook, invalid hash: "
+                                                                                  (.-hash js/location))))))]
+                                 (js/requestAnimationFrame #(.scrollIntoViewIfNeeded heading)))))]
     (let [{:keys [md-toc mobile? open? visibility]} @!state
           doc-inset (cond
                       mobile? 0
@@ -224,7 +215,6 @@
              {:class "text-[12px]"} "ToC"]]
            {:class "z-10 fixed right-2 top-2 md:right-auto md:left-3 md:top-[7px] text-slate-400 font-sans text-xs hover:underline cursor-pointer flex items-center bg-white dark:bg-gray-900 py-1 px-3 md:p-0 rounded-full md:rounded-none border md:border-0 border-slate-200 dark:border-gray-500 shadow md:shadow-none dark:text-slate-400 dark:hover:text-white"}]
           [navbar/panel !state [navbar/navbar !state]]])
-       (prn :header header)
        [:div.flex-auto.w-screen.scroll-container
         (into
          [:> (.-div motion)
@@ -767,9 +757,25 @@
   (when-let [el (and (exists? js/document) (js/document.getElementById "clerk"))]
     (react-client/createRoot el)))
 
+
+(defonce !listeners (atom #{}))
+
+(defn handle-initial-load [_]
+  (history-push-state {:path (subs js/location.pathname 1) :replace? true}))
+
+(defn setup-router! []
+  ;; TODO: unify with static app
+  (when (and (exists? js/document) (exists? js/window))
+    (doseq [listener @!listeners]
+      (gevents/unlistenByKey listener))
+    (reset! !listeners #{(gevents/listen js/document gevents/EventType.CLICK handle-anchor-click false)
+                         (gevents/listen js/window gevents/EventType.POPSTATE handle-history-popstate false)
+                         (gevents/listen js/window gevents/EventType.LOAD handle-initial-load false)})))
+
 (defn ^:export ^:dev/after-load mount []
   (when react-root
-    (.render react-root (r/as-element [root]))))
+    (.render react-root (r/as-element [root]))
+    (setup-router!)))
 
 (defn html-render [markup]
   (r/as-element

--- a/src/nextjournal/clerk/static_app.cljs
+++ b/src/nextjournal/clerk/static_app.cljs
@@ -24,10 +24,6 @@
             relative-root (str/join (repeat dir-depth "../"))]
         (str relative-root url)))))
 
-(defn hiccup [hiccup]
-  {:nextjournal/viewer render/html-viewer
-   :nextjournal/value hiccup})
-
 (defn show [{:keys [doc bundle?]}]
   (render/set-state! {:doc (assoc doc :bundle? bundle?)})
   [render/root])

--- a/src/nextjournal/clerk/static_app.cljs
+++ b/src/nextjournal/clerk/static_app.cljs
@@ -29,27 +29,9 @@
   {:nextjournal/viewer render/html-viewer
    :nextjournal/value hiccup})
 
-(defn show [{:as view-data :git/keys [sha url] :keys [bundle? doc path url->path]}]
-  (let [header [:div.viewer.w-full.max-w-prose.px-8
-                [:div.mb-8.text-xs.sans-serif.text-gray-400.not-prose
-                 (when (not= "" path)
-                   [:<>
-                    [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
-                     {:href (doc-url view-data "")} "Back to index"]
-                    [:span.mx-1 "/"]])
-                 [:span
-                  "Generated with "
-                  [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
-                   {:href "https://github.com/nextjournal/clerk"} "Clerk"]
-                  (when (and url sha (contains? url->path path))
-                    [:<>
-                     " from "
-                     [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
-                      {:href (str url "/blob/" sha "/" (url->path path))} (url->path path) "@" [:span.tabular-nums (subs sha 0 7)]]])]]]]
-    (render/set-state! {:doc (cond-> (assoc doc :bundle? bundle?)
-                               (vector? (get-in doc [:nextjournal/value :blocks]))
-                               (update-in [:nextjournal/value :blocks] (partial into [(hiccup header)])))})
-    [render/root]))
+(defn show [{:keys [doc bundle?]}]
+  (render/set-state! {:doc (assoc doc :bundle? bundle?)})
+  [render/root])
 
 (defn index [{:as view-data :keys [paths]}]
   (when (exists? js/document)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1069,6 +1069,13 @@
       #?(:clj (boolean (when-some [path (or nav-path file)]
                          (re-matches #"index\.(clj|cljc|md)" (str (last (fs/components path)))))))))
 
+(defn index-path [{:keys [static-build? index]}]
+  (prn :index (str index))
+  #?(:cljs ""
+     :clj (if static-build?
+            (if index (str index) "")
+            (if (fs/exists? "index.clj") "index.clj" "'nextjournal.clerk.index"))))
+
 (defn header [{:as opts :keys [file nav-path static-build?] :git/keys [url sha]}]
   (html [:div.viewer.w-full.max-w-prose.px-8.not-prose.mt-3
          [:div.mb-8.text-xs.sans-serif.text-slate-400
@@ -1080,7 +1087,7 @@
           (when (not (index? opts))
             [:<>
              [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
-              {:href (doc-url #?(:clj (if (fs/exists? "index.clj") "index.clj" "'nextjournal.clerk.index") :cljs ""))} "Index"]
+              {:href (doc-url (index-path opts))} "Index"]
              [:span.mx-2 "•"]])
           [:span
            (if static-build? "Generated with " "Served from ")

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1061,7 +1061,7 @@
 
 (declare html doc-url)
 
-(defn header [{:keys [url sha path url->path view-data]}]
+(defn header [{:keys [url sha path url->path view-data nav-path file]}]
   (html [:div.viewer.w-full.max-w-prose.px-8.not-prose.mt-3
          [:div.mb-8.text-xs.sans-serif.text-gray-400
           (when (not= "" path)
@@ -1078,14 +1078,17 @@
           [:span
            "Generated with "
            [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
-            {:href "https://github.com/nextjournal/clerk"} "Clerk"]
-           (when (and url sha (contains? url->path path))
-             [:<>
-              " from "
+            {:href "https://clerk.vision"} "Clerk"]
+           [:<>
+            " from "
+            (if (and url sha (contains? url->path path))
               [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
-               {:href (str url "/blob/" sha "/" (url->path path))} (url->path path) "@" [:span.tabular-nums (subs sha 0 7)]]])]]]))
+               {:href (str url "/blob/" sha "/" (url->path path))} (url->path path) "@" [:span.tabular-nums (subs sha 0 7)]]
+              (let [sha "6c335f97020a8c9aa74e9c694ee068b6b76755ee"] ;; TODO: get sha
+                [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
+                 {:href nav-path} file "@" [:span.tabular-nums (subs sha 0 7)]]))]]]]))
 
-#?(:clj (nextjournal.clerk/recompute!))
+(comment #?(:clj (nextjournal.clerk/recompute!)))
 
 (defn process-blocks [viewers {:as doc :keys [ns]}]
   (-> doc

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1099,10 +1099,9 @@
   (-> doc
       (assoc :atom-var-name->state (atom-var-name->state doc))
       (assoc :ns (->viewer-eval (list 'ns (if ns (ns-name ns) 'user))))
-      (update :blocks (partial into []
-                               (comp (mapcat (partial with-block-viewer (dissoc doc :error)))
-                                     (map (comp present
-                                                (partial ensure-wrapped-with-viewers viewers))))))
+      (update :blocks (partial into [] (comp (mapcat (partial with-block-viewer (dissoc doc :error)))
+                                             (map (comp present
+                                                        (partial ensure-wrapped-with-viewers viewers))))))
       (assoc :header (present (header doc)))
       #_(assoc :footer (present (footer doc)))
       (select-keys [:atom-var-name->state

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1064,8 +1064,10 @@
 (defn home? [{:keys [nav-path]}]
   (contains? #{"src/nextjournal/home.clj" "'nextjournal.clerk.home"} nav-path))
 
-(defn index? [{:keys [nav-path]}]
-  (contains? #{"index.clj" "src/nextjournal/index.clj" "'nextjournal.clerk.index"} nav-path))
+(defn index? [{:keys [nav-path file]}]
+  (or (and nav-path (= "'nextjournal.clerk.index" nav-path))
+      #?(:clj (boolean (when-some [path (or nav-path file)]
+                         (re-matches #"index\.(clj|cljc|md)" (str (last (fs/components path)))))))))
 
 (defn header [{:as opts :keys [url sha path url->path nav-path static-build?]}]
   (prn :header static-build? url sha path nav-path )

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -417,7 +417,7 @@
 
 #?(:clj
    (defn relative-root-prefix-from [path]
-     (str/join (repeat (get (frequencies (str path)) \/ 0) "../"))))
+     (str "./" (str/join (repeat (get (frequencies (str path)) \/ 0) "../")))))
 
 #?(:clj
    (defn map-index [{:as _opts :keys [index]} path]
@@ -1070,7 +1070,6 @@
                          (re-matches #"index\.(clj|cljc|md)" (str (last (fs/components path)))))))))
 
 (defn index-path [{:keys [static-build? index]}]
-  (prn :index (str index))
   #?(:cljs ""
      :clj (if static-build?
             (if index (str index) "")
@@ -1097,7 +1096,7 @@
            (let [default-index? (and static-build? (index? opts) (not (string? file)))]
              [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
               {:href (when (and url sha) (if default-index? (str url "/tree/" sha) (str url "/blob/" sha "/" file)))}
-              (if default-index? #?(:clj (subs (.getPath (URL. url)) 1) :cljs url) (str (or nav-path file)))
+              (if (and url default-index?) #?(:clj (subs (.getPath (URL. url)) 1) :cljs url) (str (or nav-path file)))
               (when sha [:<> "@" [:span.tabular-nums (subs sha 0 7)]])])]]]))
 
 (comment #?(:clj (nextjournal.clerk/recompute!)))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1069,8 +1069,7 @@
       #?(:clj (boolean (when-some [path (or nav-path file)]
                          (re-matches #"index\.(clj|cljc|md)" (str (last (fs/components path)))))))))
 
-(defn header [{:as opts :keys [url sha path url->path nav-path static-build?]}]
-  (prn :header static-build? url sha path nav-path )
+(defn header [{:as opts :keys [file nav-path static-build?] :git/keys [url sha]}]
   (html [:div.viewer.w-full.max-w-prose.px-8.not-prose.mt-3
          [:div.mb-8.text-xs.sans-serif.text-slate-400
           (when (and (not static-build?) (not (home? opts)))
@@ -1087,14 +1086,12 @@
            (if static-build? "Generated with " "Served from ")
            [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
             {:href "https://clerk.vision"} "Clerk"]
-           [:<>
-            " from "
-            (if (and url sha (contains? url->path path))
-              [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
-               {:href (str url "/blob/" sha "/" (url->path path))} (url->path path) "@" [:span.tabular-nums (subs sha 0 7)]]
-              (let [sha "6c335f97020a8c9aa74e9c694ee068b6b76755ee"] ;; TODO: get sha
-                [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
-                 {:href nav-path} nav-path "@" [:span.tabular-nums (subs sha 0 7)]]))]]]]))
+           " from "
+           (let [default-index? (and static-build? (index? opts) (not (string? file)))]
+             [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
+              {:href (when (and url sha) (if default-index? (str url "/tree/" sha) (str url "/blob/" sha "/" file)))}
+              (if default-index? #?(:clj (subs (.getPath (URL. url)) 1) :cljs url) (str (or nav-path file)))
+              (when sha [:<> "@" [:span.tabular-nums (subs sha 0 7)]])])]]]))
 
 (comment #?(:clj (nextjournal.clerk/recompute!)))
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -478,10 +478,10 @@
 
 (defn transform-result [{:as wrapped-value :keys [path]}]
   (let [{:as _cell :keys [form id] ::keys [result doc]} (:nextjournal/value wrapped-value)
-        {:keys [auto-expand-results? inline-results? bundle?]} doc
+        {:keys [auto-expand-results? static-build? bundle?]} doc
         {:nextjournal/keys [value blob-id viewers]} result
         blob-mode (cond
-                    (and (not inline-results?) blob-id) :lazy-load
+                    (and (not static-build?) blob-id) :lazy-load
                     bundle? :inline ;; TODO: provide a separte setting for this
                     :else :file)
         #?(:clj blob-opts :cljs _) (assoc doc :blob-mode blob-mode :blob-id blob-id)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1061,7 +1061,7 @@
 
 (declare html doc-url)
 
-(defn header [{:keys [url sha path url->path view-data nav-path file]}]
+(defn header [{:keys [url sha path url->path view-data nav-path file static-build?]}]
   (html [:div.viewer.w-full.max-w-prose.px-8.not-prose.mt-3
          [:div.mb-8.text-xs.sans-serif.text-gray-400
           (when (not= "" path)
@@ -1076,7 +1076,7 @@
                                    "'nextjournal.clerk.index"))} "Index"])
              [:span.mx-2 "•"]])
           [:span
-           "Generated with "
+           (if static-build? "Generated with " "Served from ")
            [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
             {:href "https://clerk.vision"} "Clerk"]
            [:<>
@@ -1086,7 +1086,7 @@
                {:href (str url "/blob/" sha "/" (url->path path))} (url->path path) "@" [:span.tabular-nums (subs sha 0 7)]]
               (let [sha "6c335f97020a8c9aa74e9c694ee068b6b76755ee"] ;; TODO: get sha
                 [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
-                 {:href nav-path} file "@" [:span.tabular-nums (subs sha 0 7)]]))]]]]))
+                 {:href nav-path} nav-path "@" [:span.tabular-nums (subs sha 0 7)]]))]]]]))
 
 (comment #?(:clj (nextjournal.clerk/recompute!)))
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1061,19 +1061,25 @@
 
 (declare html doc-url)
 
-(defn header [{:keys [url sha path url->path view-data nav-path file static-build?]}]
+(defn home? [{:keys [nav-path]}]
+  (contains? #{"src/nextjournal/home.clj" "'nextjournal.clerk.home"} nav-path))
+
+(defn index? [{:keys [nav-path]}]
+  (contains? #{"index.clj" "src/nextjournal/index.clj" "'nextjournal.clerk.index"} nav-path))
+
+(defn header [{:as opts :keys [url sha path url->path nav-path static-build?]}]
+  (prn :header static-build? url sha path nav-path )
   (html [:div.viewer.w-full.max-w-prose.px-8.not-prose.mt-3
          [:div.mb-8.text-xs.sans-serif.text-slate-400
-          (when (not= "" path)
+          (when (and (not static-build?) (not (home? opts)))
             [:<>
              [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
               {:href (doc-url "'nextjournal.clerk.home")} "Home"]
-             [:span.mx-2 "•"]
-             #?(:clj
-                [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
-                 {:href (doc-url (if (fs/exists? "index.clj")
-                                   "index.clj"
-                                   "'nextjournal.clerk.index"))} "Index"])
+             [:span.mx-2 "•"]])
+          (when (not (index? opts))
+            [:<>
+             [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
+              {:href (doc-url #?(:clj (if (fs/exists? "index.clj") "index.clj" "'nextjournal.clerk.index") :cljs ""))} "Index"]
              [:span.mx-2 "•"]])
           [:span
            (if static-build? "Generated with " "Served from ")

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1063,29 +1063,29 @@
 
 (defn header [{:keys [url sha path url->path view-data nav-path file static-build?]}]
   (html [:div.viewer.w-full.max-w-prose.px-8.not-prose.mt-3
-         [:div.mb-8.text-xs.sans-serif.text-gray-400
+         [:div.mb-8.text-xs.sans-serif.text-slate-400
           (when (not= "" path)
             [:<>
-             [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
+             [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
               {:href (doc-url "'nextjournal.clerk.home")} "Home"]
              [:span.mx-2 "•"]
              #?(:clj
-                [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
+                [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
                  {:href (doc-url (if (fs/exists? "index.clj")
                                    "index.clj"
                                    "'nextjournal.clerk.index"))} "Index"])
              [:span.mx-2 "•"]])
           [:span
            (if static-build? "Generated with " "Served from ")
-           [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
+           [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
             {:href "https://clerk.vision"} "Clerk"]
            [:<>
             " from "
             (if (and url sha (contains? url->path path))
-              [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
+              [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
                {:href (str url "/blob/" sha "/" (url->path path))} (url->path path) "@" [:span.tabular-nums (subs sha 0 7)]]
               (let [sha "6c335f97020a8c9aa74e9c694ee068b6b76755ee"] ;; TODO: get sha
-                [:a.hover:text-indigo-500.dark:hover:text-white.font-medium.border-b.border-dotted.border-gray-300
+                [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
                  {:href nav-path} nav-path "@" [:span.tabular-nums (subs sha 0 7)]]))]]]]))
 
 (comment #?(:clj (nextjournal.clerk/recompute!)))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1100,6 +1100,10 @@
               (if (and url default-index?) #?(:clj (subs (.getPath (URL. url)) 1) :cljs url) nav-path)
               (when sha [:<> "@" [:span.tabular-nums (subs sha 0 7)]])])]]]))
 
+(def header-viewer
+  {:name `header-viewer
+   :transform-fn (comp mark-presented (update-val header))})
+
 (comment #?(:clj (nextjournal.clerk/recompute!)))
 
 (defn process-blocks [viewers {:as doc :keys [ns]}]
@@ -1107,9 +1111,8 @@
       (assoc :atom-var-name->state (atom-var-name->state doc))
       (assoc :ns (->viewer-eval (list 'ns (if ns (ns-name ns) 'user))))
       (update :blocks (partial into [] (comp (mapcat (partial with-block-viewer (dissoc doc :error)))
-                                             (map (comp present
-                                                        (partial ensure-wrapped-with-viewers viewers))))))
-      (assoc :header (present (header doc)))
+                                             (map (comp present (partial ensure-wrapped-with-viewers viewers))))))
+      (assoc :header (present (with-viewers viewers (with-viewer `header-viewer doc))))
       #_(assoc :footer (present (footer doc)))
       (select-keys [:atom-var-name->state
                     :auto-expand-results?
@@ -1156,7 +1159,8 @@
 
 (def default-viewers
   ;; maybe make this a sorted-map
-  [char-viewer
+  [header-viewer
+   char-viewer
    string-viewer
    number-viewer
    number-hex-viewer

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -179,7 +179,8 @@
         (string? file-or-ns) (when (fs/exists? file-or-ns)
                                (fs/unixify (cond->> file-or-ns
                                              (fs/absolute? file-or-ns)
-                                             (fs/relativize (fs/cwd)))))))
+                                             (fs/relativize (fs/cwd)))))
+        :else (str file-or-ns)))
 
 #_(->nav-path 'nextjournal.clerk.home)
 #_(->nav-path 'nextjournal.clerk.tap)

--- a/test/nextjournal/clerk/builder_test.clj
+++ b/test/nextjournal/clerk/builder_test.clj
@@ -78,11 +78,11 @@
 
 (deftest doc-url
   (testing "link to same dir unbundled"
-    (is (= "../notebooks/rule_30.html" ;; NOTE: could also be just "rule_30.html"
+    (is (= "./../notebooks/rule_30.html" ;; NOTE: could also be just "rule_30.html"
            (builder/doc-url {:bundle? false} [{:file "notebooks/viewer_api.clj"} {:file "notebooks/rule_30.clj"}] "notebooks/viewer_api.clj" "notebooks/rule_30.clj"))))
 
   (testing "respects the mapped index"
-    (is (= "notebooks/rule_30.html"
+    (is (= "./notebooks/rule_30.html"
            (builder/doc-url {:bundle? false} [{:file "index.clj"} {:file "notebooks/rule_30.clj"}] "index.clj" "notebooks/rule_30.clj"))))
 
   (testing "bundle case"

--- a/test/nextjournal/clerk/builder_test.clj
+++ b/test/nextjournal/clerk/builder_test.clj
@@ -65,7 +65,11 @@
 
 (deftest build-static-app!
   (testing "error when paths are empty (issue #339)"
-    (is (thrown-with-msg? ExceptionInfo #"nothing to build" (builder/build-static-app! {:paths []})))))
+    (is (thrown-with-msg? ExceptionInfo #"nothing to build" (builder/build-static-app! {:paths []}))))
+
+  (testing "error when index is of the wrong type"
+    (is (thrown-with-msg? Exception #"`:index` must be" (builder/build-static-app! {:index 0})))
+    (is (thrown-with-msg? Exception #"`:index` must be" (builder/build-static-app! {:index "not/existing/notebook.clj"})))))
 
 (deftest process-build-opts
   (testing "assigns index when only one path is given"

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -262,12 +262,12 @@
 
   (testing "Doc options are propagated to blob processing"
     (let [test-doc (eval/eval-string "(java.awt.image.BufferedImage. 20 20 1)")]
-      (is (not-empty (tree-re-find (view/doc->viewer {:inline-results? true
+      (is (not-empty (tree-re-find (view/doc->viewer {:static-build? true
                                                       :bundle? true
                                                       :out-path builder/default-out-path} test-doc)
                                    #"data:image/png;base64")))
 
-      (is (not-empty (tree-re-find (view/doc->viewer {:inline-results? true
+      (is (not-empty (tree-re-find (view/doc->viewer {:static-build? true
                                                       :bundle? false
                                                       :out-path builder/default-out-path} test-doc)
                                    #"_data/.+\.png")))))


### PR DESCRIPTION
This improves the homepage including dark mode support. We also unify the index and make it usable in interactive mode so it's no longer needed to perform a `build!` to see it.

Add a header to the interactive mode that allows to navigate to both the index and home and allow to customize it.


* [x] Add index as a notebook
* [x] Fix multiple anchor click and history handlers after shadow reload
* [x] Add default index notebook to static build paths if none is given
* [x] Drop index view from static app 
* [x] Let `nextjournal.clerk.index` get paths from static build opts (currently always reads `deps.edn`
* [x] Rebuild header and (add footer ?) to in notebook-viewer @zampino 
* [x] Make header and footer customizable.
* [x] Only link to GitHub when sha is set (in static mode) @zampino 
* [x] Fix header in dark mode. @joe-loco
* [x] When there is no clerk alias with paths in `deps.edn` show error

Follow-up
* Build show file page. @joe-loco 
* Drop static_app.cljs in favour of render.cljs @zampino
* Unify homepage listing and static app index @joe-loco  
* follow up when a `deps.edn` guide lands in the book possibly in conjunction with a document section viewer
