### PR TITLE
Fix relative paths in static apps

### DIFF
--- a/notebooks/document_linking.clj
+++ b/notebooks/document_linking.clj
@@ -9,7 +9,7 @@
  [:ol
   [:li [:a {:href (clerk/doc-url "notebooks/viewers/html")} "HTML"]]
   [:li [:a {:href (clerk/doc-url "notebooks/viewers/image")} "Images"]]
-  [:li [:a {:href (clerk/doc-url "notebooks/markdown.md" "appendix")} "Markdown / Appendix"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/markdown" "appendix")} "Markdown / Appendix"]]
   [:li [:a {:href (clerk/doc-url "notebooks/how_clerk_works" "step-3:-analyzer")} "Clerk Analyzer"]]
   [:li [:a {:href (clerk/doc-url "book")} "The 📕Book"]]
   [:li [:a {:href (clerk/doc-url "")} "Homepage"]]])

--- a/notebooks/viewers/html.clj
+++ b/notebooks/viewers/html.clj
@@ -12,17 +12,17 @@
 (clerk/html
  [:div
   "Go to "
-  [:a.text-lg {:href (clerk/doc-url "notebooks/viewers/image.clj")} "images"]
+  [:a.text-lg {:href (clerk/doc-url "notebooks/viewers/image")} "images"]
   " notebook."])
 
 (clerk/with-viewer
   '(fn [_ _] [:div
              "Go to "
-             [:a.text-lg {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewers/image.clj")} "images"]
+             [:a.text-lg {:href (nextjournal.clerk.viewer/doc-url "notebooks/viewers/image")} "images"]
              " notebook."]) nil)
 
 (clerk/html
  [:ol
-  [:li [:a {:href (clerk/doc-url "notebooks/document_linking.clj")} "Cross Document Linking"]]
-  [:li [:a {:href (clerk/doc-url "notebooks/rule_30.clj")} "Rule 30"]]
-  [:li [:a {:href (clerk/doc-url "notebooks/markdown.md")} "Appendix"]]])
+  [:li [:a {:href (clerk/doc-url "notebooks/document_linking")} "Cross Document Linking"]]
+  [:li [:a {:href (clerk/doc-url "notebooks/rule_30")} "Rule 30"]]
+  [:li [:a {:href (clerk/doc-url "")} "Back"]]])

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -459,4 +459,3 @@
                       :bundle? true
                       :git/sha "d60f5417"
                       :git/url "https://github.com/nextjournal/clerk"}))
-

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -25,7 +25,7 @@
 
 (defn adjust-relative-path [{:as state :keys [current-path]} url]
   (cond->> url
-    (and current-path (relative? url))
+    (and (not-empty current-path) (relative? url))
     (str (v/relative-root-prefix-from (v/map-index state current-path)))))
 
 (defn include-viewer-css [state]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -437,8 +437,9 @@
 
 #?(:clj
    (defn relative-root-prefix-from [path]
-     (str "./" (str/join (repeat (inc (get (frequencies (str path)) \/ 0))
-                                 "../")))))
+     (str "./" (when (not= "index.clj" path)
+                 (str/join (repeat (inc (get (frequencies (str path)) \/ 0))
+                                   "../"))))))
 
 #?(:clj
    (defn map-index [{:as _opts :keys [index]} path]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -437,7 +437,8 @@
 
 #?(:clj
    (defn relative-root-prefix-from [path]
-     (str "./" (str/join (repeat (get (frequencies (str path)) \/ 0) "../")))))
+     (str "./" (str/join (repeat (inc (get (frequencies (str path)) \/ 0))
+                                 "../")))))
 
 #?(:clj
    (defn map-index [{:as _opts :keys [index]} path]

--- a/test/nextjournal/clerk/builder_test.clj
+++ b/test/nextjournal/clerk/builder_test.clj
@@ -103,12 +103,20 @@
 
 (deftest doc-url
   (testing "link to same dir unbundled"
-    (is (= "./../notebooks/rule_30" ;; NOTE: could also be just "rule_30.html"
+    (is (= "./../../notebooks/rule_30" ;; NOTE: could also be just "rule_30.html"
            (builder/doc-url {:bundle? false} "notebooks/viewer_api.clj" "notebooks/rule_30"))))
 
   (testing "respects the mapped index"
-    (is (= "./notebooks/rule_30"
-           (builder/doc-url {:bundle? false} "index.clj" "notebooks/rule_30"))))
+    (is (= "./../notebooks/rule_30"
+           (builder/doc-url {:bundle? false} "index.clj" "notebooks/rule_30")))
+
+    (is (= "./../notebooks/rule_30"
+           (builder/doc-url {:bundle? false :index "notebooks/path/to/notebook.clj"}
+                            "notebooks/path/to/notebook.clj" "notebooks/rule_30")))
+
+    (is (= "./../../../../notebooks/rule_30"
+           (builder/doc-url {:bundle? false}
+                            "notebooks/path/to/notebook.clj" "notebooks/rule_30"))))
 
   (testing "bundle case"
     (is (= "#/notebooks/rule_30"

--- a/test/nextjournal/clerk/builder_test.clj
+++ b/test/nextjournal/clerk/builder_test.clj
@@ -102,10 +102,12 @@
 
 
 (deftest doc-url
-  ;; unbundled: path/to/notebook.clj => path/to/notebok/[index.html]
-  ;;   bundled: path/to/notebook.clj => #/path/to/notebok
-
   (testing "link to same dir unbundled"
+    ;; in the unbundled case the current URL on a given notebook is given by
+    ;;
+    ;; fs-path              |  URL
+    ;; ----------------------------------------------------
+    ;; path/to/notebook.clj |  path/to/notebok/[index.html]
     (is (= "./../../notebooks/rule_30" ;; NOTE: could also be just "rule_30.html"
            (builder/doc-url {:bundle? false} "notebooks/viewer_api.clj" "notebooks/rule_30"))))
 

--- a/test/nextjournal/clerk/builder_test.clj
+++ b/test/nextjournal/clerk/builder_test.clj
@@ -102,15 +102,18 @@
 
 
 (deftest doc-url
+  ;; unbundled: path/to/notebook.clj => path/to/notebok/[index.html]
+  ;;   bundled: path/to/notebook.clj => #/path/to/notebok
+
   (testing "link to same dir unbundled"
     (is (= "./../../notebooks/rule_30" ;; NOTE: could also be just "rule_30.html"
            (builder/doc-url {:bundle? false} "notebooks/viewer_api.clj" "notebooks/rule_30"))))
 
   (testing "respects the mapped index"
-    (is (= "./../notebooks/rule_30"
+    (is (= "./notebooks/rule_30"
            (builder/doc-url {:bundle? false} "index.clj" "notebooks/rule_30")))
 
-    (is (= "./../notebooks/rule_30"
+    (is (= "./notebooks/rule_30"
            (builder/doc-url {:bundle? false :index "notebooks/path/to/notebook.clj"}
                             "notebooks/path/to/notebook.clj" "notebooks/rule_30")))
 


### PR DESCRIPTION
In case of unbundled static apps, `relative-root-prefix` is invoked to build relative paths, walking up by multiples of `../` until the root. Now after #529, paths to `notebooks/some/x.clj` became `/notebooks/some/x/[index.html]` adding up one level to reach the root.

Fixes #534.