### PR TITLE
Fix preserving expanded-at state on show

### DIFF
--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -609,9 +609,10 @@
    (let [digest-fn (case hash-type
                      :sha1 sha1-base58
                      :sha512 sha2-base58)]
-     (-> value
-         nippy/fast-freeze
-         digest-fn))))
+     (binding [nippy/*incl-metadata?* false]
+       (-> value
+           nippy/fast-freeze
+           digest-fn)))))
 
 #_(valuehash (range 100))
 #_(valuehash :sha1 (range 100))


### PR DESCRIPTION
Fix #547.

We're resetting expansion state when `:nextjourna/hash` is changing on a result. The hash is computed starting from the presented value using nippy/freeze. It turns out that adding pagination continuation functions (#421) as metadata on the presented result broke nippy serialization and we'd get a fresh hash (a gensym) on each call to show. We can fix it by excluding metadata when freezing.