### PR TITLE
API Doc Browser

### DIFF
--- a/notebooks/doc.clj
+++ b/notebooks/doc.clj
@@ -75,7 +75,8 @@
   ([nss-map ns-matches acc]
    (if-some [ns-name (first ns-matches)]
      (recur nss-map
-            (remove #(str/starts-with? % ns-name) ns-matches)
+            (remove (some-fn #{ns-name} #(str/starts-with? % (str ns-name ".")))
+                    ns-matches)
             (conj acc (ns-node-with-branches nss-map ns-name)))
      acc)))
 

--- a/notebooks/doc.clj
+++ b/notebooks/doc.clj
@@ -49,10 +49,10 @@
 
 (defn render-var [{:keys [name]}]
   #_(reset! doc/!ns-query ns)
-  [:div.text-red-500 name])
+  [:div.text-red-500.mt-1 name])
 
 (defn render-ns [{:keys [name nss vars]}]
-  [:div
+  [:div.mt-1
    [:div name]
    (when vars
      (into [:div.ml-3] (map render-var) vars))

--- a/notebooks/doc.clj
+++ b/notebooks/doc.clj
@@ -120,39 +120,40 @@
     [:div.px-3.py-3.border-b
      (clerk/with-viewer {:render-fn render-input
                          :transform-fn clerk/mark-presented} (viewer/->viewer-eval `!ns-query))]
-    (cond (not (str/blank? @!ns-query))
-          [:div
-           [:div.tracking-wider.uppercase.text-slate-400.px-5.font-sans.text-xs.mt-5 "Search results"]
-           (into [:div.text-sm.font-sans.px-5.mt-3]
-                 (map render-ns)
-                 (ns-tree ns-matches))]
-          (= @!active-ns :all)
-          [:div
-           [:div.tracking-wider.uppercase.text-slate-500.px-5.font-sans.text-xs.mt-5 "All namespaces"]
-           (into [:div.text-sm.font-sans.px-5.mt-2]
-                 (map render-ns)
-                 (ns-tree (sort (map (comp str ns-name) (all-ns)))))]
-          :else
-          (let [path (path-to-ns @!active-ns)]
-            [:<>
-             [:div
+    [:div.pb-5
+     (cond (not (str/blank? @!ns-query))
+           [:div
+            [:div.tracking-wider.uppercase.text-slate-400.px-5.font-sans.text-xs.mt-5 "Search results"]
+            (into [:div.text-sm.font-sans.px-5.mt-3]
+                  (map render-ns)
+                  (ns-tree ns-matches))]
+           (= @!active-ns :all)
+           [:div
+            [:div.tracking-wider.uppercase.text-slate-500.px-5.font-sans.text-xs.mt-5 "All namespaces"]
+            (into [:div.text-sm.font-sans.px-5.mt-2]
+                  (map render-ns)
+                  (ns-tree (sort (map (comp str ns-name) (all-ns)))))]
+           :else
+           (let [path (path-to-ns @!active-ns)]
+             [:<>
               [:div
-               [:div.tracking-wider.uppercase.text-slate-500.px-5.font-sans.text-xs.mt-5.mb-2 "Nav"]
-               (when-some [ns-name (some-> (str/join "." (butlast (str/split @!active-ns #"\."))) symbol find-ns ns-name str)]
-                 [:div.px-5.font-sans.text-xs.mt-1.text-indigo-600.hover:underline.cursor-pointer
-                  {:on-click (viewer/->viewer-eval `(fn []
-                                                      (reset! !active-ns ~ns-name)
-                                                      (reset! !ns-query "")))}
-                  "One level up"])
-               [:div.px-5.font-sans.text-xs.mt-1.text-indigo-600.hover:underline.cursor-pointer
-                {:on-click (viewer/->viewer-eval `(fn []
-                                                    (reset! !active-ns :all)
-                                                    (reset! !ns-query "")))}
-                "All namespaces"]]
-              [:div.tracking-wider.uppercase.text-slate-500.px-5.font-sans.text-xs.mt-5 "Current namespace"]
-              (into [:div.text-sm.font-sans.px-5.mt-2]
-                    (map render-ns)
-                    (ns-tree (match-nss @!active-ns)))]]))]
+               [:div
+                [:div.tracking-wider.uppercase.text-slate-500.px-5.font-sans.text-xs.mt-5.mb-2 "Nav"]
+                (when-some [ns-name (some-> (str/join "." (butlast (str/split @!active-ns #"\."))) symbol find-ns ns-name str)]
+                  [:div.px-5.font-sans.text-xs.mt-1.text-indigo-600.hover:underline.cursor-pointer
+                   {:on-click (viewer/->viewer-eval `(fn []
+                                                       (reset! !active-ns ~ns-name)
+                                                       (reset! !ns-query "")))}
+                   "One level up"])
+                [:div.px-5.font-sans.text-xs.mt-1.text-indigo-600.hover:underline.cursor-pointer
+                 {:on-click (viewer/->viewer-eval `(fn []
+                                                     (reset! !active-ns :all)
+                                                     (reset! !ns-query "")))}
+                 "All namespaces"]]
+               [:div.tracking-wider.uppercase.text-slate-500.px-5.font-sans.text-xs.mt-5 "Current namespace"]
+               (into [:div.text-sm.font-sans.px-5.mt-2]
+                     (map render-ns)
+                     (ns-tree (match-nss @!active-ns)))]]))]]
    [:div.flex-auto.max-h-screen.overflow-y-auto.px-8.py-5
     (let [ns (some-> @!active-ns symbol find-ns)]
       (cond
@@ -168,15 +169,18 @@
                      [:div.font-bold.font-sans.text-xl {:style {:margin 0}} (if (= @!active-ns :all)
                                                                               "All namespaces in classpath"
                                                                               @!active-ns)]
-                     (into [:div]
+                     (into [:div.mt-2]
                            (map (fn [ns-str]
-                                  [:div.pt-3.mt-3
-                                   [:div.font-sans.text-base
-                                    {:style {:margin 0}
-                                     :on-click (viewer/->viewer-eval `(fn []
-                                                                        (reset! !active-ns ~ns-str)
-                                                                        (reset! !ns-query "")))}
-                                    ns-str]]))
+                                  [:div.pt-5.mt-5.border-t.hover:text-indigo-600.cursor-pointer.group
+                                   {:on-click (viewer/->viewer-eval `(fn []
+                                                                       (reset! !active-ns ~ns-str)
+                                                                       (reset! !ns-query "")))}
+                                   [:div.font-sans.text-base.font-bold.group-hover:underline
+                                    {:style {:margin 0}}
+                                    ns-str]
+                                   (when-let [doc (some-> ns-str symbol find-ns meta :doc)]
+                                     [:div.mt-2.leading-normal.viewer-markdown.prose.text-sm
+                                      (clerk/md doc)])]))
                            (if (= :all @!active-ns)
                              (sort (map :name (ns-tree (map (comp str ns-name) (all-ns)))))
                              (match-nss @!active-ns)))]

--- a/notebooks/doc.clj
+++ b/notebooks/doc.clj
@@ -6,15 +6,23 @@
 
 (def render-input
   '(fn [!query]
-     (prn :query !query)
+     (nextjournal.clerk.render.hooks/use-effect
+      (fn []
+        (let [keydown-handler (fn [event]
+                                (when (and (.-metaKey event) (= "k" (.-key event)))
+                                  (.focus (js/document.getElementById "search-nss"))))]
+          (js/document.addEventListener "keydown" keydown-handler)
+          #(js/document.removeEventListener "keydown" keydown-handler))))
      [:div.my-1.relative
-      [:input.px-2.py-1.relative.bg-white.dark:bg-slate-900.bg-white.rounded.border.dark:border-slate-700.shadow-inner.outline-none.focus:outline-none.focus:ring.w-full.text-sm.font-sans
+      [:input#search-nss.px-2.py-1.relative.bg-white.dark:bg-slate-900.bg-white.rounded.border.dark:border-slate-700.shadow-inner.outline-none.focus:outline-none.focus:ring-2.focus.ring-indigo-500.hover:border-slate-400.focus:hover:border-slate-200.w-full.text-sm.font-sans.dark:hover:border-slate-600.dark:focus:border-sslate-700
        {:type :text
         :auto-correct "off"
         :spell-check "false"
         :placeholder "Search namespaces…"
         :value @!query
         :on-input #(reset! !query (.. % -target -value))}]
+      [:div.text-xs.absolute.right-2.text-slate-400.dark:text-slate-400.font-inter.tracking-widest.pointer-events-none
+       {:class "top-1/2 -translate-y-1/2"} "⌘K"]
       #_[:button.absolute.right-2.text-xl.cursor-pointer
          {:class "top-1/2 -translate-y-1/2"
           :on-click #(reset! !query (clojure.string/join "." (drop-last (clojure.string/split @!query #"\."))))} "⏮"]]))

--- a/notebooks/doc.clj
+++ b/notebooks/doc.clj
@@ -72,6 +72,7 @@
      acc)))
 
 #_(ns-tree ns-matches)
+#_(ns-tree ())
 
 ^{::clerk/visibility {:result :show}}
 (clerk/html
@@ -86,13 +87,7 @@
       (when ns-str
         (into [:div.text-sm.font-sans.px-5.mt-3]
               (map render-ns)
-              [{:name "nextjournal"
-                :nss [{:name "nextjournal.clerk"
-                       :vars [{:name "stop"}
-                              {:name "watch"}]
-                       :nss [{:name "nextjournal.clerk.viewer"
-                              :vars [{:name "!viewers"}
-                                     {:name "->ViewerEval"}]}]}]}]))
+              (ns-tree ns-matches)))
       #_(clerk/with-viewers [{:pred seq?
                               :render-fn '#(into [:div.flex.flex-col]
                                                  (nextjournal.clerk.render/inspect-children %2) %1) #_#_:page-size 20}

--- a/notebooks/doc.clj
+++ b/notebooks/doc.clj
@@ -15,13 +15,17 @@
                :value @!query
                :class "px-2 py-1 relative bg-white bg-white rounded border border-slate-200 shadow-inner outline-none focus:outline-none focus:ring w-full text-sm font-sans"
                :on-input #(reset! !query (.. % -target -value))}]
-      [:button.absolute.right-2.text-xl.cursor-pointer
-       {:class "top-1/2 -translate-y-1/2"
-        :on-click #(reset! !query (clojure.string/join "." (drop-last (clojure.string/split @!query #"\."))))} "⏮"]]))
+      #_[:button.absolute.right-2.text-xl.cursor-pointer
+         {:class "top-1/2 -translate-y-1/2"
+          :on-click #(reset! !query (clojure.string/join "." (drop-last (clojure.string/split @!query #"\."))))} "⏮"]]))
 
 ^{::clerk/sync true}
-(defonce !ns-query (atom "nextjournal.clerk"))
-#_(reset! !ns-query "nextjournal.clerk")
+(defonce !ns-query (atom ""))
+#_(reset! !ns-query "")
+
+^{::clerk/sync true}
+(defonce !active-ns (atom "nextjournal.clerk.viewer"))
+#_(reset! !active-ns "nextjournal.clerk.viewer")
 
 (defn escape-pattern-str [s]
   (let [esc-chars "[](){}<>*&^%$#!\\|? "]
@@ -30,8 +34,11 @@
          (reduce str)
          str)))
 
+(defn match-nss [s]
+  (filter (partial re-find (re-pattern (escape-pattern-str s))) (sort (map str (all-ns)))))
+
 (def ns-matches
-  (filter (partial re-find (re-pattern (escape-pattern-str @!ns-query))) (sort (map str (all-ns)))))
+  (match-nss @!ns-query))
 
 (defn var->doc-viewer
   "Takes a clojure `var` and returns a Clerk viewer to display its documentation."
@@ -47,21 +54,20 @@
         [:div.mt-4.viewer-markdown.prose
          (clerk/md doc)])])))
 
-(defn render-ns [{:keys [name nss vars]}]
+(defn render-ns [{:keys [name nss]}]
   [:div.mt-1
-   [:div name]
-   (when vars
-     (into [:div.ml-3] (map (fn [var]
-                              [:div.mt-1.text-xs.italic var])) vars))
+   [:div.hover:underline.cursor-pointer.hover:text-indigo-600
+    {:class (when (= @!active-ns name) "font-bold")
+     :on-click (viewer/->viewer-eval `(fn []
+                                        (reset! !active-ns ~name)
+                                        (reset! !ns-query "")))} name]
    (when nss
      (into [:div.ml-3] (map render-ns) nss))])
 
 (defn ns-node-with-branches [nss-map ns-name]
-  (let [sub-nss (get nss-map ns-name)
-        vars (some-> ns-name symbol find-ns ns-publics not-empty vals vec)]
+  (let [sub-nss (get nss-map ns-name)]
     (cond-> {:name ns-name}
-      sub-nss (assoc :nss (mapv (partial ns-node-with-branches nss-map) sub-nss))
-      vars (assoc :vars vars))))
+      sub-nss (assoc :nss (mapv (partial ns-node-with-branches nss-map) sub-nss)))))
 
 (defn ns-tree
   ([ns-matches]
@@ -80,31 +86,82 @@
 #_(ns-tree ns-matches)
 #_(ns-tree ())
 
+(defn parent-ns [ns-str]
+  (when (str/includes? ns-str ".")
+    (str/join "." (butlast (str/split ns-str #"\.")))))
+
+(defn prepend-parent [nss]
+  (when-let [parent (parent-ns (first nss))]
+    (cons parent nss)))
+
+(defn path-to-ns [ns-str]
+  (last (take-while some? (iterate prepend-parent [ns-str]))))
+
 ^{::clerk/visibility {:result :show}}
 (clerk/html
- (let [ns-str (first ns-matches)]
-   [:<>
-    [:style ".markdown-viewer { padding: 0 !important; }"]
-    [:div.w-screen.h-screen.flex.fixed.left-0.top-0.bg-white.dark:bg-slate-950
-     [:div.border-r.py-3.flex-shrink-0.overflow-y-auto {:class "w-[300px]"}
-      [:div.px-3
-       (clerk/with-viewer {:render-fn render-input
-                           :transform-fn clerk/mark-presented} (viewer/->viewer-eval `!ns-query))]
-      (when ns-str
-        (into [:div.text-sm.font-sans.px-5.mt-3]
-              (map render-ns)
-              (ns-tree ns-matches)))]
-     [:div.flex-auto.max-h-screen.overflow-y-auto.px-8.py-5
-      (if ns-str
-        (let [ns (find-ns (symbol ns-str))]
-          [:<>
-           [:div.font-bold.font-sans.text-xl {:style {:margin 0}} (ns-name ns)]
-           (when-let [doc (-> ns meta :doc)]
-             [:div.mt-4.leading-normal.viewer-markdown.prose
-              (clerk/md doc)])
-           (into [:<>]
-                 (map (comp :nextjournal/value var->doc-viewer val))
-                 (into (sorted-map) (-> ns ns-publics)))])
-        [:div "No namespaces found."])]]]))
+ [:<>
+  [:style ".markdown-viewer { padding: 0 !important; }"]
+  [:div.w-screen.h-screen.flex.fixed.left-0.top-0.bg-white.dark:bg-slate-950
+   [:div.border-r.py-3.flex-shrink-0.overflow-y-auto {:class "w-[300px]"}
+    [:div.px-3
+     (clerk/with-viewer {:render-fn render-input
+                         :transform-fn clerk/mark-presented} (viewer/->viewer-eval `!ns-query))]
+    (cond (not (str/blank? @!ns-query))
+          [:div
+           [:div.tracking-wider.uppercase.text-slate-400.px-5.font-sans.text-xs.mt-5 "Search results"]
+           (into [:div.text-sm.font-sans.px-5.mt-3]
+                 (map render-ns)
+                 (ns-tree ns-matches))]
+          (= @!active-ns :all)
+          [:div
+           [:div.tracking-wider.uppercase.text-slate-400.px-5.font-sans.text-xs.mt-5 "All namespaces"]
+           (into [:div.text-sm.font-sans.px-5.mt-2]
+                 (map render-ns)
+                 (ns-tree (sort (map (comp str ns-name) (all-ns)))))]
+          :else
+          (let [path (path-to-ns @!active-ns)]
+            [:<>
+             [:div
+              [:div.text-slate-500.px-5.font-sans.text-xs.mt-3
+               {:on-click (viewer/->viewer-eval `(fn []
+                                                   (reset! !active-ns :all)
+                                                   (reset! !ns-query "")))}
+               "Show all namespaces"]
+              (into [:div.text-sm.font-sans.px-5.mt-2]
+                    (map render-ns)
+                    (ns-tree path))]
+             (when-let [vars (some-> @!active-ns symbol find-ns ns-publics not-empty vals vec)]
+               (into [:div.text-xs.font-sans.px-5.mt-1]
+                     (map (fn [var] [:div.mt-1 {:class (str "ml-" (* (count path) 3))} var]))
+                     vars))]))]
+   [:div.flex-auto.max-h-screen.overflow-y-auto.px-8.py-5
+    (let [ns (some-> @!active-ns symbol find-ns)]
+      (cond
+        ns [:<>
+            [:div.font-bold.font-sans.text-xl {:style {:margin 0}} (ns-name ns)]
+            (when-let [doc (-> ns meta :doc)]
+              [:div.mt-4.leading-normal.viewer-markdown.prose
+               (clerk/md doc)])
+            (into [:<>]
+                  (map (comp :nextjournal/value var->doc-viewer val))
+                  (into (sorted-map) (-> ns ns-publics)))]
+        @!active-ns [:<>
+                     [:div.font-bold.font-sans.text-xl {:style {:margin 0}} (if (= @!active-ns :all)
+                                                                              "All namespaces in classpath"
+                                                                              @!active-ns)]
+                     (into [:div]
+                           (map (fn [ns-str]
+                                  [:div.pt-3.mt-3
+                                   [:div.font-sans.text-base
+                                    {:style {:margin 0}
+                                     :on-click (viewer/->viewer-eval `(fn []
+                                                                        (reset! !active-ns ~ns-str)
+                                                                        (reset! !ns-query "")))}
+                                    ns-str]]))
+                           (if (= :all @!active-ns)
+                             (sort (map :name (ns-tree (map (comp str ns-name) (all-ns)))))
+                             (match-nss @!active-ns)))]
+        :else [:div "No namespaces found."]))]]])
 
 #_(deref nextjournal.clerk.webserver/!doc)
+

--- a/notebooks/doc.clj
+++ b/notebooks/doc.clj
@@ -43,13 +43,14 @@
 (defn var->doc-viewer
   "Takes a clojure `var` and returns a Clerk viewer to display its documentation."
   [var]
-  (let [{:keys [doc name arglists]} (meta var)]
+  (let [{:keys [doc arglists] var-name :name} (meta var)]
     (clerk/html
      [:div.border-t.border-slate-200.pt-6.mt-6
-      [:div.font-sans.font-bold.text-base {:style {:margin 0}} name]
+      {:id (name (symbol var))}
+      [:div.font-sans.font-bold.text-base {:style {:margin 0}} var-name]
       (when (seq arglists)
         [:div.pt-4
-         (clerk/code (str/join "\n" (mapv (comp pr-str #(concat [name] %)) arglists)))])
+         (clerk/code (str/join "\n" (mapv (comp pr-str #(concat [var-name] %)) arglists)))])
       (when doc
         [:div.mt-4.viewer-markdown.prose
          (clerk/md doc)])])))
@@ -64,7 +65,12 @@
    (when (and vars (= @!active-ns name))
      [:<>
       (into [:div.text-xs.font-sans.mt-1.ml-3.mb-3]
-            (map (fn [var] [:div.mt-1 var]))
+            (map (fn [var]
+                   [:div.mt-1.hover:text-indigo-600.cursor-pointer.hover:underline
+                    {:on-click (viewer/->viewer-eval `(fn []
+                                                        (when-some [el (js/document.getElementById ~(str var))]
+                                                          (.scrollIntoView el))))}
+                    var]))
             vars)
       [:div.border-b.mb-3]])
    (when nss

--- a/notebooks/doc.clj
+++ b/notebooks/doc.clj
@@ -72,7 +72,7 @@
 
 (defn ns-node-with-branches [nss-map ns-name]
   (let [sub-nss (get nss-map ns-name)
-        vars (some-> ns-name symbol find-ns ns-publics not-empty vals vec)]
+        vars (some-> ns-name symbol find-ns ns-publics not-empty keys vec sort)]
     (cond-> {:name ns-name}
       sub-nss (assoc :nss (mapv (partial ns-node-with-branches nss-map) sub-nss))
       vars (assoc :vars vars))))

--- a/notebooks/doc.clj
+++ b/notebooks/doc.clj
@@ -51,11 +51,11 @@
    (when nss
      (into [:div.ml-3] (map render-ns) nss))])
 
-(defn branch-fn [nss-map ns-name]
+(defn ns-node-with-branches [nss-map ns-name]
   (let [sub-nss (get nss-map ns-name)
         vars (some-> ns-name symbol find-ns ns-publics not-empty vals vec)]
     (cond-> {:name ns-name}
-      sub-nss (assoc :nss (mapv (partial branch-fn nss-map) sub-nss))
+      sub-nss (assoc :nss (mapv (partial ns-node-with-branches nss-map) sub-nss))
       vars (assoc :vars vars))))
 
 (defn ns-tree
@@ -68,7 +68,7 @@
    (if-some [ns-name (first ns-matches)]
      (recur nss-map
             (remove #(str/starts-with? % ns-name) ns-matches)
-            (conj acc (branch-fn nss-map ns-name)))
+            (conj acc (ns-node-with-branches nss-map ns-name)))
      acc)))
 
 #_(ns-tree ns-matches)

--- a/notebooks/doc.clj
+++ b/notebooks/doc.clj
@@ -116,11 +116,11 @@
  [:<>
   [:style ".markdown-viewer { padding: 0 !important; }"]
   [:div.w-screen.h-screen.flex.fixed.left-0.top-0.bg-white.dark:bg-slate-950
-   [:div.border-r.flex-shrink-0.overflow-y-auto {:class "w-[300px]"}
+   [:div.border-r.flex-shrink-0.flex.flex-col {:class "w-[300px]"}
     [:div.px-3.py-3.border-b
      (clerk/with-viewer {:render-fn render-input
                          :transform-fn clerk/mark-presented} (viewer/->viewer-eval `!ns-query))]
-    [:div.pb-5
+    [:div.pb-5.flex-auto.overflow-y-auto
      (cond (not (str/blank? @!ns-query))
            [:div
             [:div.tracking-wider.uppercase.text-slate-400.px-5.font-sans.text-xs.mt-5 "Search results"]

--- a/notebooks/doc.clj
+++ b/notebooks/doc.clj
@@ -8,13 +8,13 @@
   '(fn [!query]
      (prn :query !query)
      [:div.my-1.relative
-      [:input {:type :text
-               :auto-correct "off"
-               :spell-check "false"
-               :placeholder "Search namespaces…"
-               :value @!query
-               :class "px-2 py-1 relative bg-white bg-white rounded border border-slate-200 shadow-inner outline-none focus:outline-none focus:ring w-full text-sm font-sans"
-               :on-input #(reset! !query (.. % -target -value))}]
+      [:input.px-2.py-1.relative.bg-white.dark:bg-slate-900.bg-white.rounded.border.dark:border-slate-700.shadow-inner.outline-none.focus:outline-none.focus:ring.w-full.text-sm.font-sans
+       {:type :text
+        :auto-correct "off"
+        :spell-check "false"
+        :placeholder "Search namespaces…"
+        :value @!query
+        :on-input #(reset! !query (.. % -target -value))}]
       #_[:button.absolute.right-2.text-xl.cursor-pointer
          {:class "top-1/2 -translate-y-1/2"
           :on-click #(reset! !query (clojure.string/join "." (drop-last (clojure.string/split @!query #"\."))))} "⏮"]]))
@@ -45,7 +45,7 @@
   [var]
   (let [{:keys [doc arglists] var-name :name} (meta var)]
     (clerk/html
-     [:div.border-t.border-slate-200.pt-6.mt-6
+     [:div.border-t.dark:border-slate-800.pt-6.mt-6
       {:id (name (symbol var))}
       [:div.font-sans.font-bold.text-base {:style {:margin 0}} var-name]
       (when (seq arglists)
@@ -57,7 +57,7 @@
 
 (defn render-ns [{:keys [name nss vars]}]
   [:div.mt-1
-   [:div.hover:underline.cursor-pointer.hover:text-indigo-600.whitespace-nowrap
+   [:div.hover:underline.cursor-pointer.hover:text-indigo-600.dark:hover:text-white.whitespace-nowrap
     {:class (when (= @!active-ns name) "font-bold")
      :on-click (viewer/->viewer-eval `(fn []
                                         (reset! !active-ns ~name)
@@ -66,13 +66,14 @@
      [:<>
       (into [:div.text-xs.font-sans.mt-1.ml-3.mb-3]
             (map (fn [var]
-                   [:div.mt-1.hover:text-indigo-600.cursor-pointer.hover:underline
+                   [:div.mt-1.hover:text-indigo-600.dark:hover:text-white.cursor-pointer.hover:underline
                     {:on-click (viewer/->viewer-eval `(fn []
                                                         (when-some [el (js/document.getElementById ~(str var))]
                                                           (.scrollIntoView el))))}
                     var]))
             vars)
-      [:div.border-b.mb-3]])
+      (when nss
+        [:div.border-b.dark:border-slate-800.mb-3])])
    (when nss
      (into [:div.ml-3] (map render-ns) nss))])
 
@@ -116,20 +117,20 @@
  [:<>
   [:style ".markdown-viewer { padding: 0 !important; }"]
   [:div.w-screen.h-screen.flex.fixed.left-0.top-0.bg-white.dark:bg-slate-950
-   [:div.border-r.flex-shrink-0.flex.flex-col {:class "w-[300px]"}
-    [:div.px-3.py-3.border-b
+   [:div.border-r.dark:border-slate-800.flex-shrink-0.flex.flex-col {:class "w-[300px]"}
+    [:div.px-3.py-3.border-b.dark:border-slate-800
      (clerk/with-viewer {:render-fn render-input
                          :transform-fn clerk/mark-presented} (viewer/->viewer-eval `!ns-query))]
     [:div.pb-5.flex-auto.overflow-y-auto
      (cond (not (str/blank? @!ns-query))
            [:div
-            [:div.tracking-wider.uppercase.text-slate-400.px-5.font-sans.text-xs.mt-5 "Search results"]
+            [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5 "Search results"]
             (into [:div.text-sm.font-sans.px-5.mt-3]
                   (map render-ns)
                   (ns-tree ns-matches))]
            (= @!active-ns :all)
            [:div
-            [:div.tracking-wider.uppercase.text-slate-500.px-5.font-sans.text-xs.mt-5 "All namespaces"]
+            [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5 "All namespaces"]
             (into [:div.text-sm.font-sans.px-5.mt-2]
                   (map render-ns)
                   (ns-tree (sort (map (comp str ns-name) (all-ns)))))]
@@ -138,19 +139,19 @@
              [:<>
               [:div
                [:div
-                [:div.tracking-wider.uppercase.text-slate-500.px-5.font-sans.text-xs.mt-5.mb-2 "Nav"]
+                [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5.mb-2 "Nav"]
                 (when-some [ns-name (some-> (str/join "." (butlast (str/split @!active-ns #"\."))) symbol find-ns ns-name str)]
-                  [:div.px-5.font-sans.text-xs.mt-1.text-indigo-600.hover:underline.cursor-pointer
+                  [:div.px-5.font-sans.text-xs.mt-1.hover:text-indigo-600.dark:hover:text-white.hover:underline.cursor-pointer
                    {:on-click (viewer/->viewer-eval `(fn []
                                                        (reset! !active-ns ~ns-name)
                                                        (reset! !ns-query "")))}
                    "One level up"])
-                [:div.px-5.font-sans.text-xs.mt-1.text-indigo-600.hover:underline.cursor-pointer
+                [:div.px-5.font-sans.text-xs.mt-1.hover:text-indigo-600.dark:hover:text-white.hover:underline.cursor-pointer
                  {:on-click (viewer/->viewer-eval `(fn []
                                                      (reset! !active-ns :all)
                                                      (reset! !ns-query "")))}
                  "All namespaces"]]
-               [:div.tracking-wider.uppercase.text-slate-500.px-5.font-sans.text-xs.mt-5 "Current namespace"]
+               [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5 "Current namespace"]
                (into [:div.text-sm.font-sans.px-5.mt-2]
                      (map render-ns)
                      (ns-tree (match-nss @!active-ns)))]]))]]
@@ -171,7 +172,7 @@
                                                                               @!active-ns)]
                      (into [:div.mt-2]
                            (map (fn [ns-str]
-                                  [:div.pt-5.mt-5.border-t.hover:text-indigo-600.cursor-pointer.group
+                                  [:div.pt-5.mt-5.border-t.dark:border-slate-800.hover:text-indigo-600.cursor-pointer.group
                                    {:on-click (viewer/->viewer-eval `(fn []
                                                                        (reset! !active-ns ~ns-str)
                                                                        (reset! !ns-query "")))}

--- a/notebooks/doc.clj
+++ b/notebooks/doc.clj
@@ -14,18 +14,15 @@
           (js/document.addEventListener "keydown" keydown-handler)
           #(js/document.removeEventListener "keydown" keydown-handler))))
      [:div.my-1.relative
-      [:input#search-nss.px-2.py-1.relative.bg-white.dark:bg-slate-900.bg-white.rounded.border.dark:border-slate-700.shadow-inner.outline-none.focus:outline-none.focus:ring-2.focus.ring-indigo-500.hover:border-slate-400.focus:hover:border-slate-200.w-full.text-sm.font-sans.dark:hover:border-slate-600.dark:focus:border-sslate-700
+      [:input#search-nss.px-2.py-1.relative.bg-white.dark:bg-slate-900.bg-white.rounded.border.dark:border-slate-700.shadow-inner.outline-none.focus:outline-none.focus:ring-2.focus.ring-indigo-500.hover:border-slate-400.focus:hover:border-slate-200.w-full.text-xs.font-sans.dark:hover:border-slate-600.dark:focus:border-sslate-700
        {:type :text
         :auto-correct "off"
         :spell-check "false"
-        :placeholder "Search namespaces…"
+        :placeholder "Search namespaces via Regex…"
         :value @!query
         :on-input #(reset! !query (.. % -target -value))}]
       [:div.text-xs.absolute.right-2.text-slate-400.dark:text-slate-400.font-inter.tracking-widest.pointer-events-none
-       {:class "top-1/2 -translate-y-1/2"} "⌘K"]
-      #_[:button.absolute.right-2.text-xl.cursor-pointer
-         {:class "top-1/2 -translate-y-1/2"
-          :on-click #(reset! !query (clojure.string/join "." (drop-last (clojure.string/split @!query #"\."))))} "⏮"]]))
+       {:class "top-1/2 -translate-y-1/2"} "⌘K"]]))
 
 ^{::clerk/sync true}
 (defonce !ns-query (atom ""))
@@ -42,11 +39,11 @@
          (reduce str)
          str)))
 
-(defn match-nss [s]
-  (filter (partial re-find (re-pattern (escape-pattern-str s))) (sort (map str (all-ns)))))
+(defn str-match-nss [s]
+  (filter #(str/includes? % s) (sort (map str (all-ns)))))
 
-(def ns-matches
-  (match-nss @!ns-query))
+(defn match-nss [re]
+  (filter (partial re-find (re-pattern re)) (sort (map str (all-ns)))))
 
 (defn var->doc-viewer
   "Takes a clojure `var` and returns a Clerk viewer to display its documentation."
@@ -122,78 +119,86 @@
 
 ^{::clerk/visibility {:result :show}}
 (clerk/html
- [:<>
-  [:style ".markdown-viewer { padding: 0 !important; }"]
-  [:div.w-screen.h-screen.flex.fixed.left-0.top-0.bg-white.dark:bg-slate-950
-   [:div.border-r.dark:border-slate-800.flex-shrink-0.flex.flex-col {:class "w-[300px]"}
-    [:div.px-3.py-3.border-b.dark:border-slate-800
-     (clerk/with-viewer {:render-fn render-input
-                         :transform-fn clerk/mark-presented} (viewer/->viewer-eval `!ns-query))]
-    [:div.pb-5.flex-auto.overflow-y-auto
-     (cond (not (str/blank? @!ns-query))
-           [:div
-            [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5 "Search results"]
-            (into [:div.text-sm.font-sans.px-5.mt-3]
-                  (map render-ns)
-                  (ns-tree ns-matches))]
-           (= @!active-ns :all)
-           [:div
-            [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5 "All namespaces"]
-            (into [:div.text-sm.font-sans.px-5.mt-2]
-                  (map render-ns)
-                  (ns-tree (sort (map (comp str ns-name) (all-ns)))))]
-           :else
-           (let [path (path-to-ns @!active-ns)]
-             [:<>
-              [:div
-               [:div
-                [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5.mb-2 "Nav"]
-                (when-some [ns-name (some-> (str/join "." (butlast (str/split @!active-ns #"\."))) symbol find-ns ns-name str)]
+ (let [matches (try
+                 (match-nss @!ns-query)
+                 (catch Exception e :error))]
+   [:<>
+    [:style ".markdown-viewer { padding: 0 !important; }"]
+    [:div.w-screen.h-screen.flex.fixed.left-0.top-0.bg-white.dark:bg-slate-950
+     [:div.border-r.dark:border-slate-800.flex-shrink-0.flex.flex-col {:class "w-[300px]"}
+      [:div.px-3.py-3.border-b.dark:border-slate-800
+       (clerk/with-viewer {:render-fn render-input
+                           :transform-fn clerk/mark-presented} (viewer/->viewer-eval `!ns-query))
+       (when (= matches :error)
+         [:div.text-red-600.dark:text-red-400.mt-2.font-sans.px-2.text-xs
+          "😖 Invalid or incomplete Regex pattern."])]
+      [:div.pb-5.flex-auto.overflow-y-auto
+       (cond (not (str/blank? @!ns-query))
+             [:div
+              [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5 "Search results"]
+              (if (and (not= :error matches) (seq matches))
+                (into [:div.text-sm.font-sans.px-5.mt-3]
+                      (map render-ns)
+                      (ns-tree matches))
+                [:div.px-5.mt-3.font-sans.text-sm "Nothing found."])]
+             (= @!active-ns :all)
+             [:div
+              [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5 "All namespaces"]
+              (into [:div.text-sm.font-sans.px-5.mt-2]
+                    (map render-ns)
+                    (ns-tree (sort (map (comp str ns-name) (all-ns)))))]
+             :else
+             (let [path (path-to-ns @!active-ns)]
+               [:<>
+                [:div
+                 [:div
+                  [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5.mb-2 "Nav"]
+                  (when-some [ns-name (some-> (str/join "." (butlast (str/split @!active-ns #"\."))) symbol find-ns ns-name str)]
+                    [:div.px-5.font-sans.text-xs.mt-1.hover:text-indigo-600.dark:hover:text-white.hover:underline.cursor-pointer
+                     {:on-click (viewer/->viewer-eval `(fn []
+                                                         (reset! !active-ns ~ns-name)
+                                                         (reset! !ns-query "")))}
+                     "One level up"])
                   [:div.px-5.font-sans.text-xs.mt-1.hover:text-indigo-600.dark:hover:text-white.hover:underline.cursor-pointer
                    {:on-click (viewer/->viewer-eval `(fn []
-                                                       (reset! !active-ns ~ns-name)
+                                                       (reset! !active-ns :all)
                                                        (reset! !ns-query "")))}
-                   "One level up"])
-                [:div.px-5.font-sans.text-xs.mt-1.hover:text-indigo-600.dark:hover:text-white.hover:underline.cursor-pointer
-                 {:on-click (viewer/->viewer-eval `(fn []
-                                                     (reset! !active-ns :all)
-                                                     (reset! !ns-query "")))}
-                 "All namespaces"]]
-               [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5 "Current namespace"]
-               (into [:div.text-sm.font-sans.px-5.mt-2]
-                     (map render-ns)
-                     (ns-tree (match-nss @!active-ns)))]]))]]
-   [:div.flex-auto.max-h-screen.overflow-y-auto.px-8.py-5
-    (let [ns (some-> @!active-ns symbol find-ns)]
-      (cond
-        ns [:<>
-            [:div.font-bold.font-sans.text-xl {:style {:margin 0}} (ns-name ns)]
-            (when-let [doc (-> ns meta :doc)]
-              [:div.mt-4.leading-normal.viewer-markdown.prose
-               (clerk/md doc)])
-            (into [:<>]
-                  (map (comp :nextjournal/value var->doc-viewer val))
-                  (into (sorted-map) (-> ns ns-publics)))]
-        @!active-ns [:<>
-                     [:div.font-bold.font-sans.text-xl {:style {:margin 0}} (if (= @!active-ns :all)
-                                                                              "All namespaces in classpath"
-                                                                              @!active-ns)]
-                     (into [:div.mt-2]
-                           (map (fn [ns-str]
-                                  [:div.pt-5.mt-5.border-t.dark:border-slate-800.hover:text-indigo-600.cursor-pointer.group
-                                   {:on-click (viewer/->viewer-eval `(fn []
-                                                                       (reset! !active-ns ~ns-str)
-                                                                       (reset! !ns-query "")))}
-                                   [:div.font-sans.text-base.font-bold.group-hover:underline
-                                    {:style {:margin 0}}
-                                    ns-str]
-                                   (when-let [doc (some-> ns-str symbol find-ns meta :doc)]
-                                     [:div.mt-2.leading-normal.viewer-markdown.prose.text-sm
-                                      (clerk/md doc)])]))
-                           (if (= :all @!active-ns)
-                             (sort (map :name (ns-tree (map (comp str ns-name) (all-ns)))))
-                             (match-nss @!active-ns)))]
-        :else [:div "No namespaces found."]))]]])
+                   "All namespaces"]]
+                 [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5 "Current namespace"]
+                 (into [:div.text-sm.font-sans.px-5.mt-2]
+                       (map render-ns)
+                       (ns-tree (str-match-nss @!active-ns)))]]))]]
+     [:div.flex-auto.max-h-screen.overflow-y-auto.px-8.py-5
+      (let [ns (some-> @!active-ns symbol find-ns)]
+        (cond
+          ns [:<>
+              [:div.font-bold.font-sans.text-xl {:style {:margin 0}} (ns-name ns)]
+              (when-let [doc (-> ns meta :doc)]
+                [:div.mt-4.leading-normal.viewer-markdown.prose
+                 (clerk/md doc)])
+              (into [:<>]
+                    (map (comp :nextjournal/value var->doc-viewer val))
+                    (into (sorted-map) (-> ns ns-publics)))]
+          @!active-ns [:<>
+                       [:div.font-bold.font-sans.text-xl {:style {:margin 0}} (if (= @!active-ns :all)
+                                                                                "All namespaces in classpath"
+                                                                                @!active-ns)]
+                       (into [:div.mt-2]
+                             (map (fn [ns-str]
+                                    [:div.pt-5.mt-5.border-t.dark:border-slate-800.hover:text-indigo-600.cursor-pointer.group
+                                     {:on-click (viewer/->viewer-eval `(fn []
+                                                                         (reset! !active-ns ~ns-str)
+                                                                         (reset! !ns-query "")))}
+                                     [:div.font-sans.text-base.font-bold.group-hover:underline
+                                      {:style {:margin 0}}
+                                      ns-str]
+                                     (when-let [doc (some-> ns-str symbol find-ns meta :doc)]
+                                       [:div.mt-2.leading-normal.viewer-markdown.prose.text-sm
+                                        (clerk/md doc)])]))
+                             (if (= :all @!active-ns)
+                               (sort (map :name (ns-tree (map (comp str ns-name) (all-ns)))))
+                               (str-match-nss @!active-ns)))]
+          :else [:div "No namespaces found."]))]]]))
 
 #_(deref nextjournal.clerk.webserver/!doc)
 

--- a/notebooks/doc.clj
+++ b/notebooks/doc.clj
@@ -47,15 +47,12 @@
         [:div.mt-4.viewer-markdown.prose
          (clerk/md doc)])])))
 
-(defn render-var [{:keys [name]}]
-  #_(reset! doc/!ns-query ns)
-  [:div.text-red-500.mt-1 name])
-
 (defn render-ns [{:keys [name nss vars]}]
   [:div.mt-1
    [:div name]
    (when vars
-     (into [:div.ml-3] (map render-var) vars))
+     (into [:div.ml-3] (map (fn [var]
+                              [:div.mt-1.text-xs.italic var])) vars))
    (when nss
      (into [:div.ml-3] (map render-ns) nss))])
 

--- a/src/nextjournal/clerk/doc.clj
+++ b/src/nextjournal/clerk/doc.clj
@@ -1,4 +1,5 @@
-(ns doc
+(ns nextjournal.clerk.doc
+  "Clerk's documentation browser."
   {:nextjournal.clerk/visibility {:code :hide :result :hide}}
   (:require [clojure.string :as str]
             [nextjournal.clerk :as clerk]
@@ -29,8 +30,8 @@
 #_(reset! !ns-query "")
 
 ^{::clerk/sync true}
-(defonce !active-ns (atom "nextjournal.clerk.viewer"))
-#_(reset! !active-ns "nextjournal.clerk.viewer")
+(defonce !active-ns (atom ""))
+#_(reset! !active-ns "nextjournal.clerk")
 
 (defn escape-pattern-str [s]
   (let [esc-chars "[](){}<>*&^%$#!\\|? "]

--- a/src/nextjournal/clerk/doc.clj
+++ b/src/nextjournal/clerk/doc.clj
@@ -33,13 +33,6 @@
 (defonce !active-ns (atom ""))
 #_(reset! !active-ns "nextjournal.clerk")
 
-(defn escape-pattern-str [s]
-  (let [esc-chars "[](){}<>*&^%$#!\\|? "]
-    (->> s
-         (replace (zipmap esc-chars (map #(str "\\" %) esc-chars)))
-         (reduce str)
-         str)))
-
 (defn str-match-nss [s]
   (filter #(str/includes? % s) (sort (map str (all-ns)))))
 

--- a/src/nextjournal/clerk/doc.clj
+++ b/src/nextjournal/clerk/doc.clj
@@ -115,7 +115,7 @@
 (clerk/html
  (let [matches (try
                  (match-nss @!ns-query)
-                 (catch Exception e :error))]
+                 (catch Exception _ :error))]
    [:<>
     [:style ".markdown-viewer { padding: 0 !important; }"]
     [:div.w-screen.h-screen.flex.fixed.left-0.top-0.bg-white.dark:bg-slate-950
@@ -142,26 +142,25 @@
                     (map render-ns)
                     (ns-tree (sort (map (comp str ns-name) (all-ns)))))]
              :else
-             (let [path (path-to-ns @!active-ns)]
-               [:<>
-                [:div
-                 [:div
-                  [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5.mb-2 "Nav"]
-                  (when-some [ns-name (some-> (str/join "." (butlast (str/split @!active-ns #"\."))) symbol find-ns ns-name str)]
-                    [:div.px-5.font-sans.text-xs.mt-1.hover:text-indigo-600.dark:hover:text-white.hover:underline.cursor-pointer
-                     {:on-click (viewer/->viewer-eval `(fn []
-                                                         (reset! !active-ns ~ns-name)
-                                                         (reset! !ns-query "")))}
-                     "One level up"])
+             [:<>
+              [:div
+               [:div
+                [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5.mb-2 "Nav"]
+                (when-some [ns-name (some-> (str/join "." (butlast (str/split @!active-ns #"\."))) symbol find-ns ns-name str)]
                   [:div.px-5.font-sans.text-xs.mt-1.hover:text-indigo-600.dark:hover:text-white.hover:underline.cursor-pointer
                    {:on-click (viewer/->viewer-eval `(fn []
-                                                       (reset! !active-ns :all)
+                                                       (reset! !active-ns ~ns-name)
                                                        (reset! !ns-query "")))}
-                   "All namespaces"]]
-                 [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5 "Current namespace"]
-                 (into [:div.text-sm.font-sans.px-5.mt-2]
-                       (map render-ns)
-                       (ns-tree (str-match-nss @!active-ns)))]]))]]
+                   "One level up"])
+                [:div.px-5.font-sans.text-xs.mt-1.hover:text-indigo-600.dark:hover:text-white.hover:underline.cursor-pointer
+                 {:on-click (viewer/->viewer-eval `(fn []
+                                                     (reset! !active-ns :all)
+                                                     (reset! !ns-query "")))}
+                 "All namespaces"]]
+               [:div.tracking-wider.uppercase.text-slate-500.dark:text-slate-400.px-5.font-sans.text-xs.mt-5 "Current namespace"]
+               (into [:div.text-sm.font-sans.px-5.mt-2]
+                     (map render-ns)
+                     (ns-tree (str-match-nss @!active-ns)))]])]]
      [:div.flex-auto.max-h-screen.overflow-y-auto.px-8.py-5
       (let [ns (some-> @!active-ns symbol find-ns)]
         (cond


### PR DESCRIPTION
Improvements to Clerk’s api docs notebook:
* move it to the classpath so it's accessible using `(nextjournal.clerk/show! 'nextjournal.clerk.doc)`
* New user interface with improved navigation (tree view, show descendant namespaces)
* Listing of public vars for the active namespace, clicking them scrolls to their respective doc
* Search is now uncoupled from active namespace
* Improved dark mode support
* Improved regex search with error handling


https://github.com/nextjournal/clerk/assets/1944/b485ba22-a478-4cd8-8612-33d27e737925


https://github.com/nextjournal/clerk/assets/1944/5f62eb0a-cf2a-4518-b0c2-9d0f61fc92e3

