### PR TITLE
Update Clerk MVN version to the latest in the book

### DIFF
--- a/book.clj
+++ b/book.clj
@@ -58,7 +58,7 @@
 ;; To use Clerk in your project, add the following dependency to your `deps.edn`:
 
 ;; ```edn
-;; {:deps {io.github.nextjournal/clerk {:mvn/version "0.9.513"}}}
+;; {:deps {io.github.nextjournal/clerk {:mvn/version "0.13.842"}}}
 ;; ```
 
 ;; Require and start Clerk as part of your system start, e.g. in `user.clj`:


### PR DESCRIPTION
The version of Clerk mentioned in the book right now is updated.

The problem this caused (for me) was with the
`:nextjournal.clerk/visibility` clause, which was a set in the previous version and is a map now. The documentation suggests using a map, but the execution fails since it expects a set.

Fixes: #492