### PR TITLE
Simplifies html render & drop reagent viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Changes can be:
 
 * 🚨 Rename `:nextjournal.clerk/opts` to `:nextjournal.clerk/render-opts` to clarify this options map is available as the second arg to parametrize the `:render-fn`. Still support the `:nextjournal.clerk/opts` for now.
 
+* 🚨 Simplify html rendering by removing `nextjournal.clerk.viewer/reagent-viewer`, `nextjournal.clerk.render/html-viewer`, `nextjournal.clerk.render/html`. Please use `nextjournal.clerk.viewer/html-viewer` and `nextjournal.clerk.viewer/html` instead.
+
 * 📖 Improve Table of Contents design and fixing re-rendering issues. Also added suport for chapter expansion.
 
 * 📒 Mention Tap Inspector in Book of Clerk & on Homepage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,20 @@ Changes can be:
 
 * 🚨 Rename `:nextjournal.clerk/opts` to `:nextjournal.clerk/render-opts` to clarify this options map is available as the second arg to parametrize the `:render-fn`. Still support the `:nextjournal.clerk/opts` for now.
 
-* 🚨 Simplify html rendering by removing `nextjournal.clerk.viewer/reagent-viewer`, `nextjournal.clerk.render/html-viewer`, `nextjournal.clerk.render/html`. Please use `nextjournal.clerk.viewer/html-viewer` and `nextjournal.clerk.viewer/html` instead.
+* 🚨 Simplify html rendering internals
+  
+  Removed
+  
+    * `nextjournal.clerk.viewer/reagent-viewer`,
+    * `nextjournal.clerk.render/html-viewer`,
+    * `nextjournal.clerk.render/html`, and
+    * `nextjournal.clerk.render/render-reagent`. 
+    
+  From now on, please use
+  * `nextjournal.clerk.viewer/html-viewer`, and
+  * `nextjournal.clerk.viewer/html` instead.
+  
+  Also rename `nextjournal.clerk.render/html-render` to `nextjournal.clerk.render/render-html` and make `nextjournal.clerk.viewer/html` use it when called from a reactive context.
 
 * 📖 Improve Table of Contents design and fixing re-rendering issues. Also added suport for chapter expansion.
 

--- a/notebooks/cards.clj
+++ b/notebooks/cards.clj
@@ -126,13 +126,12 @@
  (reagent/as-element [:h1 "♻️"]))
 
 (c/card
- (v/with-viewer `v/reagent-viewer
-   (fn []
-     (reagent/with-let [c (reagent/atom 0)]
-       [:<>
-        [:h2 "Count: " @c]
-        [:button.rounded.bg-blue-500.text-white.py-2.px-4.font-bold.mr-2 {:on-click #(swap! c inc)} "increment"]
-        [:button.rounded.bg-blue-500.text-white.py-2.px-4.font-bold {:on-click #(swap! c dec)} "decrement"]]))))
+ (v/with-viewer '(fn [] (reagent/with-let [c (reagent/atom 0)]
+                          [:<>
+                           [:h2 "Count: " @c]
+                           [:button.rounded.bg-blue-500.text-white.py-2.px-4.font-bold.mr-2 {:on-click #(swap! c inc)} "increment"]
+                           [:button.rounded.bg-blue-500.text-white.py-2.px-4.font-bold {:on-click #(swap! c dec)} "decrement"]]))
+   {}))
 
 ;; ## Using `v/with-viewer`
 (c/card
@@ -223,13 +222,6 @@
    (update doc :blocks (partial map (fn [{:as b :keys [type text]}]
                                       (cond-> b
                                         (= :code type)
-                                        (assoc :result
-                                               {:nextjournal/value
-                                                (let [val (eval (read-string text))]
-                                                  ;; FIXME: this won't be necessary once we unify v/html in SCI env to be the same as in nextjournal.clerk.viewer
-                                                  ;; v/html is currently html-render for supporting legacy render-fns
-                                                  (cond->> val
-                                                    (nextjournal.clerk.render/valid-react-element? val)
-                                                    (v/with-viewer v/reagent-viewer)))})))))
+                                        (assoc :result {:nextjournal/value (eval (read-string text))})))))
    (v/with-viewer v/notebook-viewer {::clerk/width :wide} doc))
  )

--- a/notebooks/cards.clj
+++ b/notebooks/cards.clj
@@ -1,7 +1,8 @@
 ;; # 🃏 CLJS Cards
-^{:nextjournal.clerk/toc true :nextjournal.clerk/visibility {:code :hide}}
 (ns cards
-  {:nextjournal.clerk/no-cache true}
+  {:nextjournal.clerk/toc true
+   :nextjournal.clerk/no-cache true
+   :nextjournal.clerk/visibility {:code :hide}}
   (:require [applied-science.js-interop :as-alias j]
             [cards-macro :as c]
             [nextjournal.clerk :as clerk]

--- a/notebooks/viewer_api.clj
+++ b/notebooks/viewer_api.clj
@@ -71,6 +71,10 @@
 (clerk/with-viewer '#(vector :div "Greetings to " [:strong %] "!")
   "James Clerk Maxwell")
 
+;; Legacy `:render-fn` with `html`:
+(clerk/with-viewer '#(nextjournal.clerk.viewer/html (vector :div "Greetings to " [:strong %] "!"))
+  "James Clerk Maxwell (legacy)")
+
 ^{::clerk/viewer {:render-fn '#(vector :span "The answer is " % ".")
                   :transform-fn (comp inc :nextjournal/value)}}
 (do 41)

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -27,7 +27,7 @@
 
 (r/set-default-compiler! (r/create-compiler {:function-components true}))
 
-(declare inspect inspect-presented reagent-viewer html html-viewer)
+(declare inspect inspect-presented html html-viewer)
 
 (def nbsp (gstring/unescapeEntities "&nbsp;"))
 

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -785,16 +785,10 @@
         (mount)))))
 
 
-(defn html-render [markup]
+(defn render-html [markup]
   (r/as-element (if (string? markup)
                   [:span {:dangerouslySetInnerHTML {:__html markup}}]
                   markup)))
-
-(def html-viewer
-  {:render-fn html-render})
-
-(def html
-  (partial viewer/with-viewer html-viewer))
 
 (defn render-promise [p opts]
   (let [!state (hooks/use-state {:pending true})]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -786,10 +786,9 @@
 
 
 (defn html-render [markup]
-  (r/as-element
-   (if (string? markup)
-     [:span {:dangerouslySetInnerHTML {:__html markup}}]
-     markup)))
+  (r/as-element (if (string? markup)
+                  [:span {:dangerouslySetInnerHTML {:__html markup}}]
+                  markup)))
 
 (def html-viewer
   {:render-fn html-render})

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -797,12 +797,6 @@
 (def html
   (partial viewer/with-viewer html-viewer))
 
-(defn render-reagent [x]
-  (r/as-element (cond-> x (fn? x) vector)))
-
-;; TODO: remove
-(def reagent-viewer render-reagent)
-
 (defn render-promise [p opts]
   (let [!state (hooks/use-state {:pending true})]
     (hooks/use-effect (fn []

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -105,8 +105,7 @@
 
 (def viewer-namespace
   (merge (sci/copy-ns nextjournal.clerk.viewer (sci/create-ns 'nextjournal.clerk.viewer))
-         {'html render/html-render
-          'doc-url doc-url
+         {'doc-url doc-url
           'url-for render/url-for
           'read-string read-string
           'read-string-without-tag-table read-string-without-tag-table

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -104,22 +104,22 @@
 (def ^{:doc "Stub implementation to be replaced during static site generation. Clerk is only serving one page currently."}
   doc-url (sci/new-var 'doc-url viewer/doc-url))
 
-(defn html-render-or-viewer [x]
+(defn ^:private render-html-or-viewer [x]
   ;; We've dropped the need to write `nextjournal.clerk.viewer/html` in `:render-fn`s in 0.12, see
   ;; https://github.com/nextjournal/clerk/blob/62b91b7e5a4487472129ea41095de6c62e8834ce/CHANGELOG.md#012699-2022-12-02
 
   ;; If we don't override `nextjournal.clerk.viewer/html` for the sci
   ;; env, we'd produce an infinte loop in the browser. So we're
   ;; instead checking if we're inside a reactive context and only
-  ;; calling html-render in that case. Otherwise (i.e. in
+  ;; calling `render-html` in that case. Otherwise (i.e. in
   ;; `notebooks/cards.clj` we call the normal viewer fn.
   (if ratom/*ratom-context*
-    (render/html-render x)
+    (render/render-html x)
     (viewer/html x)))
 
 (def viewer-namespace
   (merge (sci/copy-ns nextjournal.clerk.viewer (sci/create-ns 'nextjournal.clerk.viewer))
-         {'html html-render-or-viewer
+         {'html render-html-or-viewer
           'doc-url doc-url
           'url-for render/url-for
           'read-string read-string

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -911,7 +911,7 @@
 
 (def html-viewer
   {:name `html-viewer
-   :render-fn 'identity
+   :render-fn 'nextjournal.clerk.render/html-render
    :transform-fn (comp mark-presented transform-html)})
 
 #_(present (with-viewer html-viewer [:div {:nextjournal/value (range 30)} {:nextjournal/value (range 30)}]))
@@ -937,9 +937,6 @@
    :transform-fn (comp mark-presented
                        #(update-in % [:nextjournal/render-opts :language] (fn [lang] (or lang "clojure")))
                        (update-val (fn [v] (if (string? v) v (str/trim (with-out-str (pprint/pprint v)))))))})
-
-(def reagent-viewer
-  {:name `reagent-viewer :render-fn 'nextjournal.clerk.render/render-reagent :transform-fn mark-presented})
 
 (def row-viewer
   {:name `row-viewer :render-fn '(fn [items opts]
@@ -1265,7 +1262,6 @@
    plotly-viewer
    vega-lite-viewer
    markdown-viewer
-   reagent-viewer
    row-viewer
    col-viewer
    table-viewer

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -911,7 +911,7 @@
 
 (def html-viewer
   {:name `html-viewer
-   :render-fn 'nextjournal.clerk.render/html-render
+   :render-fn 'nextjournal.clerk.render/render-html
    :transform-fn (comp mark-presented transform-html)})
 
 #_(present (with-viewer html-viewer [:div {:nextjournal/value (range 30)} {:nextjournal/value (range 30)}]))


### PR DESCRIPTION
This simplifies the html rendering by:
* changing the `nextjournal.clerk.viewer/html` override (to `nextjournal.clerk.render/html-render`)
* setting the correct `:render-fn` on the `html-viewer`
* dropping the  superfluous `reagent-viewer`, folks should use the `html-viewer` instead
* dropping the superfluous `nextjournal.clerk.render/html` & `nextjournal.clerk.render/html-viewer`
