### PR TITLE
Document-wide css class setting

### DIFF
--- a/notebooks/viewer_classes.clj
+++ b/notebooks/viewer_classes.clj
@@ -1,6 +1,6 @@
-(ns notebooks.viewer-classes
+(ns viewer-classes
   {:nextjournal.clerk/visibility {:code :hide}
-   :nextjournal.clerk/css-class [:justify-center :bg-slate-200 :dark:bg-slate-900 :py-8 :min-h-screen]}
+   :nextjournal.clerk/doc-css-class [:justify-center :bg-slate-200 :dark:bg-slate-900 :py-8 :min-h-screen]}
   (:require [nextjournal.clerk :as clerk]
             [clojure.string :as str]))
 
@@ -20,4 +20,3 @@
        str/split-lines
        (group-by (comp keyword str/upper-case str first))
        (into (sorted-map))))
-

--- a/notebooks/viewer_classes.clj
+++ b/notebooks/viewer_classes.clj
@@ -2,6 +2,7 @@
   {:nextjournal.clerk/visibility {:code :hide}
    :nextjournal.clerk/doc-css-class [:justify-center :bg-slate-200 :dark:bg-slate-900 :py-8 :min-h-screen]}
   (:require [nextjournal.clerk :as clerk]
+            [babashka.fs :as fs]
             [clojure.string :as str]))
 
 (clerk/html
@@ -16,7 +17,9 @@
 ^{::clerk/viewer clerk/table
   ::clerk/css-class [:max-w-2xl :mx-auto :bg-white :p-4 :rounded-lg :shadow-lg :mt-4]}
 (def dataset
-  (->> (slurp "/usr/share/dict/words")
+  (->> (slurp (if (fs/exists? "/usr/share/dict/words")
+                "/usr/share/dict/words"
+                "https://gist.githubusercontent.com/wchargin/8927565/raw/d9783627c731268fb2935a731a618aa8e95cf465/words"))
        str/split-lines
        (group-by (comp keyword str/upper-case str first))
        (into (sorted-map))))

--- a/notebooks/viewer_classes.clj
+++ b/notebooks/viewer_classes.clj
@@ -2,8 +2,26 @@
   {:nextjournal.clerk/visibility {:code :hide}
    :nextjournal.clerk/doc-css-class [:justify-center :bg-slate-200 :dark:bg-slate-900 :py-8 :min-h-screen]}
   (:require [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.viewer :as viewer]
             [babashka.fs :as fs]
             [clojure.string :as str]))
+
+;; Setting css classes globally should happen on the viewers for the
+;; notebook and results. This makes sense because it customizes the
+;; `:render-fn`.
+(clerk/set-viewers! [(assoc viewer/notebook-viewer :render-opts {:css-class [:justify-center :bg-slate-200 :dark:bg-slate-900 :py-8 :min-h-screen]})
+                     (assoc viewer/result-viewer :render-opts {:css-class [:border :rounded-lg :shadow-lg :bg-white :p-4 :max-w-2xl :mx-auto]})])
+
+;; To support customizing the result css class, we can't really use
+;; `:render-opts` because its opts don't apply to the result but to
+;; the wrapping `result-viewer`. Should we thus stick to
+;; `::clerk/css-class` for this?
+
+;; To make things work consistently, we'd then want to support
+;; `::clerk/css-class` on the ns meta again to change it doc-wide.
+
+;; We should rename `::clerk/opts` to `::clerk/render-opts` which
+;; communicates the intent much better.
 
 (clerk/html
  {::clerk/css-class [:border :rounded-lg :shadow-lg :bg-white :p-4 :max-w-2xl :mx-auto]}

--- a/notebooks/viewer_classes.clj
+++ b/notebooks/viewer_classes.clj
@@ -1,6 +1,8 @@
+;; # 🎨 Custom Viewer CSS Classes
 (ns viewer-classes
   {:nextjournal.clerk/visibility {:code :hide}
-   :nextjournal.clerk/doc-css-class [:justify-center :bg-slate-200 :dark:bg-slate-900 :py-8 :min-h-screen]}
+   :nextjournal.clerk/doc-css-class [:flex :flex-col :items-center
+                                     :justify-center :bg-slate-200 :dark:bg-slate-900 :py-8 :min-h-screen]}
   (:require [nextjournal.clerk :as clerk]
             [nextjournal.clerk.viewer :as viewer]
             [babashka.fs :as fs]
@@ -9,8 +11,18 @@
 ;; Setting css classes globally should happen on the viewers for the
 ;; notebook and results. This makes sense because it customizes the
 ;; `:render-fn`.
-(clerk/set-viewers! [(assoc viewer/notebook-viewer :render-opts {:css-class [:justify-center :bg-slate-200 :dark:bg-slate-900 :py-8 :min-h-screen]})
-                     (assoc viewer/result-viewer :render-opts {:css-class [:border :rounded-lg :shadow-lg :bg-white :p-4 :max-w-2xl :mx-auto]})])
+
+#_
+^{::clerk/visibility {:code :show}}
+(clerk/add-viewers!
+ [(assoc viewer/notebook-viewer
+         :render-opts {:css-class [:flex :flex-col :items-center
+                                   :justify-center :bg-slate-200 :dark:bg-slate-900 :py-8 :min-h-screen]})
+
+  (assoc viewer/result-viewer
+         :render-opts {:css-class [:border :rounded-lg :shadow-lg :bg-white :p-4 :max-w-2xl :mx-auto]})])
+#_
+(clerk/reset-viewers! (clerk/get-default-viewers))
 
 ;; To support customizing the result css class, we can't really use
 ;; `:render-opts` because its opts don't apply to the result but to

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -23,6 +23,7 @@
         (map #(str "notebooks/" % ".clj"))
         ["cards"
          "controlling_width"
+         "document_linking"
          "docs"
          "hello"
          "how_clerk_works"
@@ -41,6 +42,7 @@
          "visibility"
          "viewer_api"
          "viewer_api_meta"
+         "viewer_classes"
          "viewer_d3_require"
          "viewers_nested"
          "viewer_normalization"

--- a/src/nextjournal/clerk/builder_ui.clj
+++ b/src/nextjournal/clerk/builder_ui.clj
@@ -1,6 +1,6 @@
 (ns nextjournal.clerk.builder-ui
   {:nextjournal.clerk/visibility {:code :hide :result :hide}
-   :nextjournal.clerk/css-class [:pt-0]}
+   :nextjournal.clerk/doc-css-class [:pt-0]}
   (:require [nextjournal.clerk.viewer :as viewer]
             [clojure.string :as str]))
 
@@ -155,7 +155,7 @@
                              (str "unexpected state `" (pr-str state) "`"))]
        [:div.text-sm.font-medium.leading-none.truncate
         file]]
-      
+
       (when-let [{:keys [code code-executing]} (not-empty block-counts)]
         [:div.flex-shrink-0.whitespace-no-wrap.flex.items-center
          [:span.text-xs.mr-3
@@ -210,7 +210,7 @@
                               :errored "Errored")])
       [:div.text-sm.font-medium.leading-none
        phase-name]]
-     
+
      [:div.flex.items-center
       (when docs
         [:div.text-xs.mr-3 (count docs) " notebooks"])

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -48,7 +48,13 @@
 (defn visibility-marker? [form]
   (and (map? form) (contains? form :nextjournal.clerk/visibility)))
 
+(def doc-settings
+  "Settings allowed in the namespace's metadata map."
+  #{:nextjournal.clerk/doc-css-class})
+
 (def block-settings
+  "Settings allowed in form metadata or in viewer opttions. When specified in the namespace's meta map,
+  they apply to all forms in the notebook."
   #{:nextjournal.clerk/auto-expand-results?
     :nextjournal.clerk/budget
     :nextjournal.clerk/css-class
@@ -164,17 +170,20 @@
                                  :nextjournal.clerk/visibility {:code :fold}}(inc 1))
 
 (defn ->doc-settings [first-form]
-  {:ns? (ns? first-form)
-   :error-on-missing-vars (parse-error-on-missing-vars first-form)
-   :toc-visibility (or (#{true :collapsed} (:nextjournal.clerk/toc
-                                            (merge (-> first-form meta) ;; TODO: deprecate
-                                                   (when (ns? first-form)
-                                                     (merge (-> first-form second meta)
-                                                            (first (filter map? first-form)))))))
-                       false)
-   :block-settings (merge-with merge
-                               {:nextjournal.clerk/visibility {:code :show :result :show}}
-                               (parse-global-block-settings first-form))})
+  (merge
+   (when (ns? first-form) (select-keys (first (filter map? first-form)) doc-settings))
+   {:ns? (ns? first-form)
+    :error-on-missing-vars (parse-error-on-missing-vars first-form)
+    ;; TODO: unify with doc-settings, expose :n.c/toc-visibility user-facing
+    :toc-visibility (or (#{true :collapsed} (:nextjournal.clerk/toc
+                                             (merge (-> first-form meta) ;; TODO: deprecate
+                                                    (when (ns? first-form)
+                                                      (merge (-> first-form second meta)
+                                                             (first (filter map? first-form)))))))
+                        false)
+    :block-settings (merge-with merge
+                                {:nextjournal.clerk/visibility {:code :show :result :show}}
+                                (parse-global-block-settings first-form))}))
 
 
 #_(->doc-settings '(ns foo {:nextjournal.clerk/visbility {:code :fold}}))

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -161,8 +161,7 @@
     (.preventDefault e)
     (clerk-eval (list 'nextjournal.clerk.webserver/navigate! {:nav-path path :skip-history? true}))))
 
-(defn render-notebook [{:as doc xs :blocks
-                        :keys [bundle? sidenotes? toc toc-visibility header footer]} opts]
+(defn render-notebook [{xs :blocks :keys [bundle? sidenotes? toc toc-visibility header footer]} opts]
   (r/with-let [local-storage-key "clerk-navbar"
                navbar-width 220
                !state (r/atom {:toc (toc-items (:children toc))
@@ -317,7 +316,7 @@
     true (-> viewer/assign-expanded-at (get :nextjournal/expanded-at {}))))
 
 (defn result-css-class [render-opts x]
-  (let [{:as viewer viewer-name :name} (viewer/->viewer x)
+  (let [{viewer-name :name} (viewer/->viewer x)
         viewer-css-class (:css-class render-opts)
         inner-viewer-name (some-> x viewer/->value viewer/->viewer :name)]
     (js/console.log :render-opts render-opts :viewer-css-class viewer-css-class)
@@ -338,7 +337,7 @@
          :nested-prose "w-full max-w-prose"
          "w-full max-w-prose px-8")])))
 
-(defn render-result [{:nextjournal/keys [fetch-opts hash presented]} {:as opts :keys [id auto-expand-results? viewer css-class]}]
+(defn render-result [{:nextjournal/keys [fetch-opts hash presented]} {:as opts :keys [id auto-expand-results? css-class]}]
   (let [!desc (hooks/use-state-with-deps presented [hash])
         !expanded-at (hooks/use-state-with-deps (when (map? @!desc) (->expanded-at auto-expand-results? @!desc)) [hash])
         fetch-fn (hooks/use-callback (when fetch-opts

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -161,7 +161,9 @@
     (.preventDefault e)
     (clerk-eval (list 'nextjournal.clerk.webserver/navigate! {:nav-path path :skip-history? true}))))
 
-(defn render-notebook [{:as _doc xs :blocks :keys [bundle? css-class sidenotes? toc toc-visibility header footer]} opts]
+(defn render-notebook [{:as _doc xs :blocks
+                        :keys [bundle? sidenotes? toc toc-visibility header footer]
+                        :nextjournal.clerk/keys [doc-css-class]} opts]
   (r/with-let [local-storage-key "clerk-navbar"
                navbar-width 220
                !state (r/atom {:toc (toc-items (:children toc))
@@ -217,11 +219,10 @@
            :initial (when toc-visibility {:margin-left doc-inset})
            :animate (when toc-visibility {:margin-left doc-inset})
            :transition navbar/spring
-           :class (str (or css-class "flex flex-col items-center notebook-viewer flex-auto ")
-                       (when sidenotes? "sidenotes-layout"))}]
-         ;; TODO: restore react keys via block-id
-         ;; ^{:key (str processed-block-id "@" @!eval-counter)}
-
+           :class (let [klass (or doc-css-class "flex flex-col items-center notebook-viewer flex-auto ")]
+                    (cond-> klass
+                      (string? klass) vector
+                      sidenotes? (conj "sidenotes-layout")))}]
          (inspect-children opts) (concat (when header [header]) xs (when footer [footer])))]])))
 
 (defn opts->query [opts]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -390,6 +390,7 @@
 (defn expandable? [xs]
   (< 1 (count xs)))
 
+;; TODO: make this a def (drop the opts) call [inspect-presented x] and make !expanded-at info available via React context provider
 (defn inspect-children [opts]
   (map (fn [x] (cond-> [inspect-presented opts x]
                  (get-in x [:nextjournal/opts :id])
@@ -604,6 +605,7 @@
 (defn valid-react-element? [x] (react/isValidElement x))
 
 (defn inspect-presented
+  ;; TODO: drop arity-2, pass !expanded-at via React context provided from render-result (same as :fetch-fn)
   ([x]
    (r/with-let [!expanded-at (r/atom (:nextjournal/expanded-at x))]
      [inspect-presented {:!expanded-at !expanded-at} x]))
@@ -615,7 +617,7 @@
        ;; each view function must be called in its own 'functional component' so that it gets its own hook state.
        ^{:key (str (:hash viewer) "@" (peek (:path opts)))}
        [(:render-fn viewer) value (merge opts ;; TODO: verify we really want/need to merge, probably the table viewer needs it atm
-                                         ;; consider merging on the JVM on presentation
+                                         ;; consider merging on the JVM on presentation, this 3rd entry should just be (:nextjournal/opts x)
                                          (:render-opts viewer)
                                          (:nextjournal/opts x)
                                          {:viewer viewer :path path})]))))

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -7,9 +7,11 @@
 
 (defn doc->viewer
   ([doc] (doc->viewer {} doc))
-  ([opts {:as doc :keys [ns file]}]
+  ([opts {:as doc :keys [doc-css-class ns file]}]
    (binding [*ns* ns]
-     (-> (merge doc opts) v/notebook v/present))))
+     (-> (merge doc opts) v/notebook
+         (cond->> doc-css-class (v/with-viewers (v/add-viewers [(assoc-in v/notebook-viewer [:render-opts :css-class] doc-css-class)])))
+         v/present))))
 
 #_(doc->viewer (nextjournal.clerk/eval-file "notebooks/hello.clj"))
 #_(nextjournal.clerk/show! "notebooks/test.clj")

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -10,6 +10,7 @@
   ([opts {:as doc :keys [doc-css-class ns file]}]
    (binding [*ns* ns]
      (-> (merge doc opts) v/notebook
+         ;; TODO: drop this! (see `v/notebook-viewer`)
          (cond->> doc-css-class (v/with-viewers (v/add-viewers [(assoc-in v/notebook-viewer [:render-opts :css-class] doc-css-class)])))
          v/present))))
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1116,17 +1116,17 @@
                                              (map (comp present (partial ensure-wrapped-with-viewers viewers))))))
       (assoc :header (present (with-viewers viewers (with-viewer `header-viewer doc))))
       #_(assoc :footer (present (footer doc)))
-      (select-keys (concat parser/doc-settings
-                           [:atom-var-name->state
-                            :blocks :bundle?
-                            :error
-                            :open-graph
-                            :ns
-                            :title
-                            :toc
-                            :toc-visibility
-                            :header
-                            :footer]))
+      (select-keys [:atom-var-name->state
+                    :blocks :bundle?
+                    :nextjournal.clerk/css-class
+                    :error
+                    :open-graph
+                    :ns
+                    :title
+                    :toc
+                    :toc-visibility
+                    :header
+                    :footer])
       (update-if :error present)
       (assoc :sidenotes? (boolean (seq (:footnotes doc))))
       #?(:clj (cond-> ns (assoc :scope (datafy-scope ns))))))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1116,17 +1116,17 @@
                                              (map (comp present (partial ensure-wrapped-with-viewers viewers))))))
       (assoc :header (present (with-viewers viewers (with-viewer `header-viewer doc))))
       #_(assoc :footer (present (footer doc)))
-      (select-keys [:atom-var-name->state
-                    :blocks :bundle?
-                    :nextjournal.clerk/css-class
-                    :error
-                    :open-graph
-                    :ns
-                    :title
-                    :toc
-                    :toc-visibility
-                    :header
-                    :footer])
+      (select-keys (concat parser/doc-settings
+                           [:atom-var-name->state
+                            :blocks :bundle?
+                            :error
+                            :open-graph
+                            :ns
+                            :title
+                            :toc
+                            :toc-visibility
+                            :header
+                            :footer]))
       (update-if :error present)
       (assoc :sidenotes? (boolean (seq (:footnotes doc))))
       #?(:clj (cond-> ns (assoc :scope (datafy-scope ns))))))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -494,9 +494,9 @@
                                                                          opts-from-block
                                                                          (ensure-wrapped-with-viewers (or viewers (get-viewers *ns*)) value))
         presented-result (-> (present to-present)
-                             (update :nextjournal/opts
+                             (update :nextjournal/opts      ;; TODO rename to :nextjournal/render-opts
                                      (fn [{:as opts existing-id :id}]
-                                       (cond-> opts
+                                       (cond-> opts         ;; TODO: merge `opts` into :render-opts from viewer map
                                          auto-expand-results? (assoc :auto-expand-results? auto-expand-results?)
                                          (seq path) (assoc :fragment-item? true)
                                          (not existing-id) (assoc :id (processed-block-id (str id "-result") path)))))
@@ -942,6 +942,8 @@
                          (assoc :nextjournal/viewer `table-markup-viewer)
                          (update :nextjournal/width #(or % :wide))
                          (update :nextjournal/viewers update-table-viewers)
+                         ;; TODO: instead of setting opts in this wrapped value pass them as viewer-opts to the relevant child viewers directly (e.g. `table-row-viewer)
+                         ;; (merge of opts client-side will be dropped)
                          (update :nextjournal/opts merge {:num-cols (count (or head (first rows)))
                                                           :number-col? (into #{}
                                                                              (comp (map-indexed vector)
@@ -1137,6 +1139,8 @@
    :transform-fn (fn [{:as wrapped-value :nextjournal/keys [viewers]}]
                    (-> wrapped-value
                        (update :nextjournal/value (partial process-blocks viewers))
+                       ;; TODO: this will be safe once we drop propagation of ops via inspec-children in the client
+                       ;; (cond-> doc-css-class (assoc-in [:nextjournal/render-opts :css-class] doc-css-class))
                        mark-presented))})
 
 (def viewer-eval-viewer


### PR DESCRIPTION
Allow to configure a `:nextjournal.clerk/doc-css-class` in namespace metadata to customise the main notebook viewer class. Takes string or vector values.