### PR TITLE
Support consistent customization of viewer settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changes can be:
 * 🔗 Interactive Links, Index and Homepage
 
     Links can now be followed in interactive mode and the index can be viewed. Previously this could only be seen after a `build!`.
-    
+
     Use these features to build a new welcome page that gives more useful information, including links to potential notebooks in the project.
 
 * 🍕 `clerk/fragment` for splicing a seq of values into the document as if it were produced by results of individual cells. Useful when programmatically generating content.
@@ -23,7 +23,18 @@ Changes can be:
 * 🔗 Support following `clerk/doc-url` links in interactive mode. Previously these links would only be functional in the static build. Update the browser url accordingly and support evaluating a given doc by entering it in the browser's address bar.
 
 * 🚨 Change `nextjournal.clerk.render/clerk-eval` to not recompute the currently shown document when using the 1-arity version. Added a second arity that takes an opts map with a `:recompute?` key.
-1
+
+* ⭐️ Adds support for customization of viewer options 
+
+  Support both globally (via ns metadata or a settings marker) or locally (via form metadata or the viewer options map).
+  
+  Supported options are:
+   * `:nextjournal.clerk/auto-expand-results?`
+   * `:nextjournal.clerk/budget`
+   * `:nextjournal.clerk/css-class`
+   * `:nextjournal.clerk/visibility`
+   * `:nextjournal.clerk/width`
+
 * 🔌 Make websocket reconnect automatically on close to avoid having to reload the page
 
 * 💫 Cache expressions that return `nil` in memory

--- a/book.clj
+++ b/book.clj
@@ -730,10 +730,16 @@ v/table-viewer
     Moving --> Crash
     Crash --> [*]")
 
-;; ## 🙈 Controlling Visibility
+;; ## ⚙️ Customizations
 
-;; Visibility for code and results can be controlled document-wide and
-;; per top-level form. By default, Clerk will always show code and
+;; Clerk allows easy customization of visibility, result width and
+;; budget. All settings can be applied document-wide using `ns`
+;; metadata or a top-level settings marker and per form using
+;; metadata.
+
+;; ### 🙈 Visibility
+
+;; By default, Clerk will always show code and
 ;; results for a notebook.
 
 ;; You can use a map of the following shape to set the visibility of
@@ -792,6 +798,46 @@ v/table-viewer
 ;;    (rand-int 42) ;; code will be visible
 ;;
 ;; This comes in quite handy for debugging too!
+
+;; ### 🍽 Table of Contents
+
+;; If you want a table of contents like the one in this document, set the `:nextjournal.clerk/toc` option.
+;;
+;;    (ns doc-with-table-of-contents
+;;      {:nextjournal.clerk/toc true})
+;;
+;; If you want it to be collapsed initially, use `:collapsed` as a value.
+
+;; ### 🔮 Result Expansion
+
+;; If you want to better see the shape of your data without needing to
+;; click and expand it first, set the
+;; `:nextjournal.clerk/auto-expand-results?` option.
+
+^{::clerk/visibility {:code :hide :result :hide}}
+(defn make-rows [n]
+  (take n (repeatedly (fn []
+                        {:id (gensym)
+                         :name (str
+                                (rand-nth ["Oscar" "Karen" "Vlad" "Rebecca" "Conrad"]) " "
+                                (rand-nth ["Miller" "Stasčnyk" "Ronin" "Meyer" "Black"]))
+                         :role (rand-nth [:admin :operator :manager :programmer :designer])}))))
+
+
+
+
+^{::clerk/visibility {:code :hide}
+  ::clerk/auto-expand-results? true}
+(make-rows 5)
+
+;; This option might become the default in the future.
+
+
+;; ### 🙅🏼‍♂️ Viewer Budget
+
+;; In order to not send too much data to the browser, Clerk uses a per-result budget to limit. You can adjust it's default value of `200` using the `:nextjournal.clerk/budget` key.
+
+#_"TODO: add good example"
 
 ;; ## 🧱 Static Building
 

--- a/book.clj
+++ b/book.clj
@@ -737,6 +737,8 @@ v/table-viewer
 ;; metadata or a top-level settings marker and per form using
 ;; metadata.
 
+;; Let's start with a concrete example to understand how this works.
+
 ;; ### 🙈 Visibility
 
 ;; By default, Clerk will always show code and
@@ -814,30 +816,28 @@ v/table-viewer
 ;; click and expand it first, set the
 ;; `:nextjournal.clerk/auto-expand-results?` option.
 
-^{::clerk/visibility {:code :hide :result :hide}}
-(defn make-rows [n]
-  (take n (repeatedly (fn []
-                        {:id (gensym)
-                         :name (str
-                                (rand-nth ["Oscar" "Karen" "Vlad" "Rebecca" "Conrad"]) " "
-                                (rand-nth ["Miller" "Stasčnyk" "Ronin" "Meyer" "Black"]))
-                         :role (rand-nth [:admin :operator :manager :programmer :designer])}))))
-
-
-
 
 ^{::clerk/visibility {:code :hide}
   ::clerk/auto-expand-results? true}
-(make-rows 5)
+(def rows
+  (take 15 (repeatedly (fn []
+                         {:name (str
+                                 (rand-nth ["Oscar" "Karen" "Vlad" "Rebecca" "Conrad"]) " "
+                                 (rand-nth ["Miller" "Stasčnyk" "Ronin" "Meyer" "Black"]))
+                          :role (rand-nth [:admin :operator :manager :programmer :designer])
+                          :dice (shuffle (range 1 7))}))))
 
 ;; This option might become the default in the future.
 
 
 ;; ### 🙅🏼‍♂️ Viewer Budget
 
-;; In order to not send too much data to the browser, Clerk uses a per-result budget to limit. You can adjust it's default value of `200` using the `:nextjournal.clerk/budget` key.
+;; In order to not send too much data to the browser, Clerk uses a per-result budget to limit. You can see this budget in action above. Use the `:nextjournal.clerk/budget` key to change its default value of `200` or disable it completely using `nil`.
 
-#_"TODO: add good example"
+^{::clerk/budget nil
+  ::clerk/visibility {:code :hide}
+  ::clerk/auto-expand-results? true}
+rows
 
 ;; ## 🧱 Static Building
 

--- a/notebooks/viewer_classes.clj
+++ b/notebooks/viewer_classes.clj
@@ -5,8 +5,7 @@
             [clojure.string :as str]))
 
 (clerk/html
- {::clerk/css-class [:border :rounded-lg :shadow-lg :bg-white :p-4 :max-w-2xl :mx-auto]
-  ::clerk/width :wide}
+ {::clerk/css-class [:border :rounded-lg :shadow-lg :bg-white :p-4 :max-w-2xl :mx-auto]}
  [:div
   (clerk/vl {:width 700 :height 400 :data {:url "https://vega.github.io/vega-datasets/data/us-10m.json"
                                            :format {:type "topojson" :feature "counties"}}
@@ -21,3 +20,4 @@
        str/split-lines
        (group-by (comp keyword str/upper-case str first))
        (into (sorted-map))))
+

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -353,8 +353,6 @@
                        (-> doc :blocks count range))
          doc? (-> parser/add-block-visibility
                   parser/add-open-graph-metadata
-                  parser/add-auto-expand-results
-                  parser/add-css-class
                   filter-code-blocks-without-form))))))
 
 

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -351,10 +351,9 @@
                        (cond-> state
                          doc? (merge doc))
                        (-> doc :blocks count range))
-         doc? (-> parser/add-block-visibility
+         doc? (-> parser/add-block-settings
                   parser/add-open-graph-metadata
                   filter-code-blocks-without-form))))))
-
 
 #_(let [parsed (nextjournal.clerk.parser/parse-clojure-string "clojure.core/dec")]
     (build-graph (analyze-doc parsed)))

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -132,8 +132,8 @@
    (nextjournal.clerk.analyzer/analyze-doc
     (parse-file {:doc? true} "notebooks/open_graph.clj")))
 
-(defn add-open-graph-metadata [doc] (assoc doc :open-graph (->open-graph doc)))
-
+(defn add-open-graph-metadata [doc]
+  (assoc doc :open-graph (->open-graph doc)))
 
 (defn parse-global-block-settings
   "Parses the global (doc-wide) settings the given `form` if this node

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -48,6 +48,20 @@
 (defn visibility-marker? [form]
   (and (map? form) (contains? form :nextjournal.clerk/visibility)))
 
+(def block-settings
+  #{:nextjournal.clerk/auto-expand-results?
+    :nextjournal.clerk/budget
+    :nextjournal.clerk/css-class
+    :nextjournal.clerk/visibility
+    :nextjournal.clerk/width})
+
+(defn settings-marker? [form]
+  (boolean (and (map? form)
+                (some (fn [setting] (contains? form setting)) block-settings))))
+
+#_(settings-marker? {:foo :bar})
+#_(settings-marker? {:nextjournal.clerk/budget nil})
+
 (defn parse-visibility [form visibility]
   (or (legacy-form-visibility form visibility) ;; TODO: drop legacy visibiliy support before 1.0
       (when-let [visibility-map (and visibility (cond->> visibility (not (map? visibility)) (hash-map :code)))]
@@ -97,30 +111,12 @@
                        {:nextjournal.clerk/visibility {:result :hide}}))
 
 (defn parse-error-on-missing-vars [first-form]
-  (if-some [setting (when (ns? first-form)
-                      (get-doc-setting first-form :nextjournal.clerk/error-on-missing-vars))]
+  (if-some [setting (get-doc-setting first-form :nextjournal.clerk/error-on-missing-vars)]
     (do (when-not (#{:on :off} setting)
           (throw (ex-info (str "Invalid setting `" (pr-str setting) "` for `:nextjournal.clerk/error-on-missing-vars`. Valid values are `:on` and `:off`.")
                           {:nextjournal.clerk/error-on-missing-vars setting})))
         setting)
     (if (ns? first-form) :on :off)))
-
-(defn ->doc-settings [first-form]
-  (cond-> {:ns? (ns? first-form)
-           :error-on-missing-vars (parse-error-on-missing-vars first-form)
-           :toc-visibility (or (#{true :collapsed} (:nextjournal.clerk/toc
-                                                    (merge (-> first-form meta) ;; TODO: deprecate
-                                                           (when (ns? first-form)
-                                                             (merge (-> first-form second meta)
-                                                                    (first (filter map? first-form)))))))
-                               false)}
-    (ns? first-form)
-    (merge (select-keys (first (filter map? first-form))
-                        ;; TODO: unify with viewer
-                        [:nextjournal.clerk/auto-expand-results?
-                         :nextjournal.clerk/budget
-                         :nextjournal.clerk/css-class
-                         :nextjournal.clerk/width]))))
 
 (defn ->open-graph [{:keys [title blocks]}]
   (merge {:type "article:clerk"
@@ -138,6 +134,50 @@
 
 (defn add-open-graph-metadata [doc] (assoc doc :open-graph (->open-graph doc)))
 
+
+(defn parse-global-block-settings
+  "Parses the global (doc-wide) settings the given `form` if this node
+  is `ns?` or a `settings-marker?`. Returns `nil` otherwise."
+  [form]
+  (when (or (ns? form) (settings-marker? form))
+    (merge (when-let [val (->doc-visibility form)]
+             {:nextjournal.clerk/visibility val})
+           (select-keys (cond (settings-marker? form) form
+                              (ns? form) (first (filter map? form)))
+                        (disj block-settings :nextjournal.clerk/visibility)))))
+
+#_(parse-global-block-settings '(ns foo {:nextjournal.clerk/visibility {:code :fold}}))
+#_(parse-global-block-settings '(ns foo {:nextjournal.clerk/budget nil :nextjournal.clerk/width :full}))
+
+(defn parse-local-block-settings
+  "Parses the local settings of the given `form`."
+  [form]
+  (merge (some->> (->visibility form) (hash-map :nextjournal.clerk/visibility))
+         (select-keys (merge (meta form)
+                             (cond (settings-marker? form) form
+                                   (ns? form) (first (filter map? form))))
+                      (disj block-settings :nextjournal.clerk/visibility))))
+
+#_(parse-local-block-settings '(ns foo))
+#_(parse-local-block-settings '^{:nextjournal.clerk/budget nil
+                                 :nextjournal.clerk/visibility {:code :fold}}(inc 1))
+
+(defn ->doc-settings [first-form]
+  {:ns? (ns? first-form)
+   :error-on-missing-vars (parse-error-on-missing-vars first-form)
+   :toc-visibility (or (#{true :collapsed} (:nextjournal.clerk/toc
+                                            (merge (-> first-form meta) ;; TODO: deprecate
+                                                   (when (ns? first-form)
+                                                     (merge (-> first-form second meta)
+                                                            (first (filter map? first-form)))))))
+                       false)
+   :block-settings (merge-with merge
+                               {:nextjournal.clerk/visibility {:code :show :result :show}}
+                               (parse-global-block-settings first-form))})
+
+
+#_(->doc-settings '(ns foo {:nextjournal.clerk/visbility {:code :fold}}))
+#_(->doc-settings '(ns foo {:nextjournal.clerk/budget nil :nextjournal.clerk/width :full}))
 #_(->doc-settings '^{:nextjournal.clerk/toc :boom} (ns foo)) ;; TODO: error
 
 (defn markdown? [{:as block :keys [type]}]
@@ -146,16 +186,22 @@
 (defn code? [{:as block :keys [type]}]
   (contains? #{:code} type))
 
-(defn add-block-visibility [{:as analyzed-doc :keys [blocks]}]
-  (-> (reduce (fn [{:as state :keys [visibility]} {:as block :keys [form]}]
-                (let [visibility' (merge visibility (->doc-visibility form))]
-                  (cond-> (-> state
+(defn merge-settings [current-settings new-settings]
+  (-> (merge-with merge current-settings (select-keys new-settings [:nextjournal.clerk/visibility]))
+      (merge (dissoc new-settings :nextjournal.clerk/visibility))))
+
+#_(merge-settings {:nextjournal.clerk/visibility {:code :show :result :show}} {:nextjournal.clerk/visibility {:code :fold}})
+
+(defn add-block-settings [{:as analyzed-doc :keys [blocks block-settings]}]
+  (-> (reduce (fn [{:as state :keys [block-settings i]} {:as block :keys [form]}]
+                (let [next-block-settings (merge-settings block-settings (parse-global-block-settings form))]
+                  (cond-> (-> (update state :i inc)
                               (update :blocks conj (cond-> block
-                                                     (code? block) (assoc :visibility (merge visibility' (->visibility form))))))
-                    (code? block) (assoc :visibility visibility'))))
-              (assoc analyzed-doc :blocks [] :visibility {:code :show :result :show})
+                                                     (code? block) (assoc :settings (merge-settings next-block-settings (parse-local-block-settings form))))))
+                    (code? block) (assoc :block-settings next-block-settings))))
+              (assoc analyzed-doc :blocks [] :i 0)
               blocks)
-      (dissoc :visibility)))
+      (dissoc :block-settings)))
 
 (def code-tags
   #{:deref :map :meta :list :quote :syntax-quote :reader-macro :set :token :var :vector})

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -493,7 +493,6 @@
                                 (select-keys (disj (set (vals viewer-opts-normalization))
                                                    :nextjournal/viewer
                                                    :nextjournal/viewers)))
-        _ (prn :opts-from-form-meta opts-from-form-meta)
         {:as to-present :nextjournal/keys [auto-expand-results?]} (merge (dissoc (->opts wrapped-value) :!budget :nextjournal/budget)
                                                                          opts-from-block
                                                                          (ensure-wrapped-with-viewers (or viewers (get-viewers *ns*)) value)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -527,9 +527,7 @@
   {:name `hide-result-viewer :transform-fn (fn [_] nil)})
 
 (defn ->display [{:as code-cell :keys [result settings]}]
-  (let [{:as visibility :keys [code result]} (:nextjournal.clerk/visibility settings)]
-    (when-not visibility
-      (throw (ex-info "missing visibility" {:code-cell code-cell})))
+  (let [{:keys [code result]} (:nextjournal.clerk/visibility settings)]
     {:result? (not= :hide result)
      :fold? (= code :fold)
      :code? (not= :hide code)}))

--- a/test/nextjournal/clerk/parser_test.clj
+++ b/test/nextjournal/clerk/parser_test.clj
@@ -77,19 +77,21 @@ par two"))))
   (testing "sets toc visibility on doc"
     (is (:toc-visibility (analyze-string "(ns foo {:nextjournal.clerk/toc true})")))))
 
+(defn map-blocks-setting [setting {:keys [blocks]}]
+  (mapv #(get-in % [:settings :nextjournal.clerk/visibility]) blocks))
 
 (deftest add-block-visbility
   (testing "assigns doc visibility from ns metadata"
     (is (= [{:code :fold, :result :hide} {:code :fold, :result :show}]
-           (->> "(ns foo {:nextjournal.clerk/visibility {:code :fold}}) (rand-int 42)" analyze-string :blocks (mapv :visibility)))))
+           (->> "(ns foo {:nextjournal.clerk/visibility {:code :fold}}) (rand-int 42)" analyze-string (map-blocks-setting :nextjournal.clerk/visibility)))))
 
   (testing "assigns doc visibility from top-level visbility map marker"
     (is (= [{:code :hide, :result :hide} {:code :fold, :result :show}]
-           (->> "{:nextjournal.clerk/visibility {:code :fold}} (rand-int 42)" analyze-string :blocks (mapv :visibility)))))
+           (->> "{:nextjournal.clerk/visibility {:code :fold}} (rand-int 42)" analyze-string (map-blocks-setting :nextjournal.clerk/visibility)))))
 
   (testing "can change visibility halfway"
     (is (= [{:code :show, :result :show} {:code :hide, :result :hide} {:code :fold, :result :hide}]
-           (->> "(rand-int 42) {:nextjournal.clerk/visibility {:code :fold :result :hide}} (rand-int 42)" analyze-string :blocks (mapv :visibility))))))
+           (->> "(rand-int 42) {:nextjournal.clerk/visibility {:code :fold :result :hide}} (rand-int 42)" analyze-string (map-blocks-setting :nextjournal.clerk/visibility))))))
 
 (deftest add-open-graph-metadata
   (testing "OG metadata should be inferred, but customizable via ns map"


### PR DESCRIPTION
This adds support for customization of viewer options both globally (via ns metadata or a settings marker) or locally (via form metadata or the viewer options map). 