### PR TITLE
First cut of Clerk CLJS Editor component

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,7 +143,9 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0.3.0
 
       - name: 📓 Build Clerk Book
-        run: clojure -J-Dclojure.main.report=stderr -X:demo:nextjournal/clerk :git/sha '"${{ github.sha }}"' :git/url '"https://github.com/nextjournal/clerk"' :paths '["book.clj" "CHANGELOG.md"]'
+        run: |
+          cp notebooks/editor.clj editor.clj
+          clojure -J-Dclojure.main.report=stderr -X:demo:nextjournal/clerk :git/sha '"${{ github.sha }}"' :git/url '"https://github.com/nextjournal/clerk"' :paths '["book.clj" "CHANGELOG.md" "editor.clj"]'
 
       - name: 🏗 Build Clerk Static App with default Notebooks
         run: clojure -J-Dclojure.main.report=stderr -X:demo:nextjournal/clerk :git/sha '"${{ github.sha }}"' :git/url '"https://github.com/nextjournal/clerk"' :bundle true

--- a/notebooks/editor.clj
+++ b/notebooks/editor.clj
@@ -1,0 +1,29 @@
+(ns notebooks.editor
+  {:nextjournal.clerk/visibility {:code :hide}
+   :nextjournal.clerk/doc-css-class [:overflow-hidden :p-0]}
+  (:require [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.viewer :as v]))
+
+(clerk/with-viewer
+  {:render-fn 'nextjournal.clerk.render.editor/view
+   :transform-fn clerk/mark-presented}
+  ";; # 👋 Hello CLJS
+;; This is `fold`
+;;
+;; $$(\\beta\\rightarrow\\alpha\\rightarrow\\beta)\\rightarrow\\beta\\rightarrow [\\alpha] \\rightarrow\\beta$$
+;;
+(defn fold [f i xs]
+  (if (seq xs)
+    (fold f (f i (first xs)) (rest xs))
+    i))
+
+(fold str \"\" (range 10))
+
+;; ## And the usual Clerk's perks
+(nextjournal.clerk.viewer/plotly {:data [{:y (shuffle (range 10)) :name \"The Federation\"}
+                  {:y (shuffle (range 10)) :name \"The Empire\"}]})
+;; tables
+(nextjournal.clerk.viewer/table {:a [1 2 3] :b [4 5 6]})
+;; html
+(nextjournal.clerk.viewer/html [:h1 \"🧨\"])
+")

--- a/notebooks/editor.clj
+++ b/notebooks/editor.clj
@@ -7,23 +7,4 @@
 (clerk/with-viewer
   {:render-fn 'nextjournal.clerk.render.editor/view
    :transform-fn clerk/mark-presented}
-  ";; # 👋 Hello CLJS
-;; This is `fold`
-;;
-;; $$(\\beta\\rightarrow\\alpha\\rightarrow\\beta)\\rightarrow\\beta\\rightarrow [\\alpha] \\rightarrow\\beta$$
-;;
-(defn fold [f i xs]
-  (if (seq xs)
-    (fold f (f i (first xs)) (rest xs))
-    i))
-
-(fold str \"\" (range 10))
-
-;; ## And the usual Clerk's perks
-(nextjournal.clerk.viewer/plotly {:data [{:y (shuffle (range 10)) :name \"The Federation\"}
-                  {:y (shuffle (range 10)) :name \"The Empire\"}]})
-;; tables
-(nextjournal.clerk.viewer/table {:a [1 2 3] :b [4 5 6]})
-;; html
-(nextjournal.clerk.viewer/html [:h1 \"🧨\"])
-")
+  (slurp "notebooks/rule_30.clj"))

--- a/notebooks/editor.clj
+++ b/notebooks/editor.clj
@@ -1,8 +1,7 @@
 (ns editor
   {:nextjournal.clerk/visibility {:code :hide}
    :nextjournal.clerk/doc-css-class [:overflow-hidden :p-0]}
-  (:require [nextjournal.clerk :as clerk]
-            [nextjournal.clerk.viewer :as v]))
+  (:require [nextjournal.clerk :as clerk]))
 
 (clerk/with-viewer
   {:render-fn 'nextjournal.clerk.render.editor/view

--- a/notebooks/editor.clj
+++ b/notebooks/editor.clj
@@ -1,4 +1,4 @@
-(ns notebooks.editor
+(ns editor
   {:nextjournal.clerk/visibility {:code :hide}
    :nextjournal.clerk/doc-css-class [:overflow-hidden :p-0]}
   (:require [nextjournal.clerk :as clerk]

--- a/notebooks/rule_30.clj
+++ b/notebooks/rule_30.clj
@@ -10,7 +10,8 @@
    {:pred (every-pred list? (partial every? (some-fn number? vector?)))
     :render-fn '#(into [:div.flex.flex-col] (nextjournal.clerk.render/inspect-children %2) %1)}
    {:pred (every-pred vector? (complement map-entry?) (partial every? number?))
-    :render-fn '#(into [:div.flex.inline-flex] (nextjournal.clerk.render/inspect-children %2) %1)}])
+    :render-fn '#(into [:div.flex.inline-flex] (nextjournal.clerk.render/inspect-children %2) %1)}
+   {:pred var? :transform-fn (clerk/update-val deref)}])
 
 (clerk/add-viewers! viewers)
 

--- a/notebooks/rule_30.clj
+++ b/notebooks/rule_30.clj
@@ -10,7 +10,9 @@
    {:pred (every-pred list? (partial every? (some-fn number? vector?)))
     :render-fn '#(into [:div.flex.flex-col] (nextjournal.clerk.render/inspect-children %2) %1)}
    {:pred (every-pred vector? (complement map-entry?) (partial every? number?))
-    :render-fn '#(into [:div.flex.inline-flex] (nextjournal.clerk.render/inspect-children %2) %1)}])
+    :render-fn '#(into [:div.flex.inline-flex] (nextjournal.clerk.render/inspect-children %2) %1)}
+   {:pred var?
+    :transform-fn (clerk/update-val deref)}])
 
 (clerk/add-viewers! viewers)
 

--- a/notebooks/rule_30.clj
+++ b/notebooks/rule_30.clj
@@ -1,7 +1,7 @@
 ;; # Rule 30 🕹
 ;; Let's explore cellular automata in a Clerk Notebook. We start by requiring the custom viewers.
 (ns rule-30
-  (:require [nextjournal.clerk :as clerk]))
+  (:require [nextjournal.clerk.viewer :as clerk]))
 
 (def viewers
   [{:pred number?

--- a/notebooks/rule_30.clj
+++ b/notebooks/rule_30.clj
@@ -1,7 +1,7 @@
 ;; # Rule 30 🕹
 ;; Let's explore cellular automata in a Clerk Notebook. We start by requiring the custom viewers.
 (ns rule-30
-  (:require [nextjournal.clerk.viewer :as clerk]))
+  (:require [nextjournal.clerk :as clerk]))
 
 (def viewers
   [{:pred number?

--- a/notebooks/rule_30.clj
+++ b/notebooks/rule_30.clj
@@ -10,9 +10,7 @@
    {:pred (every-pred list? (partial every? (some-fn number? vector?)))
     :render-fn '#(into [:div.flex.flex-col] (nextjournal.clerk.render/inspect-children %2) %1)}
    {:pred (every-pred vector? (complement map-entry?) (partial every? number?))
-    :render-fn '#(into [:div.flex.inline-flex] (nextjournal.clerk.render/inspect-children %2) %1)}
-   {:pred var?
-    :transform-fn (clerk/update-val deref)}])
+    :render-fn '#(into [:div.flex.inline-flex] (nextjournal.clerk.render/inspect-children %2) %1)}])
 
 (clerk/add-viewers! viewers)
 

--- a/render/deps.edn
+++ b/render/deps.edn
@@ -5,7 +5,7 @@
         org.babashka/sci {:mvn/version "0.7.39"}
         reagent/reagent {:mvn/version "1.2.0"}
         io.github.babashka/sci.configs {:git/sha "0702ea5a21ad92e6d7cca6d36de84271083ea68f"}
-        io.github.nextjournal/clojure-mode {:git/sha "ac038ebf6e5da09dd2b8a31609e9ff4a65e36852"}
+        io.github.nextjournal/clojure-mode {:git/sha "1f55406087814a0dda6806396aa596dbe13ea302"}
         thheller/shadow-cljs {:mvn/version "2.23.1"}
         io.github.squint-cljs/cherry {;; :local/root "/Users/borkdude/dev/cherry"
                                       :git/sha "ac89d93f136ee8fab91f62949de5b5822ba08b3c"}}}

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -310,9 +310,6 @@
             (throw (ex-info (str "The var `#'" missing-dep "` is being referenced, but Clerk can't find it in the namespace's source code. Did you remove it? This validation can fail when the namespace is mutated programmatically (e.g. using `clojure.core/intern` or side-effecting macros). You can turn off this check by adding `{:nextjournal.clerk/error-on-missing-vars :off}` to the namespace metadata.")
                             {:var-name missing-dep :form form :file file #_#_:defined defined }))))))))
 
-(defn filter-code-blocks-without-form [doc]
-  (update doc :blocks #(filterv (some-fn :form (complement parser/code?)) %)))
-
 (defn ns-resolver [notebook-ns]
   (if notebook-ns
     (into {} (map (juxt key (comp ns-name val))) (ns-aliases notebook-ns))
@@ -363,7 +360,7 @@
                        (-> doc :blocks count range))
          doc? (-> parser/add-block-settings
                   parser/add-open-graph-metadata
-                  filter-code-blocks-without-form))))))
+                  parser/filter-code-blocks-without-form))))))
 
 #_(let [parsed (nextjournal.clerk.parser/parse-clojure-string "clojure.core/dec")]
     (build-graph (analyze-doc parsed)))

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -28,6 +28,7 @@
          "controlling_width"
          "docs"
          "document_linking"
+         "editor"
          "hello"
          "how_clerk_works"
          "exec_status"

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -324,7 +324,6 @@
                     (update :nodes rest)
                     (update :blocks conj {:type :code
                                           :text (n/string node)
-                                          :node node
                                           :loc (-> (meta node)
                                                    (set/rename-keys {:row :line :end-row :end-line
                                                                      :col :column :end-col :end-column})

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -372,6 +372,9 @@
 #_(runnable-code-block? {:type :code :language "clojure" :info "clojure"})
 #_(runnable-code-block? {:type :code :language "clojure" :info "clojure {:nextjournal.clerk/code-listing true}"})
 
+(defn filter-code-blocks-without-form [doc]
+  (update doc :blocks #(filterv (some-fn :form (complement code?)) %)))
+
 (defn parse-markdown-string [{:as opts :keys [doc?]} s]
   (let [{:as ctx :keys [content]} (parse-markdown (markdown-context) s)]
     (loop [{:as state :keys [nodes] ::keys [md-slice]} {:blocks [] ::md-slice [] :nodes content :md-context ctx}]

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -324,6 +324,7 @@
                     (update :nodes rest)
                     (update :blocks conj {:type :code
                                           :text (n/string node)
+                                          :node node
                                           :loc (-> (meta node)
                                                    (set/rename-keys {:row :line :end-row :end-line
                                                                      :col :column :end-col :end-column})

--- a/src/nextjournal/clerk/render/code.cljs
+++ b/src/nextjournal/clerk/render/code.cljs
@@ -151,7 +151,22 @@
                                  :overflow "hidden"}
                   ".cm-tooltip > ul > li" {:padding "3px 10px 3px 0 !important"}
                   ".cm-tooltip > ul > li:first-child" {:border-top-left-radius "3px"
-                                                       :border-top-right-radius "3px"}})))
+                                                       :border-top-right-radius "3px"}
+                  ".cm-tooltip.cm-tooltip-autocomplete" {:border "0"
+                                                         :border-radius "6px"
+                                                         :box-shadow "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)"
+                                                         "& > ul" {:font-size "12px"
+                                                                   :font-family "'Fira Code', monospace"
+                                                                   :background "rgb(241 245 249)"
+                                                                   :border "1px solid rgb(203 213 225)"
+                                                                   :border-radius "6px"}}
+                  ".cm-tooltip-autocomplete ul li[aria-selected]" {:background "rgb(79 70 229)"
+                                                                   :color "#fff"}
+                  ".cm-tooltip.cm-tooltip-hover" {:background "rgb(241 245 249)"
+                                                  :border-radius "6px"
+                                                  :border "1px solid rgb(203 213 225)"
+                                                  :box-shadow "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)"
+                                                  :max-width "550px"}})))
 
 (def read-only (.. EditorView -editable (of false)))
 

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -144,7 +144,7 @@
      [:style {:type "text/css"} ".notebook-viewer { padding-top: 2.5rem; } .notebook-viewer .viewer:first-child { display: none; }"]
      [:div.fixed.w-screen.h-screen.flex.flex-col.top-0.left-0
       [:div.flex
-       [:div.bg-slate-200.border-r.border-slate-300.dark:border-slate-600.px-4.py-3.dark:bg-slate-800
+       [:div.bg-slate-200.border-r.border-slate-300.dark:border-slate-600.px-4.py-3.dark:bg-slate-800.overflow-y-auto
         {:class "w-[50vw]" :style {:height (str "calc(100vh - " command-bar-height "px)")}}
         [:div.h-screen {:ref !container-el}]]
        [:div.bg-white.dark:bg-slate-950.bg-white.flex.flex-col.overflow-y-auto

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -73,14 +73,8 @@
     (update doc :blocks (partial map (fn [{:as b :keys [type text]}]
                                        (cond-> b
                                          (= :code type)
-                                         (assoc :result
-                                                {:nextjournal/value
-                                                 (let [val (eval (render/read-string text))]
-                                                   ;; FIXME: this won't be necessary once we unify v/html in SCI env to be the same as in nextjournal.clerk.viewer
-                                                   ;; v/html is currently html-render for supporting legacy render-fns
-                                                   (cond->> val
-                                                     (render/valid-react-element? val)
-                                                     (v/with-viewer v/reagent-viewer)))})))))
+                                         (assoc :result                                                
+                                                {:nextjournal/value (eval (render/read-string text))})))))
     (v/with-viewer v/notebook-viewer {:nextjournal.clerk/width :wide} doc)))
 
 (defonce bar-height 26)
@@ -95,8 +89,7 @@
         on-result #(reset! !eval-result %)
         on-eval #(reset! !notebook (try
                                      (eval-notebook (.. % -state -doc toString))
-                                     (catch js/Error error (v/with-viewer v/reagent-viewer
-                                                             [render/error-view error]))))]
+                                     (catch js/Error error (v/html [render/error-view error]))))]
     (hooks/use-effect
      (fn []
        (let [^js view

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -1,0 +1,149 @@
+(ns nextjournal.clerk.render.editor
+  (:require ["@codemirror/autocomplete" :refer [autocompletion]]
+            ["@codemirror/language" :refer [syntaxTree]]
+            ["@codemirror/view" :refer [keymap placeholder hoverTooltip]]
+            ["@nextjournal/lang-clojure" :refer [clojureLanguage]]
+            ["react" :as react]
+            [applied-science.js-interop :as j]
+            [clojure.string :as str]
+            [nextjournal.clerk.render.hooks :as hooks]
+            [nextjournal.clerk.render :as render]
+            [nextjournal.clerk.render.code :as code]
+            [nextjournal.clerk.viewer :as v]
+            [nextjournal.clojure-mode :as clojure-mode]
+            [nextjournal.clojure-mode.keymap :as clojure-mode.keymap]
+            [nextjournal.clojure-mode.extensions.eval-region :as eval-region]
+            [nextjournal.clerk.sci-env.completions :as sci-completions]
+            [sci.core :as sci]
+            [sci.ctx-store]
+            [shadow.esm]))
+
+(defn eval-string
+  ([source] (sci/eval-string* (sci.ctx-store/get-ctx) source))
+  ([ctx source]
+   (when-some [code (not-empty (str/trim source))]
+     (try {:result (sci/eval-string* ctx code)}
+          (catch js/Error e
+            {:error (str (.-message e))})))))
+
+(j/defn eval-at-cursor [on-result ^:js {:keys [state]}]
+  (some->> (eval-region/cursor-node-string state)
+           (eval-string)
+           (on-result))
+  true)
+
+(j/defn eval-top-level [on-result ^:js {:keys [state]}]
+  (some->> (eval-region/top-level-string state)
+           (eval-string)
+           (on-result))
+  true)
+
+(j/defn eval-cell [on-result ^:js {:keys [state]}]
+  (-> (.-doc state)
+      (str)
+      (eval-string)
+      (on-result))
+  true)
+
+(defn autocomplete [^js context]
+  (let [node-before (.. (syntaxTree (.-state context)) (resolveInner (.-pos context) -1))
+        text-before (.. context -state (sliceDoc (.-from node-before) (.-pos context)))]
+    #js {:from (.-from node-before)
+         :options (clj->js (map
+                            (fn [{:as option :keys [candidate info]}]
+                              (let [{:keys [arglists arglists-str]} info]
+                                (cond-> {:label candidate :type (if arglists "function" "namespace")}
+                                  arglists (assoc :detail arglists-str))))
+                            (:completions (sci-completions/completions {:ctx (sci.ctx-store/get-ctx) :ns "user" :symbol text-before}))))}))
+
+(def completion-source
+  (autocompletion #js {:override #js [autocomplete]}))
+
+(def doc-tooltip
+  (hoverTooltip
+   (fn [^js view pos side]
+     (let [node-before (.. (syntaxTree (.-state view)) (resolveInner pos -1))
+           text-at-point (.. view -state (sliceDoc (.-from node-before) (.-to node-before)))
+           {:as res :keys [candidated info]} (some->> (sci-completions/completions {:ctx (sci.ctx-store/get-ctx) :ns "user" :symbol text-at-point})
+                                                      :completions
+                                                      (filter #(= (:candidate %) text-at-point))
+                                                      first)]
+       (when (and res info)
+         (let [{:keys [arglists-str doc name]} info]
+           #js {:pos pos
+                :create (fn [view]
+                          (let [dom (doto (js/document.createElement "div")
+                                      (.setAttribute "class" "font-mono text-[11px] p-2"))
+                                name-el (doto (js/document.createElement "div")
+                                          (.setAttribute "class" "font-bold"))
+                                args-el (doto (js/document.createElement "span")
+                                          (.setAttribute "class" "ml-2 italic font-normal"))
+                                docs-el (doto (js/document.createElement "div")
+                                          (.setAttribute "class" "pre-wrap mt-3"))]
+                            (set! (.-textContent name-el) (str name))
+                            (set! (.-textContent args-el) arglists-str)
+                            (.appendChild name-el args-el)
+                            (.appendChild dom name-el)
+                            (set! (.-textContent docs-el) doc)
+                            (.appendChild dom docs-el)
+                            #js {:dom dom}))}))))))
+
+(defn eval-notebook [code]
+  (as-> code doc
+    (nextjournal.clerk.parser/parse-clojure-string {:doc? true} doc)
+    (update doc :blocks (partial map (fn [{:as b :keys [type text]}]
+                                       (cond-> b
+                                         (= :code type)
+                                         (assoc :result
+                                                {:nextjournal/value
+                                                 (let [val (eval (render/read-string text))]
+                                                   ;; FIXME: this won't be necessary once we unify v/html in SCI env to be the same as in nextjournal.clerk.viewer
+                                                   ;; v/html is currently html-render for supporting legacy render-fns
+                                                   (cond->> val
+                                                     (render/valid-react-element? val)
+                                                     (v/with-viewer v/reagent-viewer)))})))))
+    (v/with-viewer v/notebook-viewer {:nextjournal.clerk/width :wide} doc)))
+
+
+
+(defn view [code-string]
+  (let [!notebook (hooks/use-state nil)
+        !eval-result (hooks/use-state nil)
+        !container-el (hooks/use-ref nil)
+        !view (hooks/use-ref nil)
+        on-result #(reset! !eval-result %)
+        on-eval #(reset! !notebook (try
+                                     (eval-notebook (.. % -state -doc toString))
+                                     (catch js/Error error (v/with-viewer v/reagent-viewer
+                                                             [render/error-view error]))))]
+    (hooks/use-effect
+     (fn []
+       (let [^js view
+             (reset! !view (code/make-view
+                            (code/make-state code-string
+                                             (.concat code/default-extensions
+                                                      #js [(placeholder "Show code with Option+Return")
+                                                           (.of keymap clojure-mode.keymap/paredit)
+                                                           doc-tooltip
+                                                           completion-source
+                                                           (.of keymap
+                                                                (j/lit
+                                                                 [{:key "Alt-Enter"
+                                                                   :run on-eval}
+                                                                  {:key "Mod-Enter"
+                                                                   :shift (partial eval-top-level on-result)
+                                                                   :run (partial eval-at-cursor on-result)}]))]))
+                            @!container-el))]
+         (on-eval view)
+         #(.destroy view))))    
+    [:div.fixed.w-screen.h-screen.flex.flex-col.top-0.left-0
+     [:div.flex.flex-auto
+      [:div.bg-slate-200.border-r.border-slate-300.dark:border-slate-600.px-4.py-3.dark:bg-slate-800
+       {:class "w-[50vw]"}
+       [:div {:ref !container-el}]]
+      [:div.bg-white.dark:bg-slate-950.overflow-y-auto
+       {:class "w-[50vw]"}
+       [render/inspect @!notebook]]]
+     (when-let [result @!eval-result]
+       [:div.border-t.bg-white.px-4.py-2
+        [render/inspect result]])]))

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -1,5 +1,6 @@
 (ns nextjournal.clerk.render.editor
   (:require ["@codemirror/autocomplete" :refer [autocompletion]]
+            ["@codemirror/state" :refer [EditorState]]
             ["@codemirror/language" :refer [syntaxTree]]
             ["@codemirror/view" :refer [keymap placeholder hoverTooltip]]
             ["@nextjournal/lang-clojure" :refer [clojureLanguage]]
@@ -126,6 +127,11 @@
                                                            (.of keymap clojure-mode.keymap/paredit)
                                                            doc-tooltip
                                                            completion-source
+                                                           (.. EditorState -transactionExtender
+                                                               (of (fn [^js tr]
+                                                                     (when (.-selection tr)
+                                                                       (reset! !eval-result nil))
+                                                                     #js {})))
                                                            (.of keymap
                                                                 (j/lit
                                                                  [{:key "Alt-Enter"
@@ -137,13 +143,14 @@
          (on-eval view)
          #(.destroy view))))    
     [:div.fixed.w-screen.h-screen.flex.flex-col.top-0.left-0
-     [:div.flex.flex-auto
+     [:div.flex
       [:div.bg-slate-200.border-r.border-slate-300.dark:border-slate-600.px-4.py-3.dark:bg-slate-800
        {:class "w-[50vw]"}
        [:div {:ref !container-el}]]
-      [:div.bg-white.dark:bg-slate-950.overflow-y-auto
+      [:div.bg-white.dark:bg-slate-950.bg-white.flex.flex-col.max-h-screen.overflow-y-auto
        {:class "w-[50vw]"}
        [render/inspect @!notebook]]]
      (when-let [result @!eval-result]
-       [:div.border-t.bg-white.px-4.py-2
+       [:div.border-t.border-slate-300.px-4.py-2.flex-shrink-0.absolute.bottom-0.left-0.w-screen.bg-white
+        {:style {:box-shadow "0 -2px 3px 0 rgb(0 0 0 / 0.025)"}}
         [render/inspect result]])]))

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -179,6 +179,6 @@
            (when (and doc @!show-docstring?)
              [:div.text-slate-300.mt-2.mb-1.leading-relaxed {:class "max-w-[640px]"} doc])])]]
       (when-let [result @!eval-result]
-        [:div.border-t.border-slate-300.px-4.py-2.flex-shrink-0.absolute.left-0.w-screen.bg-white
+        [:div.border-t.border-slate-300.dark:border-slate-600.px-4.py-2.flex-shrink-0.absolute.left-0.w-screen.bg-white.dark:bg-slate-950
          {:style {:box-shadow "0 -2px 3px 0 rgb(0 0 0 / 0.025)" :bottom (* bar-height 2)}}
          [render/inspect result]])]]))

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -149,8 +149,9 @@
         [:div.h-screen {:ref !container-el}]]
        [:div.bg-white.dark:bg-slate-950.bg-white.flex.flex-col.overflow-y-auto
         {:class "w-[50vw]" :style {:height (str "calc(100vh - " command-bar-height "px)")}}
-        [:> render/ErrorBoundary {:hash (gensym)}
-         [render/inspect @!notebook]]]]
+        (when-let [notebook @!notebook]
+          [:> render/ErrorBoundary {:hash (gensym)}
+           [render/inspect notebook]])]]
       [:div.absolute.left-0.bottom-0.w-screen.bg-slate-900.border-t.border-slate-950.flex.justify-left.px-4.font-mono.gap-4.items-center.text-white
        {:class "text-[12px]" :style {:height command-bar-height}}
        [:div.flex.gap-1.items-center

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -151,7 +151,8 @@
         [:div.h-screen {:ref !container-el}]]
        [:div.bg-white.dark:bg-slate-950.bg-white.flex.flex-col.overflow-y-auto.h-screen
         {:class "w-[50vw]"}
-        [render/inspect @!notebook]]]
+        [:> render/ErrorBoundary {:hash (gensym)}
+         [render/inspect @!notebook]]]]
       (when-let [result @!eval-result]
         [:div.border-t.border-slate-300.px-4.py-2.flex-shrink-0.absolute.bottom-0.left-0.w-screen.bg-white
          {:style {:box-shadow "0 -2px 3px 0 rgb(0 0 0 / 0.025)"}}

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -103,7 +103,7 @@
                                                      (v/with-viewer v/reagent-viewer)))})))))
     (v/with-viewer v/notebook-viewer {:nextjournal.clerk/width :wide} doc)))
 
-
+(defonce command-bar-height 26)
 
 (defn view [code-string]
   (let [!notebook (hooks/use-state nil)
@@ -144,14 +144,25 @@
      [:style {:type "text/css"} ".notebook-viewer { padding-top: 2.5rem; } .notebook-viewer .viewer:first-child { display: none; }"]
      [:div.fixed.w-screen.h-screen.flex.flex-col.top-0.left-0
       [:div.flex
-       [:div.bg-slate-200.border-r.border-slate-300.dark:border-slate-600.px-4.py-3.dark:bg-slate-800.h-screen
-        {:class "w-[50vw]"}
+       [:div.bg-slate-200.border-r.border-slate-300.dark:border-slate-600.px-4.py-3.dark:bg-slate-800
+        {:class "w-[50vw]" :style {:height (str "calc(100vh - " command-bar-height "px)")}}
         [:div.h-screen {:ref !container-el}]]
-       [:div.bg-white.dark:bg-slate-950.bg-white.flex.flex-col.overflow-y-auto.h-screen
-        {:class "w-[50vw]"}
+       [:div.bg-white.dark:bg-slate-950.bg-white.flex.flex-col.overflow-y-auto
+        {:class "w-[50vw]" :style {:height (str "calc(100vh - " command-bar-height "px)")}}
         [:> render/ErrorBoundary {:hash (gensym)}
          [render/inspect @!notebook]]]]
+      [:div.absolute.left-0.bottom-0.w-screen.bg-slate-900.border-t.border-slate-950.flex.justify-left.px-4.font-mono.gap-4.items-center.text-white
+       {:class "text-[12px]" :style {:height command-bar-height}}
+       [:div.flex.gap-1.items-center
+        "Eval notebook"
+        [:div.font-inter.text-slate-300 "⌥↩"]]
+       [:div.flex.gap-1.items-center
+        "Eval at cursor"
+        [:div.font-inter.text-slate-300 "⌘↩"]]
+       [:div.flex.gap-1.items-center
+        "Eval top level"
+        [:div.font-inter.text-slate-300 "⇧⌘↩"]]]
       (when-let [result @!eval-result]
-        [:div.border-t.border-slate-300.px-4.py-2.flex-shrink-0.absolute.bottom-0.left-0.w-screen.bg-white
-         {:style {:box-shadow "0 -2px 3px 0 rgb(0 0 0 / 0.025)"}}
+        [:div.border-t.border-slate-300.px-4.py-2.flex-shrink-0.absolute.left-0.w-screen.bg-white
+         {:style {:box-shadow "0 -2px 3px 0 rgb(0 0 0 / 0.025)" :bottom command-bar-height}}
          [render/inspect result]])]]))

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -141,16 +141,18 @@
                                                                    :run (partial eval-at-cursor on-result)}]))]))
                             @!container-el))]
          (on-eval view)
-         #(.destroy view))))    
-    [:div.fixed.w-screen.h-screen.flex.flex-col.top-0.left-0
-     [:div.flex
-      [:div.bg-slate-200.border-r.border-slate-300.dark:border-slate-600.px-4.py-3.dark:bg-slate-800.h-screen
-       {:class "w-[50vw]"}
-       [:div.h-screen {:ref !container-el}]]
-      [:div.bg-white.dark:bg-slate-950.bg-white.flex.flex-col.overflow-y-auto.h-screen
-       {:class "w-[50vw]"}
-       [render/inspect @!notebook]]]
-     (when-let [result @!eval-result]
-       [:div.border-t.border-slate-300.px-4.py-2.flex-shrink-0.absolute.bottom-0.left-0.w-screen.bg-white
-        {:style {:box-shadow "0 -2px 3px 0 rgb(0 0 0 / 0.025)"}}
-        [render/inspect result]])]))
+         #(.destroy view))))
+    [:<>
+     [:style {:type "text/css"} ".notebook-viewer { padding-top: 2.5rem; } .notebook-viewer .viewer:first-child { display: none; }"]
+     [:div.fixed.w-screen.h-screen.flex.flex-col.top-0.left-0
+      [:div.flex
+       [:div.bg-slate-200.border-r.border-slate-300.dark:border-slate-600.px-4.py-3.dark:bg-slate-800.h-screen
+        {:class "w-[50vw]"}
+        [:div.h-screen {:ref !container-el}]]
+       [:div.bg-white.dark:bg-slate-950.bg-white.flex.flex-col.overflow-y-auto.h-screen
+        {:class "w-[50vw]"}
+        [render/inspect @!notebook]]]
+      (when-let [result @!eval-result]
+        [:div.border-t.border-slate-300.px-4.py-2.flex-shrink-0.absolute.bottom-0.left-0.w-screen.bg-white
+         {:style {:box-shadow "0 -2px 3px 0 rgb(0 0 0 / 0.025)"}}
+         [render/inspect result]])]]))

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -144,10 +144,10 @@
          #(.destroy view))))    
     [:div.fixed.w-screen.h-screen.flex.flex-col.top-0.left-0
      [:div.flex
-      [:div.bg-slate-200.border-r.border-slate-300.dark:border-slate-600.px-4.py-3.dark:bg-slate-800
+      [:div.bg-slate-200.border-r.border-slate-300.dark:border-slate-600.px-4.py-3.dark:bg-slate-800.h-screen
        {:class "w-[50vw]"}
-       [:div {:ref !container-el}]]
-      [:div.bg-white.dark:bg-slate-950.bg-white.flex.flex-col.max-h-screen.overflow-y-auto
+       [:div.h-screen {:ref !container-el}]]
+      [:div.bg-white.dark:bg-slate-950.bg-white.flex.flex-col.overflow-y-auto.h-screen
        {:class "w-[50vw]"}
        [render/inspect @!notebook]]]
      (when-let [result @!eval-result]

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -2,7 +2,7 @@
   (:require ["@codemirror/autocomplete" :refer [autocompletion]]
             ["@codemirror/language" :refer [syntaxTree]]
             ["@codemirror/state" :refer [EditorState]]
-            ["@codemirror/view" :refer [keymap placeholder hoverTooltip]]
+            ["@codemirror/view" :refer [keymap placeholder]]
             [applied-science.js-interop :as j]
             [clojure.string :as str]
             [nextjournal.clerk.parser :as parser]
@@ -122,13 +122,14 @@
                             @!container-el))]
          (on-eval view)
          #(.destroy view))))
+    (code/use-dark-mode !view)
     [:<>
      [:style {:type "text/css"} (str ".notebook-viewer { padding-top: 2.5rem; } "
                                      ".notebook-viewer .viewer:first-child { display: none; } "
-                                     ".dark-mode-toggle { display: none !important; }")]
+                                     "#clerk > div > div > .dark-mode-toggle { display: none !important; }")]
      [:div.fixed.w-screen.h-screen.flex.flex-col.top-0.left-0
       [:div.flex
-       [:div.bg-slate-200.border-r.border-slate-300.dark:border-slate-600.px-4.py-3.dark:bg-slate-800.overflow-y-auto
+       [:div.bg-slate-200.border-r.border-slate-300.dark:border-slate-600.px-4.py-3.dark:bg-slate-950.overflow-y-auto
         {:class "w-[50vw]" :style {:height (str "calc(100vh - " (* bar-height 2) "px)")}}
         [:div.h-screen {:ref !container-el}]]
        [:div.bg-white.dark:bg-slate-950.bg-white.flex.flex-col.overflow-y-auto
@@ -136,8 +137,8 @@
         (when-let [notebook @!notebook]
           [:> render/ErrorBoundary {:hash (gensym)}
            [render/inspect notebook]])]]
-      [:div.absolute.left-0.bottom-0.w-screen.border-t.font-mono.text-white
-       [:div.bg-slate-900.border-t.border-slate-950.flex.px-4.font-mono.gap-4.items-center.text-white
+      [:div.absolute.left-0.bottom-0.w-screen.font-mono.text-white.border-t.dark:border-slate-600
+       [:div.bg-slate-900.dark:bg-slate-800.flex.px-4.font-mono.gap-4.items-center.text-white
         {:class "text-[12px]" :style {:height bar-height}}
         [:div.flex.gap-1.items-center
          "Eval notebook"
@@ -163,7 +164,7 @@
         [:div.flex.gap-1.items-center
          "Contract selection"
          [:div.font-inter.text-slate-300 "⌘2"]]]
-       [:div.w-screen.bg-slate-800.border-t.border-slate-950.px-4.font-mono.items-center.text-white.flex.items-center
+       [:div.w-screen.bg-slate-800.dark:bg-slate-950.px-4.font-mono.items-center.text-white.flex.items-center
         {:class "text-[12px] py-[4px]" :style {:min-height bar-height}}
         (when-let [{:keys [name arglists-str doc]} @!info]
           [:div

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -130,6 +130,7 @@
                                                                      (when (.-selection tr)
                                                                        (reset! !eval-result nil))
                                                                      #js {})))
+                                                           (eval-region/extension {:modifier "Meta"})
                                                            (.of keymap
                                                                 (j/lit
                                                                  [{:key "Alt-Enter"

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -4,7 +4,6 @@
             ["@codemirror/state" :refer [EditorState]]
             ["@codemirror/view" :refer [keymap placeholder]]
             [applied-science.js-interop :as j]
-
             [clojure.string :as str]
             [nextjournal.clerk.parser :as parser]
             [nextjournal.clerk.render :as render]
@@ -16,6 +15,7 @@
             [nextjournal.clojure-mode.extensions.eval-region :as eval-region]
             [nextjournal.clojure-mode.keymap :as clojure-mode.keymap]
             [rewrite-clj.node :as n]
+            [rewrite-clj.parser :as p]
             [sci.core :as sci]
             [sci.ctx-store]
             [shadow.esm]))
@@ -115,10 +115,11 @@
    (binding [*ns* *ns*]
      (let [!id->count (atom {})]
        (cond-> (reduce (fn [{:as state notebook-ns :ns :keys [ns-aliases]} i]
-                         (let [{:as block :keys [type text node]} (get-in doc [:blocks i])]
+                         (let [{:as block :keys [type text]} (get-in doc [:blocks i])]
                            (if (not= type :code)
                              (assoc-in state [:blocks i :id] (get-block-id !id->count block))
-                             (let [form (try (n/sexpr node (when ns-aliases {:auto-resolve ns-aliases}))
+                             (let [node (p/parse-string text)
+                                   form (try (n/sexpr node (when ns-aliases {:auto-resolve ns-aliases}))
                                              (catch js/Error e
                                                (throw (ex-info (str "Clerk analysis failed reading block: "
                                                                     (ex-message e))

--- a/src/nextjournal/clerk/render/panel.cljs
+++ b/src/nextjournal/clerk/render/panel.cljs
@@ -2,7 +2,8 @@
   (:require [applied-science.js-interop :as j]
             [nextjournal.clerk.render.hooks :as hooks]))
 
-(defn resizer [{:keys [on-resize on-resize-start on-resize-end] :or {on-resize-start #() on-resize-end #()}}]
+(defn resizer [{:keys [axis on-resize on-resize-start on-resize-end]
+                :or {on-resize-start #() on-resize-end #()}}]
   (let [!direction (hooks/use-state nil)
         !mouse-down (hooks/use-state false)
         handle-mouse-down (fn [dir]
@@ -23,31 +24,35 @@
                                                 (reset! !mouse-down false))]
                           (js/addEventListener "mouseup" handle-mouse-up)
                           #(js/removeEventListener "mouseup" handle-mouse-up))))
-    [:<>
-     [:div.absolute.z-2.cursor-nwse-resize
-      {:on-mouse-down #(handle-mouse-down :top-left)
-       :class "w-[14px] h-[14px] -left-[7px] -top-[7px]"}]
-     [:div.absolute.z-1.left-0.w-full.cursor-ns-resize
-      {:on-mouse-down #(handle-mouse-down :top)
-       :class "h-[4px] -top-[4px]"}]
-     [:div.absolute.z-2.cursor-nesw-resize
-      {:on-mouse-down #(handle-mouse-down :top-right)
-       :class "w-[14px] h-[14px] -right-[7px] -top-[7px]"}]
-     [:div.absolute.z-1.top-0.h-full.cursor-ew-resize
-      {:on-mouse-down #(handle-mouse-down :right)
-       :class "w-[4px] -right-[2px]"}]
-     [:div.absolute.z-2.cursor-nwse-resize
-      {:on-mouse-down #(handle-mouse-down :bottom-right)
-       :class "w-[14px] h-[14px] -right-[7px] -bottom-[7px]"}]
-     [:div.absolute.z-1.bottom-0.w-full.cursor-ns-resize
-      {:on-mouse-down #(handle-mouse-down :bottom)
-       :class "h-[4px] -left-[2px]"}]
-     [:div.absolute.z-2.cursor-nesw-resize
-      {:on-mouse-down #(handle-mouse-down :bottom-left)
-       :class "w-[14px] h-[14px] -left-[7px] -bottom-[7px]"}]
-     [:div.absolute.z-1.left-0.top-0.h-full.cursor-ew-resize
-      {:on-mouse-down #(handle-mouse-down :left)
-       :class "w-[4px]"}]]))
+    (if axis
+      [:div.w-full.h-full
+       {:class (if (= axis :x) "cursor-col-resize" "cursor-row-resize")
+        :on-mouse-down #(handle-mouse-down (if (= axis :x) :left :up))}]
+      [:<>
+       [:div.absolute.z-2.cursor-nwse-resize
+        {:on-mouse-down #(handle-mouse-down :top-left)
+         :class "w-[14px] h-[14px] -left-[7px] -top-[7px]"}]
+       [:div.absolute.z-1.left-0.w-full.cursor-ns-resize
+        {:on-mouse-down #(handle-mouse-down :top)
+         :class "h-[4px] -top-[4px]"}]
+       [:div.absolute.z-2.cursor-nesw-resize
+        {:on-mouse-down #(handle-mouse-down :top-right)
+         :class "w-[14px] h-[14px] -right-[7px] -top-[7px]"}]
+       [:div.absolute.z-1.top-0.h-full.cursor-ew-resize
+        {:on-mouse-down #(handle-mouse-down :right)
+         :class "w-[4px] -right-[2px]"}]
+       [:div.absolute.z-2.cursor-nwse-resize
+        {:on-mouse-down #(handle-mouse-down :bottom-right)
+         :class "w-[14px] h-[14px] -right-[7px] -bottom-[7px]"}]
+       [:div.absolute.z-1.bottom-0.w-full.cursor-ns-resize
+        {:on-mouse-down #(handle-mouse-down :bottom)
+         :class "h-[4px] -left-[2px]"}]
+       [:div.absolute.z-2.cursor-nesw-resize
+        {:on-mouse-down #(handle-mouse-down :bottom-left)
+         :class "w-[14px] h-[14px] -left-[7px] -bottom-[7px]"}]
+       [:div.absolute.z-1.left-0.top-0.h-full.cursor-ew-resize
+        {:on-mouse-down #(handle-mouse-down :left)
+         :class "w-[4px]"}]])))
 
 (defn header [{:keys [id title on-drag on-drag-start on-drag-end on-close] :or {on-drag-start #() on-drag-end #()}}]
   (let [!mouse-down (hooks/use-state false)

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -164,6 +164,7 @@
              "react" react}
    :ns-aliases '{clojure.math cljs.math}
    :namespaces (merge {'nextjournal.clerk.viewer viewer-namespace
+                       'nextjournal.clerk viewer-namespace ;; TODO: expose cljs variant of `nextjournal.clerk` with docstrings
                        'clojure.core {'read-string read-string
                                       'implements? (sci/copy-var implements?* core-ns)
                                       'time (sci/copy-var time core-ns)

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -19,6 +19,7 @@
             [nextjournal.clerk.render :as render]
             [nextjournal.clerk.render.code]
             [nextjournal.clerk.render.context :as view-context]
+            [nextjournal.clerk.render.editor]
             [nextjournal.clerk.render.hooks]
             [nextjournal.clerk.render.navbar]
             [nextjournal.clerk.trim-image]
@@ -158,6 +159,7 @@
                        'nextjournal.clerk.parser
                        'nextjournal.clerk.render
                        'nextjournal.clerk.render.code
+                       'nextjournal.clerk.render.editor
                        'nextjournal.clerk.render.hooks
                        'nextjournal.clerk.render.navbar
 

--- a/src/nextjournal/clerk/sci_env/completions.cljs
+++ b/src/nextjournal/clerk/sci_env/completions.cljs
@@ -1,0 +1,138 @@
+(ns nextjournal.clerk.sci-env.completions
+  (:require [clojure.string :as str]
+            [goog.object :as gobject]
+            [sci.core :as sci]
+            [sci.ctx-store]))
+
+(defn format [fmt-str x]
+  (str/replace fmt-str "%s" x))
+
+(defn fully-qualified-syms [ctx ns-sym]
+  (let [syms (sci/eval-string* ctx (format "(keys (ns-map '%s))" ns-sym))
+        sym-strs (map #(str "`" %) syms)
+        sym-expr (str "[" (str/join " " sym-strs) "]")
+        syms (sci/eval-string* ctx sym-expr)
+        syms (remove #(str/starts-with? (str %) "nbb.internal") syms)]
+    syms))
+
+(defn- ns-imports->completions [ctx query-ns query]
+  (let [[_ns-part name-part] (str/split query #"/")
+        resolved (sci/eval-string* ctx
+                                   (pr-str `(let [resolved# (resolve '~query-ns)]
+                                              (when-not (var? resolved#)
+                                                resolved#))))]
+    (when resolved
+      (when-let [[prefix imported] (if name-part
+                                     (let [ends-with-dot? (str/ends-with? name-part ".")
+                                           fields (str/split name-part #"\.")
+                                           fields (if ends-with-dot?
+                                                    fields
+                                                    (butlast fields))]
+                                       [(str query-ns "/" (when (seq fields)
+                                                            (let [joined (str/join "." fields)]
+                                                              (str joined "."))))
+                                        (apply gobject/getValueByKeys resolved
+                                               fields)])
+                                     [(str query-ns "/") resolved])]
+        (let [props (loop [obj imported
+                           props []]
+                      (if obj
+                        (recur (js/Object.getPrototypeOf obj)
+                               (into props (js/Object.getOwnPropertyNames obj)))
+                        props))
+              completions (map (fn [k]
+                                 [nil (str prefix k)]) props)]
+          completions)))))
+
+(defn- match [_alias->ns ns->alias query [sym-ns sym-name qualifier]]
+  (let [pat (re-pattern query)]
+    (or (when (and (= :unqualified qualifier) (re-find pat sym-name))
+          [sym-ns sym-name])
+        (when sym-ns
+          (or (when (re-find pat (str (get ns->alias (symbol sym-ns)) "/" sym-name))
+                [sym-ns (str (get ns->alias (symbol sym-ns)) "/" sym-name)])
+              (when (re-find pat (str sym-ns "/" sym-name))
+                [sym-ns (str sym-ns "/" sym-name)]))))))
+
+(defn format-1 [fmt-str x]
+  (str/replace-first fmt-str "%s" x))
+
+(defn info [{:keys [sym ctx] ns-str :ns}]
+  (if-not sym
+    {:status ["no-eldoc" "done"]
+     :err "Message should contain a `sym`"}
+    (let [code (-> "(when-let [the-var (ns-resolve '%s '%s)] (meta the-var))"
+                   (format-1 ns-str)
+                   (format-1 sym))
+          [kind val] (try [::success (sci/eval-string* ctx code)]
+                          (catch :default e
+                            [::error (str e)]))
+          {:keys [doc file line name arglists]} val]
+      (if (and name (= kind ::success))
+        (cond-> {:ns (some-> val :ns ns-name)
+                 :arglists (pr-str arglists)
+                 :eldoc (mapv #(mapv str %) arglists)
+                 :arglists-str (.join (apply array arglists) "\n")
+                 :status ["done"]
+                 :name name}
+          doc (assoc :doc doc)
+          file (assoc :file file)
+          line (assoc :line line))
+        {:status ["done" "no-eldoc"]}))))
+
+(defn completions [{:keys [ctx] ns-str :ns :as request}]
+  (try
+    (let [sci-ns (when ns-str
+                   (sci/find-ns ctx (symbol ns-str)))]
+      (sci/binding [sci/ns (or sci-ns @sci/ns)]
+        (if-let [query (or (:symbol request)
+                           (:prefix request))]
+          (let [has-namespace? (str/includes? query "/")
+                query-ns (when has-namespace? (some-> (str/split query #"/")
+                                                      first symbol))
+                from-current-ns (fully-qualified-syms ctx (sci/eval-string* ctx "(ns-name *ns*)"))
+                from-current-ns (map (fn [sym]
+                                       [(namespace sym) (name sym) :unqualified])
+                                     from-current-ns)
+                alias->ns (sci/eval-string* ctx "(let [m (ns-aliases *ns*)] (zipmap (keys m) (map ns-name (vals m))))")
+                ns->alias (zipmap (vals alias->ns) (keys alias->ns))
+                from-aliased-nss (doall (mapcat
+                                         (fn [alias]
+                                           (let [ns (get alias->ns alias)
+                                                 syms (sci/eval-string* ctx (format "(keys (ns-publics '%s))" ns))]
+                                             (map (fn [sym]
+                                                    [(str ns) (str sym) :qualified])
+                                                  syms)))
+                                         (keys alias->ns)))
+                all-namespaces (->> (sci/eval-string* ctx "(all-ns)")
+                                    (map (fn [ns]
+                                           [(str ns) nil :qualified])))
+                from-imports (when has-namespace? (ns-imports->completions ctx query-ns query))
+                fully-qualified-names (when-not from-imports
+                                        (when has-namespace?
+                                          (let [ns (get alias->ns query-ns query-ns)
+                                                syms (sci/eval-string* ctx (format "(and (find-ns '%s)
+                                                                                         (keys (ns-publics '%s)))"
+                                                                                   ns))]
+                                            (map (fn [sym]
+                                                   [(str ns) (str sym) :qualified])
+                                                 syms))))
+                svs (concat from-current-ns from-aliased-nss all-namespaces fully-qualified-names)
+                completions (keep (fn [entry]
+                                    (match alias->ns ns->alias query entry))
+                                  svs)
+                completions (concat completions from-imports)
+                completions (->> (map (fn [[namespace name]]
+                                        (let [candidate (str name)
+                                              info (when namespace
+                                                     (info {:ns (str namespace) :sym candidate :ctx ctx}))]
+                                          {:candidate candidate :info info}))
+                                      completions)
+                                 distinct vec)]
+            {:completions completions
+             :status ["done"]})
+          {:status ["done"]})))
+    (catch :default e
+      (js/console.error "ERROR" e)
+      {:completions []
+       :status ["done"]})))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1,4 +1,5 @@
 (ns nextjournal.clerk.viewer
+  (:refer-clojure :exclude [var?])
   (:require [clojure.string :as str]
             [clojure.pprint :as pprint]
             [clojure.datafy :as datafy]
@@ -390,6 +391,10 @@
   (fn [wrapped-value] (apply update wrapped-value :nextjournal/value f args)))
 
 #_((update-val + 1) {:nextjournal/value 41})
+
+(defn var? [x]
+  (or (clojure.core/var? x)
+      #?(:cljs (instance? sci.lang.Var x))))
 
 (defn var-from-def? [x]
   (var? (get-safe x :nextjournal.clerk/var-from-def)))
@@ -834,7 +839,7 @@
 
 (def var-viewer
   {:name `var-viewer
-   :pred (some-fn var? #?(:cljs #(instance? sci.lang.Var %)))
+   :pred var?
    :transform-fn (comp #?(:cljs var->symbol :clj symbol) ->value)
    :render-fn '(fn [x] [:span.inspected-value [:span.cmt-meta "#'" (str x)]])})
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -14,6 +14,7 @@
                        [goog.crypt.Sha1]
                        [reagent.ratom :as ratom]
                        [sci.core :as sci]
+                       [sci.impl.vars]
                        [sci.lang]
                        [applied-science.js-interop :as j]])
             [nextjournal.clerk.parser :as parser]
@@ -465,7 +466,7 @@
 (defn datafy-scope [scope]
   (cond
     #?@(:clj [(instance? clojure.lang.Namespace scope) (ns-name scope)]
-        :cljs [(instance? sci.lang.Namespace scope) (sci.impl.namespaces/sci-ns-name scope)])
+        :cljs [(instance? sci.lang.Namespace scope) (sci/ns-name scope)])
     (symbol? scope) scope
     (#{:default} scope) scope
     :else (throw (ex-info (str "Unsupported scope `" scope "`. Valid scopes are namespaces, symbol namespace names or `:default`.")


### PR DESCRIPTION
Adds `nextjournal.clerk.render.editor`, a clojure-mode based editor for Clerk documents in the browser. Uses completions based on the sci environment. Parses and evaluates the doc as a Clerk doc in ClojureScript.

https://snapshots.nextjournal.com/clerk/build/465f5351161eb28ad631bee197b34d6e0849bd6f/editor.html

https://github.com/nextjournal/clerk/assets/1187/221d8302-3b75-43e2-81aa-1ba7cee088aa

