### PR TITLE
Editor Improvements

### DIFF
--- a/render/deps.edn
+++ b/render/deps.edn
@@ -6,7 +6,7 @@
         reagent/reagent {:mvn/version "1.2.0"}
         io.github.babashka/sci.configs {:git/sha "0702ea5a21ad92e6d7cca6d36de84271083ea68f"}
         io.github.nextjournal/clojure-mode {:git/sha "760512c0434944975ab19784ae8c73d2152bf72b"}
-        io.github.nextjournal/command-bar {:git/sha "7dfea8391960fa6f8a853b2ed32586834affff09"
+        io.github.nextjournal/command-bar {:git/sha "0f6c1db58b42a2f7ee0704edc00b4526c66f2c4a"
                                            :exclusions [io.github.nextjournal/clojure-mode]}
         thheller/shadow-cljs {:mvn/version "2.23.1"}
         io.github.squint-cljs/cherry {;; :local/root "/Users/borkdude/dev/cherry"

--- a/render/deps.edn
+++ b/render/deps.edn
@@ -6,7 +6,7 @@
         reagent/reagent {:mvn/version "1.2.0"}
         io.github.babashka/sci.configs {:git/sha "0702ea5a21ad92e6d7cca6d36de84271083ea68f"}
         io.github.nextjournal/clojure-mode {:git/sha "760512c0434944975ab19784ae8c73d2152bf72b"}
-        io.github.nextjournal/command-bar {:git/sha "0f6c1db58b42a2f7ee0704edc00b4526c66f2c4a"
+        io.github.nextjournal/command-bar {:git/sha "2d5283952bc56c6987e91485d6c0883d73528c81"
                                            :exclusions [io.github.nextjournal/clojure-mode]}
         thheller/shadow-cljs {:mvn/version "2.23.1"}
         io.github.squint-cljs/cherry {;; :local/root "/Users/borkdude/dev/cherry"

--- a/render/deps.edn
+++ b/render/deps.edn
@@ -5,7 +5,9 @@
         org.babashka/sci {:mvn/version "0.7.39"}
         reagent/reagent {:mvn/version "1.2.0"}
         io.github.babashka/sci.configs {:git/sha "0702ea5a21ad92e6d7cca6d36de84271083ea68f"}
-        io.github.nextjournal/clojure-mode {:git/sha "1f55406087814a0dda6806396aa596dbe13ea302"}
+        io.github.nextjournal/clojure-mode {:git/sha "760512c0434944975ab19784ae8c73d2152bf72b"}
+        io.github.nextjournal/command-bar {:git/sha "7dfea8391960fa6f8a853b2ed32586834affff09"
+                                           :exclusions [io.github.nextjournal/clojure-mode]}
         thheller/shadow-cljs {:mvn/version "2.23.1"}
         io.github.squint-cljs/cherry {;; :local/root "/Users/borkdude/dev/cherry"
                                       :git/sha "ac89d93f136ee8fab91f62949de5b5822ba08b3c"}}}

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -164,24 +164,29 @@
 (defn error-view [error]
   (let [!stack-expanded (hooks/use-state false)]
     [:div.bg-red-100.dark:bg-gray-800.px-6.py-4.rounded-md.text-xs.dark:border-2.dark:border-red-300.not-prose
-     [:p.font-mono.text-red-600.dark:text-red-300.font-bold (or (:message error) (.-message error))]
+     [:p.font-mono.text-red-600.dark:text-red-300.font-bold (or (:message error) (:cause error) (.-message error))]
      (when-let [data (or (:data error) (.-data error))]
        [:<>
         (when-let [extra-view (::extra-view data)]
           [:div.mt-2.overflow-auto [inspect extra-view]])
         [:div.mt-2.overflow-auto [inspect (dissoc data ::extra-view)]]])
-     (when-let [stack (try
-                        (->> (or (:stack error) (.-stack error))
-                             str/split-lines
-                             (drop 1)
-                             (mapv str/trim))
-                        (catch js/Error _ nil))]
-       [:pre.text-red-600.dark:text-red-300.w-full.overflow-auto.mt-2 {:class "text-[11px] max-h-[155px]"}
-        [:span.underline.cursor-pointer {:on-click #(swap! !stack-expanded not)}
-         (if @!stack-expanded "Hide" "Show")
-         " Stacktrace (" (count stack) " lines)\n"]
-        (when @!stack-expanded
-          (str/join "\n" stack))])]))
+     (let [stack (or (:stack error) (:trace error) (.-stack error))]
+       (when-let [stack (cond
+                          (string? stack)
+                          (try
+                            (->> stack
+                                 str/split-lines
+                                 (drop 1)
+                                 (mapv str/trim))
+                            (catch js/Error _ nil))
+                          (coll? stack)
+                          (map str stack))]
+         [:pre.text-red-600.dark:text-red-300.w-full.overflow-auto.mt-2 {:class "text-[11px] max-h-[155px]"}
+          [:span.underline.cursor-pointer {:on-click #(swap! !stack-expanded not)}
+           (if @!stack-expanded "Hide" "Show")
+           " Stacktrace (" (count stack) " lines)\n"]
+          (when @!stack-expanded
+            (str/join "\n" stack))]))]))
 
 
 (defclass ErrorBoundary

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -15,6 +15,7 @@
             [nextjournal.clerk.viewer :as v]
             [nextjournal.clojure-mode.extensions.eval-region :as eval-region]
             [nextjournal.clojure-mode.keymap :as clojure-mode.keymap]
+            [nextjournal.command-bar :as command-bar]
             [rewrite-clj.node :as n]
             [rewrite-clj.parser :as p]
             [sci.core :as sci]
@@ -191,6 +192,7 @@
                                                       #js [(placeholder "Show code with Option+Return")
                                                            (.of keymap clojure-mode.keymap/paredit)
                                                            completion-source
+                                                           command-bar/extension
                                                            (.. EditorState -transactionExtender
                                                                (of (fn [^js tr]
                                                                      (when (.-selection tr)
@@ -224,7 +226,7 @@
        [:div.relative
         {:ref !editor-panel :style {:width "50vw"}}
         [:div.bg-slate-200.border-r.border-slate-300.dark:border-slate-600.px-4.py-3.dark:bg-slate-950.overflow-y-auto.relative
-         {:style {:height (str "calc(100vh - " (* bar-height 2) "px)")}}
+         {:style {:height (str "calc(100vh - " bar-height "px)")}}
          [:div.h-screen {:ref !container-el}]]
         [:div.absolute.right-0.top-0.bottom-0.z-1000.group
          {:class "w-[9px] -mr-[5px]"}
@@ -241,48 +243,8 @@
            [render/inspect-presented notebook]]
           [:div.flex.flex-col.items-center.justify-items-center.my-10
            [spinner-svg {:size "100px"}]])]]
-      [:div.absolute.left-0.bottom-0.w-screen.font-mono.text-white.border-t.dark:border-slate-600
-       [:div.bg-slate-900.dark:bg-slate-800.flex.px-4.font-mono.gap-4.items-center.text-white
-        {:class "text-[12px]" :style {:height bar-height}}
-        [:div.flex.gap-1.items-center
-         "Eval notebook"
-         [:div.font-inter.text-slate-300 "⌥↩"]]
-        [:div.flex.gap-1.items-center
-         "Eval at cursor"
-         [:div.font-inter.text-slate-300 "⌘↩"]]
-        [:div.flex.gap-1.items-center
-         "Eval top level"
-         [:div.font-inter.text-slate-300 "⇧⌘↩"]]
-        [:div.flex.gap-1.items-center
-         "Slurp forward"
-         [:div.font-inter.text-slate-300 "Ctrl→"]]
-        [:div.flex.gap-1.items-center
-         "Barf forward"
-         [:div.font-inter.text-slate-300 "Ctrl←"]]
-        [:div.flex.gap-1.items-center
-         "Splice"
-         [:div.font-inter.text-slate-300 "⌥S"]]
-        [:div.flex.gap-1.items-center
-         "Expand selection"
-         [:div.font-inter.text-slate-300 "⌘1"]]
-        [:div.flex.gap-1.items-center
-         "Contract selection"
-         [:div.font-inter.text-slate-300 "⌘2"]]]
-       [:div.w-screen.bg-slate-800.dark:bg-slate-950.px-4.font-mono.items-center.text-white.flex.items-center
-        {:class "text-[12px] py-[4px]" :style {:min-height bar-height}}
-        (when-let [{:keys [name arglists-str doc]} @!info]
-          [:div
-           [:div.flex.gap-4
-            [:div.flex.gap-2
-             [:span.font-bold (str name)]
-             [:span arglists-str]]
-            (when (and doc (not @!show-docstring?))
-              [:div.flex.gap-1.items-center.text-slate-300
-               "Show docstring"
-               [:div.font-inter.text-slate-400.flex-shrink-0 "⌘I"]])]
-           (when (and doc @!show-docstring?)
-             [:div.text-slate-300.mt-2.mb-1.leading-relaxed {:class "max-w-[640px]"} doc])])]]
       (when-let [result @!eval-result]
         [:div.border-t.border-slate-300.dark:border-slate-600.px-4.py-2.flex-shrink-0.absolute.left-0.w-screen.bg-white.dark:bg-slate-950
          {:style {:box-shadow "0 -2px 3px 0 rgb(0 0 0 / 0.025)" :bottom (* bar-height 2)}}
-         [render/inspect-presented result]])]]))
+         [render/inspect-presented result]])
+      [command-bar/view {}]]]))

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -312,11 +312,13 @@
                                                                  [{:key "Alt-Enter"
                                                                    :run show-notebook}
                                                                   {:key "Mod-Enter"
-                                                                   :shift (partial eval-region* eval-region/top-level-string (or eval-string-fn eval-string) on-result)
-                                                                   :run (partial eval-region* eval-region/cursor-node-string (or eval-string-fn eval-string) on-result)}
-                                                                  {:key "Mod-i"
-                                                                   :preventDefault true
-                                                                   :run #(swap! !show-docstring? not)}
+                                                                   :shift (fn eval-top-level-form [state]
+                                                                            (eval-region* eval-region/top-level-string (or eval-string-fn eval-string) on-result state))
+                                                                   :run (fn eval-form-at-cursor [state]
+                                                                          (eval-region* eval-region/cursor-node-string (or eval-string-fn eval-string) on-result state))}
+                                                                  #_#_{:key "Mod-i"
+                                                                       :preventDefault true
+                                                                       :run #(swap! !show-docstring? not)}
                                                                   {:key "Escape"
                                                                    :run #(reset! !show-docstring? false)}]))]))
                             @!container-el))]

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -310,6 +310,7 @@
                                                                      #js {})))
                                                            (eval-region/extension {:modifier "Meta"})
                                                            (.of keymap historyKeymap)
+                                                           (.of keymap clojure-mode.keymap/complete)
                                                            (.of keymap
                                                                 (j/lit
                                                                  [{:key "Alt-Enter"

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -221,7 +221,7 @@
                                                                   {:key "Escape"
                                                                    :run #(reset! !show-docstring? false)}]))]))
                             @!container-el))]
-         (goog.events/listenOnce js/window "clerk.wsopen" #(on-eval view) false)
+         (on-eval view)
          #(.destroy view))))
     (code/use-dark-mode !view)
     [:<>

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -5,6 +5,7 @@
             ["@codemirror/view" :refer [keymap placeholder]]
             [applied-science.js-interop :as j]
             [clojure.string :as str]
+            [goog.events]
             [nextjournal.clerk.parser :as parser]
             [nextjournal.clerk.render :as render]
             [nextjournal.clerk.render.code :as code]
@@ -220,8 +221,7 @@
                                                                   {:key "Escape"
                                                                    :run #(reset! !show-docstring? false)}]))]))
                             @!container-el))]
-         ;; FIXME! we need a callback on ws ready
-         (js/setTimeout #(on-eval view) 500)
+         (goog.events/listenOnce js/window "clerk.wsopen" #(on-eval view) false)
          #(.destroy view))))
     (code/use-dark-mode !view)
     [:<>

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -1,5 +1,6 @@
 (ns nextjournal.clerk.render.editor
   (:require ["@codemirror/autocomplete" :refer [autocompletion]]
+            ["@codemirror/commands" :refer [history historyKeymap]]
             ["@codemirror/language" :refer [syntaxTree]]
             ["@codemirror/state" :refer [EditorState]]
             ["@codemirror/view" :refer [keymap placeholder]]
@@ -296,6 +297,7 @@
                             (code/make-state code-string
                                              (.concat code/default-extensions
                                                       #js [(placeholder "Show code with Option+Return")
+                                                           (history)
                                                            (.of keymap clojure-mode.keymap/paredit)
                                                            completion-source
                                                            command-bar/extension
@@ -307,6 +309,7 @@
                                                                        (reset! !info (some-> (info-at-point @!view (.-to (first (.. tr -selection asSingle -ranges)))))))
                                                                      #js {})))
                                                            (eval-region/extension {:modifier "Meta"})
+                                                           (.of keymap historyKeymap)
                                                            (.of keymap
                                                                 (j/lit
                                                                  [{:key "Alt-Enter"

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -298,7 +298,6 @@
                                              (.concat code/default-extensions
                                                       #js [(placeholder "Show code with Option+Return")
                                                            (history)
-                                                           (.of keymap clojure-mode.keymap/paredit)
                                                            completion-source
                                                            command-bar/extension
                                                            (.. EditorState -transactionExtender

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -325,6 +325,11 @@
                                                                   {:key "Escape"
                                                                    :run #(reset! !show-docstring? false)}]))]))
                             @!container-el))]
+
+         (js/console.log :keys
+                         (->> (.. view -state (facet keymap) flat (filter #(and (or (.-key %) (.-mac %)) (.-run %) (.. % -run -name))))
+                              (map #(.. % -run -name))))
+
          (show-notebook view)
          #(.destroy view))))
     (code/use-dark-mode !view)

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -167,6 +167,14 @@
 
 (defonce bar-height 26)
 
+(defn spinner-svg [& [{:keys [size] :or {size 16}}]]
+  [:div.flex.items-center.justify-center {:class "w-[50px] h-[50px]"}
+   [:svg.animate-spin.text-greenish
+    {:xmlns "http://www.w3.org/2000/svg" :fill "none" :viewBox "0 0 24 24"
+     :style {:width size :height size}}
+    [:circle.opacity-25 {:cx "12" :cy "12" :r "10" :stroke "currentColor" :stroke-width "4"}]
+    [:path.opacity-75 {:fill "currentColor" :d "M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"}]]])
+
 (defn view [code-string {:as _opts :keys [eval-notebook-fn]}]
   (let [!notebook (hooks/use-state nil)
         !eval-result (hooks/use-state nil)
@@ -212,7 +220,8 @@
                                                                   {:key "Escape"
                                                                    :run #(reset! !show-docstring? false)}]))]))
                             @!container-el))]
-         (on-eval view)
+         ;; FIXME! we need a callback on ws ready
+         (js/setTimeout #(on-eval view) 500)
          #(.destroy view))))
     (code/use-dark-mode !view)
     [:<>
@@ -236,9 +245,11 @@
        [:div.bg-white.dark:bg-slate-950.bg-white.flex.flex-col.overflow-y-auto
         {:ref !notebook-panel
          :style {:width "50vw" :height (str "calc(100vh - " (* bar-height 2) "px)")}}
-        (when-let [notebook @!notebook]
+        (if-some [notebook @!notebook]
           [:> render/ErrorBoundary {:hash (gensym)}
-           [render/inspect-presented notebook]])]]
+           [render/inspect-presented notebook]]
+          [:div.flex.flex-col.items-center.justify-items-center.my-10
+           [spinner-svg {:size "100px"}]])]]
       [:div.absolute.left-0.bottom-0.w-screen.font-mono.text-white.border-t.dark:border-slate-600
        [:div.bg-slate-900.dark:bg-slate-800.flex.px-4.font-mono.gap-4.items-center.text-white
         {:class "text-[12px]" :style {:height bar-height}}

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -180,7 +180,8 @@
         on-eval (fn [^js editor-view]
                   (.. ((or eval-notebook-fn eval-notebook) (.. editor-view -state -doc toString))
                       (then (fn [result] (reset! !notebook result)))
-                      (catch (fn [error] (reset! !notebook (v/html [render/error-view error]))))))]
+                      (catch (fn [error]
+                               (reset! !notebook (v/present (v/html [render/error-view error])))))))]
     (hooks/use-effect
      (fn []
        (let [^js view

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -14,6 +14,7 @@
             [clojure.string :as str]
             [edamame.core :as edamame]
             [goog.object]
+            [goog.events]
             [nextjournal.clerk.cherry-env :as cherry-env]
             [nextjournal.clerk.parser]
             [nextjournal.clerk.render :as render]
@@ -205,7 +206,9 @@
     (swap! render/!doc assoc ::connection-status "Reconnecting…"))
   (let [ws (js/WebSocket. ws-url)]
     (set! (.-onmessage ws) onmessage)
-    (set! (.-onopen ws) (fn [e] (swap! render/!doc dissoc ::connection-status ::failed-attempts)))
+    (set! (.-onopen ws) (fn [e]
+                          (swap! render/!doc dissoc ::connection-status ::failed-attempts)
+                          (.dispatchEvent js/window (new js/Event "clerk.wsopen"))))
     (set! (.-onclose ws) (fn [e]
                            (let [timeout (reconnect-timeout (::failed-attempts @render/!doc 0))]
                              (swap! render/!doc

--- a/src/nextjournal/clerk/sci_env/completions.cljs
+++ b/src/nextjournal/clerk/sci_env/completions.cljs
@@ -133,6 +133,6 @@
              :status ["done"]})
           {:status ["done"]})))
     (catch :default e
-      (js/console.error "ERROR" e)
+      #_(js/console.error "ERROR" e)
       {:completions []
        :status ["done"]})))


### PR DESCRIPTION
- [ ] add command bar
- [x]  allow to configure eval fns (notebook / string) e.g. for JVM side evaluation
- [x] buffer messages while web socket is not connected, send later when connected
- [ ] ~~extract eval + present-result in one function to allow caching and pagination on single expressions~~

Paired with [notebook](https://github.com/nextjournal/clerk-web-editor/blob/main/src/clerk_web_editor.clj), live on https://clerk-editor.live.clerk.garden.