### PR TITLE
Metadata handling fixes in analyzer for #488 and #489

### DIFF
--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -12,6 +12,7 @@
             [clojure.tools.analyzer.ast :as ana-ast]
             [clojure.tools.analyzer.jvm :as ana-jvm]
             [clojure.tools.analyzer.utils :as ana-utils]
+            [clojure.walk :as walk]
             [multiformats.base.b58 :as b58]
             [multiformats.hash :as hash]
             [nextjournal.clerk.parser :as parser]
@@ -113,8 +114,12 @@
 (defn unresolvable-symbol-handler [ns sym ast-node]
   ast-node)
 
+(defn wrong-tag-handler [tag ast-node]
+  ast-node)
+
 (def analyzer-passes-opts
   (assoc ana-jvm/default-passes-opts
+         :validate/wrong-tag-handler wrong-tag-handler
          :validate/unresolvable-symbol-handler unresolvable-symbol-handler))
 
 (defn form->ex-data


### PR DESCRIPTION
This PR fixes the issues mentioned, by stripping metadata from forms before printing them to hash, and by not throwing an exception on an unrecognized class in a :type metadata tag.

closes #488 and #489