### PR TITLE
Simplify Settings

### DIFF
--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -53,6 +53,7 @@
     :nextjournal.clerk/budget
     :nextjournal.clerk/css-class
     :nextjournal.clerk/visibility
+    :nextjournal.clerk/opts
     :nextjournal.clerk/width})
 
 (defn settings-marker? [form]

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -192,14 +192,15 @@
 
 #_(merge-settings {:nextjournal.clerk/visibility {:code :show :result :show}} {:nextjournal.clerk/visibility {:code :fold}})
 
-(defn add-block-settings [{:as analyzed-doc :keys [blocks block-settings]}]
-  (-> (reduce (fn [{:as state :keys [block-settings i]} {:as block :keys [form]}]
+(defn add-block-settings [{:as analyzed-doc :keys [blocks]}]
+  (-> (reduce (fn [{:as state :keys [block-settings]} {:as block :keys [form]}]
                 (let [next-block-settings (merge-settings block-settings (parse-global-block-settings form))]
-                  (cond-> (-> (update state :i inc)
-                              (update :blocks conj (cond-> block
-                                                     (code? block) (assoc :settings (merge-settings next-block-settings (parse-local-block-settings form))))))
+                  (cond-> (update state :blocks conj
+                                  (cond-> block
+                                    (code? block)
+                                    (assoc :settings (merge-settings next-block-settings (parse-local-block-settings form)))))
                     (code? block) (assoc :block-settings next-block-settings))))
-              (assoc analyzed-doc :blocks [] :i 0)
+              (assoc analyzed-doc :blocks [])
               blocks)
       (dissoc :block-settings)))
 

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -76,7 +76,7 @@
 #_(parse-visibility nil {:code :fold :result :hide})
 
 (defn ->visibility [form]
-  (if (visibility-marker? form)
+  (if (settings-marker? form)
     {:code :hide :result :hide}
     (cond-> (parse-visibility form (-> form meta :nextjournal.clerk/visibility))
       (ns? form) (merge {:result :hide}))))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -489,14 +489,9 @@
         opts-from-block (-> settings
                             (select-keys (keys viewer-opts-normalization))
                             (set/rename-keys viewer-opts-normalization))
-        opts-from-form-meta (-> result
-                                (select-keys (disj (set (vals viewer-opts-normalization))
-                                                   :nextjournal/viewer
-                                                   :nextjournal/viewers)))
         {:as to-present :nextjournal/keys [auto-expand-results?]} (merge (dissoc (->opts wrapped-value) :!budget :nextjournal/budget)
                                                                          opts-from-block
-                                                                         (ensure-wrapped-with-viewers (or viewers (get-viewers *ns*)) value)
-                                                                         opts-from-form-meta)
+                                                                         (ensure-wrapped-with-viewers (or viewers (get-viewers *ns*)) value))
         presented-result (-> (present to-present)
                              (update :nextjournal/opts
                                      (fn [{:as opts existing-id :id}]
@@ -518,7 +513,7 @@
 
                                      #?@(:clj [(= blob-mode :lazy-load)
                                                (assoc :nextjournal/fetch-opts {:blob-id blob-id}
-                                                      :nextjournal/hash (analyzer/->hash-str [blob-id presented-result opts-from-form-meta]))]))}
+                                                      :nextjournal/hash (analyzer/->hash-str [blob-id presented-result opts-from-block]))]))}
                (dissoc presented-result :nextjournal/value :nextjournal/viewer :nextjournal/viewers)))))
 
 #_(nextjournal.clerk.view/doc->viewer @nextjournal.clerk.webserver/!doc)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -161,7 +161,7 @@
     (:nextjournal/css-class x)))
 
 (def viewer-opts-normalization
-  ":nextjournal.clerk/X => :nextjournal/X"
+  "Normalizes ns for viewer opts keywords `:nextjournal.clerk/x` => `:nextjournal/x`"
   (into {}
         (map (juxt #(keyword "nextjournal.clerk" (name %))
                    #(keyword "nextjournal" (name %))))
@@ -490,8 +490,6 @@
         opts-from-block (-> settings
                             (select-keys (keys viewer-opts-normalization))
                             (set/rename-keys viewer-opts-normalization))
-        #_ (println :opts-from-block opts-from-block)
-        #_ (println :opts-from-value (->opts (ensure-wrapped value)))
         {:as to-present :nextjournal/keys [auto-expand-results?]} (merge (dissoc (->opts wrapped-value) :!budget :nextjournal/budget)
                                                                          opts-from-block
                                                                          (ensure-wrapped-with-viewers (or viewers (get-viewers *ns*)) value))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -489,6 +489,8 @@
         opts-from-block (-> settings
                             (select-keys (keys viewer-opts-normalization))
                             (set/rename-keys viewer-opts-normalization))
+        #_ (println :opts-from-block opts-from-block)
+        #_ (println :opts-from-value (->opts (ensure-wrapped value)))
         {:as to-present :nextjournal/keys [auto-expand-results?]} (merge (dissoc (->opts wrapped-value) :!budget :nextjournal/budget)
                                                                          opts-from-block
                                                                          (ensure-wrapped-with-viewers (or viewers (get-viewers *ns*)) value))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -15,6 +15,7 @@
                        [sci.impl.vars]
                        [sci.lang]
                        [applied-science.js-interop :as j]])
+            [nextjournal.clerk.parser :as parser]
             [nextjournal.markdown :as md]
             [nextjournal.markdown.parser :as md.parser]
             [nextjournal.markdown.transform :as md.transform])
@@ -159,12 +160,12 @@
   (when (wrapped-value? x)
     (:nextjournal/css-class x)))
 
-
 (def viewer-opts-normalization
+  ":nextjournal.clerk/X => :nextjournal/X"
   (into {}
-        (map #(vector (keyword "nextjournal.clerk" (name %))
-                      (keyword "nextjournal"       (name %))))
-        [:auto-expand-results? :budget :viewer :viewers :opts :width :css-class]))
+        (map (juxt #(keyword "nextjournal.clerk" (name %))
+                   #(keyword "nextjournal" (name %))))
+        (conj parser/block-settings :viewer :viewers)))
 
 (defn throw-when-viewer-opts-invalid [opts]
   (when-not (map? opts)

--- a/test/nextjournal/clerk/eval_test.clj
+++ b/test/nextjournal/clerk/eval_test.clj
@@ -112,8 +112,8 @@
   (testing "assigning viewers from form meta"
     (is (match? {:blocks [{:result {:nextjournal/viewer fn?}}]}
                 (eval/eval-string "^{:nextjournal.clerk/viewer nextjournal.clerk/table} (def markup [:h1 \"hi\"])")))
-    (is (match? {:blocks [{:result {:nextjournal/viewer :html}}]}
-                (eval/eval-string "^{:nextjournal.clerk/viewer :html} (def markup [:h1 \"hi\"])"))))
+    (is (match? {:blocks [{:result {:nextjournal/viewer `viewer/html}}]}
+                (eval/eval-string "^{:nextjournal.clerk/viewer 'nextjournal.clerk.viewer/html} (def markup [:h1 \"hi\"])"))))
 
   (testing "var result that's not from a def should stay untouched"
     (is (match? {:blocks [{:result {:nextjournal/value {:nextjournal.clerk/var-from-def var?}}}

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -292,6 +292,27 @@
                view/doc->viewer v/->value :blocks second
                v/->value :nextjournal/presented :nextjournal/css-class))))
 
+  (testing "Settings propagation from ns to form"
+    (is (= :full
+           (-> (eval/eval-string "(ns nextjournal.clerk.viewer-test.settings {:nextjournal.clerk/width :full}) (nextjournal.clerk/html [:div])")
+               view/doc->viewer v/->value :blocks (nth 2)
+               v/->value :nextjournal/presented :nextjournal/width)))
+
+    (is (= :wide
+           (-> (eval/eval-string "(ns nextjournal.clerk.viewer-test.settings {:nextjournal.clerk/width :full}) (nextjournal.clerk/html {:nextjournal.clerk/width :wide} [:div])")
+               view/doc->viewer v/->value :blocks (nth 2)
+               v/->value :nextjournal/presented :nextjournal/width)))
+
+    (is (= :wide
+           (-> (eval/eval-string "(ns nextjournal.clerk.viewer-test.settings {:nextjournal.clerk/width :full}) ^{:nextjournal.clerk/width :wide} (nextjournal.clerk/html [:div])")
+               view/doc->viewer v/->value :blocks (nth 2)
+               v/->value :nextjournal/presented :nextjournal/width)))
+
+    (is (= :wide
+           (-> (eval/eval-string "(ns nextjournal.clerk.viewer-test.settings {:nextjournal.clerk/width :full}) {:nextjournal.clerk/width :wide} (nextjournal.clerk/html [:div])")
+               view/doc->viewer v/->value :blocks (nth 2)
+               v/->value :nextjournal/presented :nextjournal/width))))
+
   (testing "Presented doc (with fragments) has unambiguous ids assigned to results"
     (let [ids (->> (eval/eval-string "(nextjournal.clerk/table [[1 2][3 4]])
 (nextjournal.clerk/fragment


### PR DESCRIPTION
* Fix visibility of settings marker
* Removing redundant merge of options from meta in `v/transform-result` fixes
  * viewer opts now win over opts from meta 
  * opts from meta set on a fragment forms can be overridden by its children via viewer opts
* Unify allowed block settings with viewer key normalization

Follow up to #464.