### PR TITLE
Unify link handling between `build!` and `serve!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ Changes can be:
   * `nextjournal.clerk.viewer/html` instead.
   
   Also rename `nextjournal.clerk.render/html-render` to `nextjournal.clerk.render/render-html` and make `nextjournal.clerk.viewer/html` use it when called from a reactive context.
+  
+* 🚨 Unify the link handling between `build!` and `serve!` 
+
+  By no longer using extensions in either mode (was `.clj|md` in `serve!` and `.html` in `build!`).
+  
+  To support this in the unbundled static build, we're now writing directories with `index.html` for each notebook. This makes links in this build no longer accessible without a http server. If you're looking for a self-contained html that works without a webserver, set the `:bundle` option.
 
 * 📖 Improve Table of Contents design and fixing re-rendering issues. Also added suport for chapter expansion.
 

--- a/index.clj
+++ b/index.clj
@@ -8,5 +8,5 @@
 (clerk/html
  [:div.viewer-markdown
   [:ul
-   [:li [:a.underline {:href (clerk/doc-url "notebooks/rule_30.clj")} "Rule 30"]]
-   [:li [:a.underline {:href (clerk/doc-url "notebooks/markdown.md")} "Markdown"]]]])
+   [:li [:a.underline {:href "notebooks/rule_30"} "Rule 30"]]
+   [:li [:a.underline {:href "notebooks/markdown"} "Markdown"]]]])

--- a/index.clj
+++ b/index.clj
@@ -9,5 +9,5 @@
  [:div.viewer-markdown
   [:ul
    [:li [:a.underline {:href (clerk/doc-url "notebooks/rule_30")} "Rule 30"]]
-   [:li [:a.underline {:href (clerk/doc-url "design/links.md")} "Link Design"]]
+   [:li [:a.underline {:href (clerk/doc-url "notebooks/links")} "Link Design"]]
    [:li [:a.underline {:href (clerk/doc-url "notebooks/markdown")} "Markdown"]]]])

--- a/index.clj
+++ b/index.clj
@@ -8,5 +8,6 @@
 (clerk/html
  [:div.viewer-markdown
   [:ul
-   [:li [:a.underline {:href "notebooks/rule_30"} "Rule 30"]]
-   [:li [:a.underline {:href "notebooks/markdown"} "Markdown"]]]])
+   [:li [:a.underline {:href (clerk/doc-url "notebooks/rule_30")} "Rule 30"]]
+   [:li [:a.underline {:href (clerk/doc-url "design/links.md")} "Link Design"]]
+   [:li [:a.underline {:href (clerk/doc-url "notebooks/markdown")} "Markdown"]]]])

--- a/notebooks/document_linking.clj
+++ b/notebooks/document_linking.clj
@@ -7,11 +7,11 @@
 ;; The helper `clerk/doc-url` allows to reference notebooks by path. We currently support relative paths with respect to the directory which started the Clerk application. An optional trailing hash fragment can appended to the path in order for the page to be scrolled up to the indicated identifier.
 (clerk/html
  [:ol
-  [:li [:a {:href (clerk/doc-url "notebooks/viewers/html.clj")} "HTML"]]
-  [:li [:a {:href (clerk/doc-url "notebooks/viewers/image.clj")} "Images"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/viewers/html")} "HTML"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/viewers/image")} "Images"]]
   [:li [:a {:href (clerk/doc-url "notebooks/markdown.md" "appendix")} "Markdown / Appendix"]]
-  [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works.clj" "step-3:-analyzer")} "Clerk Analyzer"]]
-  [:li [:a {:href (clerk/doc-url "book.clj")} "The 📕Book"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works" "step-3:-analyzer")} "Clerk Analyzer"]]
+  [:li [:a {:href (clerk/doc-url "book")} "The 📕Book"]]
   [:li [:a {:href (clerk/doc-url "")} "Homepage"]]])
 
 
@@ -20,6 +20,6 @@
 (clerk/with-viewer
   '(fn [_ _]
      [:ol
-      [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewers/html.clj")} "HTML"]]
-      [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/markdown.md")} "Markdown"]]
-      [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewer_api.clj")} "Viewer API / Tables"]]]) nil)
+      [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewers/html")} "HTML"]]
+      [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/markdown")} "Markdown"]]
+      [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewer_api")} "Viewer API / Tables"]]]) nil)

--- a/notebooks/links.md
+++ b/notebooks/links.md
@@ -1,0 +1,67 @@
+# Links
+```clojure
+(ns links
+  {:nextjournal.clerk/toc true}
+  (:require [nextjournal.clerk :as clerk]))
+```
+## Design
+
+We have three different modes to consider for links:
+
+1. Interactive mode `serve!`
+2. Static build unbundled `(build! {:bundle false})`
+3. Static build bundled `(build! {:bundle true})`
+
+The behaviour when triggering links we want is:
+
+1. Interactive mode: trigger a js event `(clerk-eval 'nextjournal.clerk.webserver/navigate! ,,,)`, the doc will in turn be updated via the websocket
+2. Static build unbundled: not intercept the link, let the browser perform its normal navigation
+3. Static build bundled: trigger a js event to update the doc, update the browser's hash so the doc state is persisted on reload
+
+We can allow folks to write normal (relative) links. The limitations here being that things like open in new tab would not work and we can't support a routing function. Both these limitations means we probably want to continue encouraging the use of a helper like `clerk/doc-url` going forward.
+
+We currently don't support navigating to headings / table of contents sections in the bundled build. This could be supported however by introducing a way to encode that in the hash e.g. with `#page:section`.
+
+
+## Examples
+
+
+### JVM-Side
+
+The helper `clerk/doc-url` allows to reference notebooks by path. We currently support relative paths with respect to the directory which started the Clerk application. An optional trailing hash fragment can appended to the path in order for the page to be scrolled up to the indicated identifier.
+
+
+```clojure
+(clerk/html
+ [:ol
+  [:li [:a {:href (clerk/doc-url 'nextjournal.clerk.home)} "Home"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/viewers/html")} "HTML"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/viewers/image")} "Images"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/markdown.md" "appendix")} "Markdown / Appendix"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works" "step-3:-analyzer")} "Clerk Analyzer"]]
+  [:li [:a {:href (clerk/doc-url "book")} "The 📕Book"]]
+  [:li [:a {:href (clerk/doc-url "")} "Homepage"]]])
+```
+
+### Render
+
+The same functionality is available in the SCI context when building render functions.
+
+```clojure
+(clerk/with-viewer
+  '(fn [_ _]
+     [:ol
+      [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewers/html")} "HTML"]]
+      [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/markdown")} "Markdown"]]
+      [:li [:a {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewer_api")} "Viewer API / Tables"]]]) nil)
+
+```
+
+
+### Inside Markdown
+
+Links should work inside markdown as well.
+
+* [HTML](../notebooks/viewers/html) (relative link)
+* [HTML](clerk/doc-url,"notebooks/viewers/html") (doc url, currently not functional)
+

--- a/notebooks/rule_30.clj
+++ b/notebooks/rule_30.clj
@@ -3,6 +3,8 @@
 (ns rule-30
   (:require [nextjournal.clerk :as clerk]))
 
+;; [Back to index](../)
+
 (def viewers
   [{:pred number?
     :render-fn '#(vector :div.inline-block {:style {:width 16 :height 16}

--- a/notebooks/rule_30.clj
+++ b/notebooks/rule_30.clj
@@ -3,8 +3,6 @@
 (ns rule-30
   (:require [nextjournal.clerk :as clerk]))
 
-;; [Back to index](../)
-
 (def viewers
   [{:pred number?
     :render-fn '#(vector :div.inline-block {:style {:width 16 :height 16}

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -321,8 +321,8 @@
       (update opts :resource->url assoc "/css/viewer.css" url))))
 
 (defn doc-url
-  ([opts doc file path] (doc-url opts doc file path nil))
-  ([opts docs file path fragment]
+  ([opts file path] (doc-url opts doc file path nil))
+  ([opts file path fragment]
    (str (viewer/relative-root-prefix-from (viewer/map-index opts file))
         path (when fragment (str "#" fragment)))))
 
@@ -382,7 +382,7 @@
                                                                 (try
                                                                   (binding [*ns* *ns*
                                                                             *build-opts* opts
-                                                                            viewer/doc-url (partial doc-url opts state file)]
+                                                                            viewer/doc-url (partial doc-url opts file)]
                                                                     (let [doc (eval/eval-analyzed-doc doc)]
                                                                       (assoc doc :viewer (view/doc->viewer (assoc opts :static-build? true
                                                                                                                   :nav-path (str file)) doc))))

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -410,6 +410,7 @@
 (comment
   (build-static-app! {:paths clerk-docs :bundle? true})
   (build-static-app! {:paths ["notebooks/hello.clj"]})
+  (build-static-app! {:paths ["CHANGELOG.md" "notebooks/editor.clj"]})
   (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true})
   (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? false})
   (build-static-app! {:paths ["notebooks/viewers/**"]})
@@ -443,16 +444,3 @@
                       :bundle? true
                       :git/sha "d60f5417"
                       :git/url "https://github.com/nextjournal/clerk"}))
-
-
-
-(comment
-  ;; single doc
-  (build-static-app! {:paths ["notebooks/hello.clj"]})
-  ;; multi bundle
-  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true})
-  ;; multi unbundled
-  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? false})
-
-  )
-

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -329,8 +329,11 @@
 (defn doc-url
   ([opts file path] (doc-url opts file path nil))
   ([opts file path fragment]
-   (str (viewer/relative-root-prefix-from (viewer/map-index opts file))
-        path (when fragment (str "#" fragment)))))
+   (if (:bundle? opts)
+     (cond-> (str "#/" path)
+       fragment (str ":" fragment))
+     (str (viewer/relative-root-prefix-from (viewer/map-index opts file)) path
+          (when fragment (str "#" fragment))))))
 
 (defn read-opts-from-deps-edn! []
   (if (fs/exists? "deps.edn")
@@ -418,7 +421,7 @@
   (build-static-app! {:paths clerk-docs :bundle? true})
   (build-static-app! {:paths ["notebooks/editor.clj"] :browse? true})
   (build-static-app! {:paths ["CHANGELOG.md" "notebooks/editor.clj"] :browse? true})
-  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true :browse? true})
+  (build-static-app! {:paths ["index.clj" "design/links.md" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true :browse? true})
   (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? false :browse? true})
   (build-static-app! {:paths ["notebooks/viewers/**"]})
   (build-static-app! {:index "notebooks/rule_30.clj" :git/sha "bd85a3de12d34a0622eb5b94d82c9e73b95412d1" :git/url "https://github.com/nextjournal/clerk"})

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -409,8 +409,9 @@
 
 (comment
   (build-static-app! {:paths clerk-docs :bundle? true})
-  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/viewer_api.md"] :bundle? true})
-  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? false :browse? false})
+  (build-static-app! {:paths ["notebooks/hello.clj"]})
+  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true})
+  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? false})
   (build-static-app! {:paths ["notebooks/viewers/**"]})
   (build-static-app! {:index "notebooks/rule_30.clj" :git/sha "bd85a3de12d34a0622eb5b94d82c9e73b95412d1" :git/url "https://github.com/nextjournal/clerk"})
   (reset! config/!resource->url @config/!asset-map)

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -320,14 +320,11 @@
       (fs/delete-tree tw-folder)
       (update opts :resource->url assoc "/css/viewer.css" url))))
 
-#_(defn doc-url
-    ([opts doc file path] (doc-url opts doc file path nil))
-    ([{:as opts :keys [bundle?]} docs file path fragment]
-     (let [url (get (build-path->url (viewer/update-if opts :index str) docs) path)]
-       (if bundle?
-         (str "#/" url)
-         (str (viewer/relative-root-prefix-from (viewer/map-index opts file))
-              url (when fragment (str "#" fragment)))))))
+(defn doc-url
+  ([opts doc file path] (doc-url opts doc file path nil))
+  ([opts docs file path fragment]
+   (str (viewer/relative-root-prefix-from (viewer/map-index opts file))
+        path (when fragment (str "#" fragment)))))
 
 (defn read-opts-from-deps-edn! []
   (if (fs/exists? "deps.edn")
@@ -385,7 +382,7 @@
                                                                 (try
                                                                   (binding [*ns* *ns*
                                                                             *build-opts* opts
-                                                                            #_#_viewer/doc-url (partial doc-url opts state file)]
+                                                                            viewer/doc-url (partial doc-url opts state file)]
                                                                     (let [doc (eval/eval-analyzed-doc doc)]
                                                                       (assoc doc :viewer (view/doc->viewer (assoc opts :static-build? true
                                                                                                                   :nav-path (str file)) doc))))
@@ -452,7 +449,9 @@
   ;; single doc
   (build-static-app! {:paths ["notebooks/hello.clj"]})
   ;; multi bundle
-  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/viewer_api.md"] :bundle? true})
+  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true})
   ;; multi unbundled
-  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/viewer_api.md"] :bundle? false}))
+  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? false})
+
+  )
 

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -234,7 +234,6 @@
                                "notebooks/markdown.md"] :expand-paths? true})
 
 (defn build-static-app-opts [{:as opts :keys [bundle? out-path browse? index]} docs]
-  (prn :build-static-app-opts index)
   (let [path->doc (into {} (map (juxt (comp str fs/strip-ext strip-index (partial viewer/map-index opts) :file) :viewer)) docs)]
     (assoc opts
            :bundle? bundle?
@@ -395,7 +394,10 @@
                                                                     (let [doc (eval/eval-analyzed-doc doc)]
                                                                       (assoc doc :viewer (view/doc->viewer (assoc opts
                                                                                                                   :static-build? true
-                                                                                                                  :nav-path (str file)) doc))))
+                                                                                                                  :nav-path (if (instance? java.net.URL file)
+                                                                                                                              (str "'" (:ns doc))
+                                                                                                                              (str file)))
+                                                                                                           doc))))
                                                                   (catch Exception e
                                                                     {:error e})))]
                         (report-fn (merge {:stage :built :duration duration :idx idx}
@@ -421,7 +423,8 @@
   (build-static-app! {:paths clerk-docs :bundle? true})
   (build-static-app! {:paths ["notebooks/editor.clj"] :browse? true})
   (build-static-app! {:paths ["CHANGELOG.md" "notebooks/editor.clj"] :browse? true})
-  (build-static-app! {:paths ["index.clj" "design/links.md" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true :browse? true})
+  (build-static-app! {:paths ["index.clj" "notebooks/links.md" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true :browse? true})
+  (build-static-app! {:paths ["notebooks/links.md" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true :browse? true})
   (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? false :browse? true})
   (build-static-app! {:paths ["notebooks/viewers/**"]})
   (build-static-app! {:index "notebooks/rule_30.clj" :git/sha "bd85a3de12d34a0622eb5b94d82c9e73b95412d1" :git/url "https://github.com/nextjournal/clerk"})
@@ -454,3 +457,4 @@
                       :bundle? true
                       :git/sha "d60f5417"
                       :git/url "https://github.com/nextjournal/clerk"}))
+

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -416,7 +416,7 @@
 
 (comment
   (build-static-app! {:paths clerk-docs :bundle? true})
-  (build-static-app! {:paths ["notebooks/hello.clj"] :browse? true})
+  (build-static-app! {:paths ["notebooks/editor.clj"] :browse? true})
   (build-static-app! {:paths ["CHANGELOG.md" "notebooks/editor.clj"] :browse? true})
   (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true :browse? true})
   (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? false :browse? true})

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -283,7 +283,9 @@
                                           (cond-> ssr? ssr!)
                                           cleanup))))))
     (when browse?
-      (browse/browse-url (-> index-html fs/absolutize .toString path-to-url-canonicalize)))
+      (browse/browse-url (if-let [{:keys [port]} (and (= out-path "public/build") @webserver/!server)]
+                           (str "http://localhost:" port "/build/")
+                           (-> index-html fs/absolutize .toString path-to-url-canonicalize))))
     {:docs docs
      :index-html index-html
      :build-href (if (and @webserver/!server (= out-path default-out-path)) "/build/" index-html)}))
@@ -414,10 +416,10 @@
 
 (comment
   (build-static-app! {:paths clerk-docs :bundle? true})
-  (build-static-app! {:paths ["notebooks/hello.clj"]})
-  (build-static-app! {:paths ["CHANGELOG.md" "notebooks/editor.clj"]})
-  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true})
-  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? false})
+  (build-static-app! {:paths ["notebooks/hello.clj"] :browse? true})
+  (build-static-app! {:paths ["CHANGELOG.md" "notebooks/editor.clj"] :browse? true})
+  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true :browse? true})
+  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? false :browse? true})
   (build-static-app! {:paths ["notebooks/viewers/**"]})
   (build-static-app! {:index "notebooks/rule_30.clj" :git/sha "bd85a3de12d34a0622eb5b94d82c9e73b95412d1" :git/url "https://github.com/nextjournal/clerk"})
   (reset! config/!resource->url @config/!asset-map)

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -321,7 +321,7 @@
       (update opts :resource->url assoc "/css/viewer.css" url))))
 
 (defn doc-url
-  ([opts file path] (doc-url opts doc file path nil))
+  ([opts file path] (doc-url opts file path nil))
   ([opts file path fragment]
    (str (viewer/relative-root-prefix-from (viewer/map-index opts file))
         path (when fragment (str "#" fragment)))))

--- a/src/nextjournal/clerk/builder_ui.clj
+++ b/src/nextjournal/clerk/builder_ui.clj
@@ -22,18 +22,18 @@
 
 (defn checkmark-svg [& [{:keys [size] :or {size 18}}]]
   [:div.flex.justify-center {:class "w-[24px] h-[24px]"}
-   [:svg {:xmlns "http://www.w3.org/2000/svg", :fill "none", :viewbox "0 0 24 24", :stroke-width "1.5", :stroke "currentColor", :class "w-6 h-6"}
+   [:svg {:xmlns "http://www.w3.org/2000/svg", :fill "none", :viewBox "0 0 24 24", :stroke-width "1.5", :stroke "currentColor", :class "w-6 h-6"}
     [:path {:stroke-linecap "round", :stroke-linejoin "round", :d "M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"}]]])
 
 (defn error-svg [& [{:keys [size] :or {size 18}}]]
   [:div.flex.justify-center {:class "w-[24px] h-[24px]"}
    [:svg.text-red-400
-    {:xmlns "http://www.w3.org/2000/svg", :viewbox "0 0 20 20", :fill "currentColor"
+    {:xmlns "http://www.w3.org/2000/svg", :viewBox "0 0 20 20", :fill "currentColor"
      :style {:width size :height size}}
     [:path {:fill-rule "evenodd", :d "M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z", :clip-rule "evenodd"}]]])
 
 (def publish-icon-svg
-  [:svg {:width "18", :height "18", :viewbox "0 0 18 18", :fill "none", :xmlns "http://www.w3.org/2000/svg"}
+  [:svg {:width "18", :height "18", :viewBox "0 0 18 18", :fill "none", :xmlns "http://www.w3.org/2000/svg"}
    [:path {:d "M9 17C12.7267 17 15.8583 14.4517 16.7473 11.0026M9 17C5.27327 17 2.14171 14.4517 1.25271 11.0026M9 17C11.2091 17 13 13.4183 13 9C13 4.58172 11.2091 1 9 1M9 17C6.79086 17 5 13.4183 5 9C5 4.58172 6.79086 1 9 1M9 1C11.9913 1 14.5991 2.64172 15.9716 5.07329M9 1C6.00872 1 3.40088 2.64172 2.02838 5.07329M15.9716 5.07329C14.102 6.68924 11.6651 7.66667 9 7.66667C6.33486 7.66667 3.89802 6.68924 2.02838 5.07329M15.9716 5.07329C16.6264 6.23327 17 7.573 17 9C17 9.69154 16.9123 10.3626 16.7473 11.0026M16.7473 11.0026C14.4519 12.2753 11.8106 13 9 13C6.18943 13 3.54811 12.2753 1.25271 11.0026M1.25271 11.0026C1.08775 10.3626 1 9.69154 1 9C1 7.573 1.37362 6.23327 2.02838 5.07329", :stroke "currentColor", :stroke-linecap "round", :stroke-linejoin "round"}]])
 
 ^{:nextjournal.clerk/visibility {:result :show}}
@@ -304,7 +304,7 @@
       (checkmark-svg)
       [:div.text-lg.ml-2.mb-0.font-medium "Your notebooks have been built."]]
      [:a.font-medium.rounded-full.text-sm.px-3.py-1.bg-greenish-20.flex.items-center.border-2.border-greenish.animate-border-pulse.hover:border-white.hover:animate-none
-      {:href link}
+      {:href link :data-ignore-anchor-click true}
       [:div publish-icon-svg]
       [:span.ml-2 "Open"]]]
     [:div.flex.items-center.px-4.lg:px-0

--- a/src/nextjournal/clerk/index.clj
+++ b/src/nextjournal/clerk/index.clj
@@ -15,7 +15,7 @@
                                       [:li.border-t.first:border-t-0.dark:border-gray-800.odd:bg-slate-50.dark:odd:bg-white
                                        {:class "dark:odd:bg-opacity-[0.03]"}
                                        [:a.pl-4.pr-4.py-2.flex.w-full.items-center.justify-between.hover:bg-indigo-50.dark:hover:bg-gray-700
-                                        {:href (clerk/doc-url path)}
+                                        {:href (clerk/doc-url (fs/strip-ext path))}
                                         [:span.text-sm.md:text-md.monospace.flex-auto.block.truncate path]
                                         [:svg.h-4.w-4.flex-shrink-0 {:xmlns "http://www.w3.org/2000/svg" :fill "none" :viewBox "0 0 24 24" :stroke "currentColor"}
                                          [:path {:stroke-linecap "round" :stroke-linejoin "round" :stroke-width "2" :d "M9 5l7 7-7 7"}]]]])))})

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -710,9 +710,8 @@
 
 (defn ignore-anchor-click?
   [e ^js url]
-  (let [current-origin (if (exists? js/location)
+  (let [current-origin (when (exists? js/location)
                          (.-origin js/location))
-        el (some-> e .-target closest-anchor-parent)
         ^js dataset (some-> e .-target closest-anchor-parent .-dataset)]
     (or (not= current-origin (.-origin url))
         (.-altKey e)

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -112,12 +112,11 @@
 
 (defn handle-anchor-click [^js e]
   (when-some [url (some-> e .-target closest-anchor-parent .-href ->URL)]
-    (when (= (.-search url) "?clerk/show!")
-      (.preventDefault e)
-      (clerk-eval (list 'nextjournal.clerk.webserver/navigate!
-                        (cond-> {:nav-path (subs (js/decodeURI (.-pathname url)) 1)}
-                          (seq (.-hash url))
-                          (assoc :fragment (subs (.-hash url) 1))))))))
+    (.preventDefault e)
+    (clerk-eval (list 'nextjournal.clerk.webserver/navigate!
+                      (cond-> {:nav-path (subs (js/decodeURI (.-pathname url)) 1)}
+                        (seq (.-hash url))
+                        (assoc :fragment (subs (.-hash url) 1)))))))
 
 (defn history-push-state [{:as opts :keys [path fragment replace?]}]
   (when (not= path (some-> js/history .-state .-path))

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -714,8 +714,9 @@
       (when (:bundle? state)
         (.preventDefault e)
         (js/console.log :click-bundle e (->doc-url url) )
-        (when-some [doc (get path->doc (->doc-url url))]
-          (set-state! {:doc doc})))
+        (if-some [doc (get path->doc (->doc-url url))]
+          (set-state! {:doc doc})
+          (js/console.warn :doc-url (->doc-url url) :missing-in-docs (keys path->doc))))
       (do (.preventDefault e)
           (clerk-eval (list 'nextjournal.clerk.webserver/navigate!
                             (cond-> {:nav-path (->doc-url url)}

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1767,7 +1767,7 @@
 (defn ^:dynamic doc-url
   ([path] (doc-url path nil))
   ([path fragment]
-   (str "/" path "?clerk/show!" (when fragment (str "#" fragment)))))
+   (str "/" path (when fragment (str "#" fragment)))))
 
 #_(doc-url "notebooks/rule_30.clj#board")
 #_(doc-url "notebooks/rule_30.clj")

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -441,8 +441,7 @@
 
 #?(:clj
    (defn map-index [{:as _opts :keys [index]} path]
-     (prn :map-index index path)
-     (get {index "index.clj"} (str path) (str path))))
+     (get {index "index.clj"} path path)))
 
 #?(:clj
    (defn maybe-store-result-as-file [{:as doc+blob-opts :keys [out-path file]} {:as result :nextjournal/keys [content-type value]}]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1138,7 +1138,7 @@
 (defn index-path [{:keys [static-build? index]}]
   #?(:cljs ""
      :clj (if static-build?
-            (if index (str index) "")
+            ""
             (if (fs/exists? "index.clj") "index.clj" "'nextjournal.clerk.index"))))
 
 (defn header [{:as opts :keys [nav-path static-build?] :git/keys [url sha]}]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -441,7 +441,8 @@
 
 #?(:clj
    (defn map-index [{:as _opts :keys [index]} path]
-     (get {index "index.clj"} path path)))
+     (prn :map-index index path)
+     (get {index "index.clj"} (str path) (str path))))
 
 #?(:clj
    (defn maybe-store-result-as-file [{:as doc+blob-opts :keys [out-path file]} {:as result :nextjournal/keys [content-type value]}]

--- a/test/nextjournal/clerk/builder_test.clj
+++ b/test/nextjournal/clerk/builder_test.clj
@@ -100,7 +100,7 @@
   (testing "coerces index symbol arg and adds it to expanded-paths"
     (is (= ["book.clj"] (:expanded-paths (builder/process-build-opts {:index 'book.clj :expand-paths? true}))))))
 
-
+#_
 (deftest doc-url
   (testing "link to same dir unbundled"
     (is (= "./../notebooks/rule_30.html" ;; NOTE: could also be just "rule_30.html"

--- a/test/nextjournal/clerk/builder_test.clj
+++ b/test/nextjournal/clerk/builder_test.clj
@@ -100,16 +100,16 @@
   (testing "coerces index symbol arg and adds it to expanded-paths"
     (is (= ["book.clj"] (:expanded-paths (builder/process-build-opts {:index 'book.clj :expand-paths? true}))))))
 
-#_
+
 (deftest doc-url
   (testing "link to same dir unbundled"
-    (is (= "./../notebooks/rule_30.html" ;; NOTE: could also be just "rule_30.html"
-           (builder/doc-url {:bundle? false} [{:file "notebooks/viewer_api.clj"} {:file "notebooks/rule_30.clj"}] "notebooks/viewer_api.clj" "notebooks/rule_30.clj"))))
+    (is (= "./../notebooks/rule_30" ;; NOTE: could also be just "rule_30.html"
+           (builder/doc-url {:bundle? false} "notebooks/viewer_api.clj" "notebooks/rule_30"))))
 
   (testing "respects the mapped index"
-    (is (= "./notebooks/rule_30.html"
-           (builder/doc-url {:bundle? false} [{:file "index.clj"} {:file "notebooks/rule_30.clj"}] "index.clj" "notebooks/rule_30.clj"))))
+    (is (= "./notebooks/rule_30"
+           (builder/doc-url {:bundle? false} "index.clj" "notebooks/rule_30"))))
 
   (testing "bundle case"
-    (is (= "#/notebooks/rule_30.clj"
-           (builder/doc-url {:bundle? true} [{:file "notebooks/index.clj"} {:file "notebooks/rule_30.clj"}] "index.clj" "notebooks/rule_30.clj")))))
+    (is (= "#/notebooks/rule_30"
+           (builder/doc-url {:bundle? true} "index.clj" "notebooks/rule_30")))))


### PR DESCRIPTION
This unifies the link handling between `build!` and `serve!` by no longer using extensions in either mode (was `.clj|md` in `serve!` and `.html` in `build!`). 

To support this in the unbundled static build, we're now writing directories with `index.html` for each notebook. This makes links in this build no longer accessible without a http server. If you're looking for a self-contained html that works without a webserver, set the `:bundle` option.