### PR TITLE
Add `meta-viewer` for metadata-based viewer assignment

### DIFF
--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -868,6 +868,17 @@
 (def mathjax-viewer
   {:name `mathjax-viewer :render-fn 'nextjournal.clerk.render/render-mathjax :transform-fn mark-presented})
 
+(def meta-viewer
+  {:name `meta-viewer
+   :pred (comp (some-fn fn? map?) :nextjournal.clerk/viewer meta)
+   :transform-fn
+   (update-val
+    (fn [v]
+      (let [viewer (-> v meta :nextjournal.clerk/viewer)]
+        (if (fn? viewer)
+          (viewer v)
+          (with-viewer viewer v)))))})
+
 (defn ->opts [wrapped-value]
   (select-keys wrapped-value [:nextjournal/budget :nextjournal/css-class :nextjournal/width :nextjournal/opts
                               :nextjournal/render-evaluator
@@ -1193,6 +1204,7 @@
    elision-viewer
    katex-viewer
    mathjax-viewer
+   meta-viewer
    html-viewer
    plotly-viewer
    vega-lite-viewer


### PR DESCRIPTION
@mk and I came up with this approach working on `emmy-viewers` together.

Another viewer I'd like to suggest for inclusion is a "reagent-viewer"... or maybe a `render-fn-viewer`. It acts on quoted reagent forms.

The existing `reagent-viewer` produces nothing for reagent forms like

```clojure
(clerk/with-viewer nextjournal.clerk.viewer/reagent-viewer
  ['mafs.core/Mafs {} ['mafs.coordinates/Cartesian {}]])
```

Here is the viewer:

```clojure
(defn- strip-meta [form]
  (postwalk (fn [x]
              (if (meta x)
                (vary-meta x dissoc ::clerk/viewer)
                x))
            form))

(def reagent-viewer
  {:name `reagent-viewer
   :transform-fn
   (clerk/update-val
    (fn [form]
      (clerk/with-viewer
        {:render-fn
         (list 'fn [] (strip-meta form))}
        nil)))})
```