### PR TITLE
Configure Paths for static Assets

### DIFF
--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -31,6 +31,8 @@
   (atom (or resource-manifest-from-props
             @!asset-map)))
 
+(defonce !static-assets-paths (atom ["public"]))
+
 #_(swap! !resource->url assoc "/css/viewer.css" "https://storage.googleapis.com/nextjournal-cas-eu/data/8VvAV62HzsvhcsXEkHP33uj4cV9UvdDz7DU9qLeVRCfEP9kWLFAzaMKL77trdx898DzcVyDVejdfxvxj5XB84UpWvQ")
 #_(swap! !resource->url dissoc "/css/viewer.css")
 #_(reset! !resource->url identity)


### PR DESCRIPTION
This allows to serve notebooks which might re-use view components created for rendering in different contexts/applications.