### PR TITLE
Speed up analysis of gitlibs using git sha, resolve protocol methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Changes can be:
 
     Use these features to build a new welcome page that gives more useful information, including links to potential notebooks in the project.
 
+* ⚡️ Speed up analysis of gitlibs using git sha, resolve protocol methods
+
+    This significantly speeds up analysis for gitlibs by using the git sha as a hash (thus treating them as immutable) instead of handling them on a per-form level.
+
+    Also resolve protocol methods to the defining protocol, which would previously not be detected.
+
+    Lastly drop the location cache which is no longer needed.
+
 * 🍕 `clerk/fragment` for splicing a seq of values into the document as if it were produced by results of individual cells. Useful when programmatically generating content.
 
 * 🚨 Change `nextjournal.clerk.render/clerk-eval` to not recompute the currently shown document when using the 1-arity version. Added a second arity that takes an opts map with a `:recompute?` key.

--- a/notebooks/emmy.clj
+++ b/notebooks/emmy.clj
@@ -1,33 +1,39 @@
-(ns emmy-repro
+(ns emmy
   (:require [emmy.env :as e]
             [emmy.mechanics.lagrange]))
 
-;; ## BUG 1:
+;; `emmy.env` is importing vars via potemkin. This notebook exists to
+;; test that the analysis finds the correct locations for imported
+;; vars.
 
-;; This notebook takes close to 2 seconds to evaluate:
-
-;; Clerk evaluated '/Users/sritchie/code/clj/clerk-demo/notebooks/emmy_repro.clj' in 1853.674042ms.
-
-;; For the final Langrangian in generalized coordinates (the angles of each
-;; segment) by composing `L-rect` with a properly transformed `angles->rect`
-;; coordinate transform!
-
-;; ## BUG 2:
-;;
-;; The following form:
-
-#_
 (let [L (emmy.mechanics.lagrange/L-pendulum 'g 'm 'l)]
   (((e/Lagrange-equations L)
     (e/literal-function 'theta_1))
    't))
 
-;; Evaluates to this:
-(e/literal-number
- '(- (* 1/2 m 2 l (((expt D 2) theta_1) t) l) (* g m l (- (sin (theta_1 t))))))
+(comment
+  (require '[nextjournal.clerk.analyzer :as analyzer]
+           '[clj-async-profiler.core :as prof])
 
+  
+  (analyzer/unhashed-deps (:->analysis-info @nextjournal.clerk.webserver/!doc))
 
-;; But if I include it in a notebook, I get this:
+  (analyzer/find-location 'emmy.util.stopwatch/repr)
+  (analyzer/find-location 'emmy.value/zero?)
+  (meta #'emmy.value/zero?)
+  
+  (meta #'emmy.value/Value)
 
-;; Execution error (NullPointerException) at clojure.tools.analyzer.jvm.utils/members* (utils.clj:272).
-;; Cannot invoke "java.lang.Class.getName()" because the return value of "clojure.lang.IFn.invoke(Object)" is null
+  (def parsed
+    (nextjournal.clerk.parser/parse-file "notebooks/emmy.clj"))
+
+  (def analyzed
+    (analyzer/analyze-doc parsed))
+  
+  (time (do
+          (prof/profile (dotimes [i 10] (analyzer/build-graph analyzed)))
+          :done))
+
+  )
+
+#_(nextjournal.clerk/clear-cache!)

--- a/notebooks/profile.clj
+++ b/notebooks/profile.clj
@@ -10,6 +10,8 @@
 (def parsed
   (parser/parse-file "notebooks/rule_30.clj"))
 
+
+
 (def analyzed
   (analyzer/analyze-doc parsed))
 
@@ -18,6 +20,8 @@
 (do (time (analyzer/build-graph analyzed)) :done)
 
 
+
+(prof/profile (analyzer/build-graph analyzed))
 
 (prof/profile (analyzer/build-graph analyzed))
 

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -522,8 +522,6 @@
   * the form of an anonymous expression"
   ([]
    (swap! webserver/!doc dissoc :blob->result)
-   (reset! analyzer/!file->analysis-cache {})
-   (reset! analyzer/!ns->loc-cache {})
    (if (fs/exists? config/cache-dir)
      (do (fs/delete-tree config/cache-dir)
          (prn :cache-dir/deleted config/cache-dir))

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -75,7 +75,11 @@
     (is (every? symbol? (:deps (ana/analyze '(.hashCode clojure.lang.Compiler)))))
 
     (is (every? symbol? (:deps (ana/analyze '(defprotocol MyProtocol
-                                               (-check [_]))))))))
+                                               (-check [_])))))))
+
+  (testing "protocol methods are resolved to protocol in deps"
+    (is (= '#{nextjournal.clerk.analyzer/BoundedCountCheck}
+           (:deps (ana/analyze 'ana/-exceeds-bounded-count-limit?))))))
 
 (deftest read-string-tests
   (testing "read-string should read regex's such that value equalility is preserved"
@@ -193,16 +197,6 @@
 
   (testing "weavejester.dependency/graph"
     (is (re-find #"dependency-.*\.jar" (ana/find-location 'weavejester.dependency/graph)))))
-
-(deftest find-location+cache
-  (let [!ns->loc (atom {})]
-    (testing "populates the cache"
-      (ana/find-location+cache !ns->loc 'clojure.core/inc)
-      (is (= (@!ns->loc 'clojure.core) (ana/find-location 'clojure.core/inc))))
-
-    (testing "doesn't call `find-location` with cache populated"
-      (with-redefs [ana/find-location (fn [_] :bogus/value)]
-        (is (re-find #"clojure-1\..*\.jar" (ana/find-location+cache !ns->loc 'clojure.core/inc)))))))
 
 (defn analyze-string [s]
   (-> (parser/parse-clojure-string {:doc? true} s)

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -79,7 +79,7 @@
 
   (testing "protocol methods are resolved to protocol in deps"
     (is (= '#{nextjournal.clerk.analyzer/BoundedCountCheck}
-           (:deps (ana/analyze 'ana/-exceeds-bounded-count-limit?))))))
+           (:deps (ana/analyze 'nextjournal.clerk.analyzer/-exceeds-bounded-count-limit?))))))
 
 (deftest read-string-tests
   (testing "read-string should read regex's such that value equalility is preserved"


### PR DESCRIPTION
This significantly speeds up analysis for gitlibs by using the git sha as a hash (thus treating them as immutable) instead of handling them on a per-form level.

Also resolve protocol methods to the defining protocol, which would previously not be detected.

Lastly drop the location cache which is no longer needed.