### PR TITLE
Markdown Captions & Book Update: clerk/image, clerk/caption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changes can be:
 
 * 💫 Allow to disable welcome page in `serve!`
 
+* 💫 Support using Markdown syntax in `clerk/caption` text
+
 * 🛠 Bump depdendencies
 
   * `com.taoensso/nippy` to `3.4.0-beta1`

--- a/book.clj
+++ b/book.clj
@@ -378,14 +378,14 @@ int main() {
 ;; nice captions:
 
 (defn caption [text]
-  (clerk/html [:span.text-slate-500.text-xs.text-center.font-sans text]))
+  (clerk/html [:figcaption.text-center.mt-1 text]))
 
 (clerk/row
  (clerk/col image-1 (caption "Figure 1: Decorative A"))
  (clerk/col image-2 (caption "Figure 2: Decorative B"))
  (clerk/col image-3 (caption "Figure 3: Decorative C")))
 
-;; Note: the caption example is _exactly_ how clerk actually implements `clerk/caption`.
+;; Note: the caption example is _exactly_ how `clerk/caption` is implemented in Clerk.
 
 ;; **Alternative notations**
 ;;

--- a/book.clj
+++ b/book.clj
@@ -327,6 +327,20 @@ int main() {
  "Implements of the Paper Printing Industry"
  (clerk/image "https://nextjournal.com/data/QmX99isUndwqBz7nj8fdG7UoDakNDSH1TZcvY2Y6NUTe6o?filename=image.gif&content-type=image/gif"))
 
+;; Captions aren't limited to images and work together with any arbitrary content that you provide, e.g. a table:
+
+^{::clerk/visibility {:code :fold}}
+(clerk/caption
+ "Modern Symmetrical Unary(7) in [Solresol](https://wiki.xxiivv.com/site/solresol.html)"
+ (clerk/table {:head ["Solfège" "French IPA" "English IPA" "Meaning"]
+               :rows [["Do"	"/do/" "/doʊ/" "no"]
+                      ["Re" "/ʁɛ/" "/ɹeɪ/" "and, also"]
+                      ["Mi" "/mi/" "/miː/" "or"]
+                      ["Fa" "/fa/" "/fɑː/" "at, to"]
+                      ["Sol" "/sɔl/" "/soʊl/" "but, if"]
+                      ["La" "/la/" "/lɑː/" "the, then"]
+                      ["Si" "/si/" "/siː/" "yes"]]}))
+
 ;; ### 📒 Markdown
 
 ;; The same Markdown support Clerk uses for comment blocks is also

--- a/book.clj
+++ b/book.clj
@@ -299,20 +299,15 @@ int main() {
 
 ;; ### 🏞 Images
 
-;; Clerk now has built-in support for the
-;; `java.awt.image.BufferedImage` class, which is the native image
-;; format of the JVM.
-;;
-;; When combined with `javax.imageio.ImageIO/read`, one can easily
-;; load images in a variety of formats from a `java.io.File`, an
-;; `java.io.InputStream`, or any resource that a `java.net.URL` can
-;; address.
+;; Clerk offers the `clerk/image` viewer to create a buffered image
+;; from a string or anything `javax.imageio.ImageIO/read` can take
+;; (URL, File or InputStream).
 ;;
 ;; For example, we can fetch a photo of De zaaier, Vincent van Gogh's
 ;; famous painting of a farmer sowing a field from Wiki Commons like
 ;; this:
 
-(ImageIO/read (URL. "https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/The_Sower.jpg/1510px-The_Sower.jpg"))
+(clerk/image "https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/The_Sower.jpg/1510px-The_Sower.jpg")
 
 ;; We've put some effort into making the default image rendering
 ;; pleasing. The viewer uses the dimensions and aspect ratio of each
@@ -320,11 +315,17 @@ int main() {
 ;; fashion. For example, an image larger than 900px wide with an
 ;; aspect ratio larger then two will be displayed full width:
 
-(ImageIO/read (URL. "https://images.unsplash.com/photo-1532879311112-62b7188d28ce?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8"))
+(clerk/image "https://images.unsplash.com/photo-1532879311112-62b7188d28ce?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8")
 
 ;; On the other hand, smaller images are centered and shown using their intrinsic dimensions:
 
-(ImageIO/read (URL. "https://nextjournal.com/data/QmSJ6eu6kUFeWrqXyYaiWRgJxAVQt2ivaoNWc1dtTEADCf?filename=thermo.png&content-type=image/png"))
+(clerk/image "https://nextjournal.com/data/QmSJ6eu6kUFeWrqXyYaiWRgJxAVQt2ivaoNWc1dtTEADCf?filename=thermo.png&content-type=image/png")
+
+;; You can use `clerk/image` together with `clerk/caption` which will render a simple caption under the image:
+
+(clerk/caption
+ "Implements of the Paper Printing Industry"
+ (clerk/image "https://nextjournal.com/data/QmX99isUndwqBz7nj8fdG7UoDakNDSH1TZcvY2Y6NUTe6o?filename=image.gif&content-type=image/gif"))
 
 ;; ### 📒 Markdown
 
@@ -369,6 +370,8 @@ int main() {
  (clerk/col image-1 (caption "Figure 1: Decorative A"))
  (clerk/col image-2 (caption "Figure 2: Decorative B"))
  (clerk/col image-3 (caption "Figure 3: Decorative C")))
+
+;; Note: the caption example is _exactly_ how clerk actually implements `clerk/caption`.
 
 ;; **Alternative notations**
 ;;

--- a/notebooks/viewers/caption.clj
+++ b/notebooks/viewers/caption.clj
@@ -30,3 +30,16 @@
                 (clerk/image "https://nextjournal.com/data/QmX99isUndwqBz7nj8fdG7UoDakNDSH1TZcvY2Y6NUTe6o?filename=image.gif&content-type=image/gif")
                 (clerk/image "https://nextjournal.com/data/QmV8UanpZwTaLvLnKgJkR9etvVH9YPZX3rMFHN7YHbSGbv?filename=image.gif&content-type=image/gif")
                 (clerk/image "https://nextjournal.com/data/QmPzBy1GBTAJf8Zzwhx5yyCfHqX5h7Wgx9geRpzgghyoEZ?filename=image.gif&content-type=image/gif")))
+
+;; Captions can also include Markdown, e.g. to render links:
+
+(clerk/caption
+ "Modern Symmetrical Unary(7) in [Solresol](https://wiki.xxiivv.com/site/solresol.html)"
+ (clerk/table {:head ["Solfège" "French IPA" "English IPA" "Meaning"]
+               :rows [["Do"	"/do/" "/doʊ/" "no"]
+                      ["Re" "/ʁɛ/" "/ɹeɪ/" "and, also"]
+                      ["Mi" "/mi/" "/miː/" "or"]
+                      ["Fa" "/fa/" "/fɑː/" "at, to"]
+                      ["Sol" "/sɔl/" "/soʊl/" "but, if"]
+                      ["La" "/la/" "/lɑː/" "the, then"]
+                      ["Si" "/si/" "/siː/" "yes"]]}))

--- a/resources/stylesheets/viewer.css
+++ b/resources/stylesheets/viewer.css
@@ -259,6 +259,13 @@
     @apply mb-0 !important;
 }
 
+figcaption .markdown-viewer {
+    @apply text-xs text-slate-500;
+}
+
+figcaption .markdown-viewer a {
+    @apply underline;
+}
 /* Images */
 /* --------------------------------------------------------------- */
 

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -871,7 +871,7 @@
 (defn render-folded-code-block [code-string {:as opts :keys [id]}]
   (let [!hidden? (hooks/use-state true)]
     (if @!hidden?
-      [:div.relative.pl-12.font-sans.text-slate-400.cursor-pointer.flex.overflow-y-hidden.group
+      [:div.relative.font-sans.text-slate-400.cursor-pointer.flex.overflow-y-hidden.group
        [:span.hover:text-slate-500
         {:class "text-[10px]"
          :on-click #(swap! !hidden? not)}

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1789,7 +1789,7 @@
 (defn caption [text content]
   (col
    content
-   (html [:figcaption.text-xs.text-slate-500.text-center.mt-1 text])))
+   (html [:figcaption.text-center.mt-1 (md text)])))
 
 (defn ^:dynamic doc-url
   ([path] (doc-url path nil))


### PR DESCRIPTION
This updates the book to use `clerk/image` for all image examples and also provides examples of `clerk/caption`.

In addition, the PR adds support to use Markdown syntax for the caption text, e.g. for easily adding links to captions.

![CleanShot 2023-11-09 at 17 11 34@2x](https://github.com/nextjournal/clerk/assets/1944/390f76b8-2daf-4490-9ec6-3773f5415e4f)
