### PR TITLE
Pass more Context to Viewer Functions + Cell Viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changes can be:
 
 ## Unreleased
 
+* 🌟 The whole cell context (e.g. its form, code text etc.) is now passed to viewer functions along with the wrapped result. In addition, a new cell-viewer has been added to possibly transform a cell's properties prior to presentation. This can be used, for instance, to alter a cell's visibility programmatically ([#575](https://github.com/nextjournal/clerk/issues/575)). 
+
 * 💫 Allow to disable welcome page in `serve!`
 
 * 💫 Add `clerk/comment` that behaves like `clojure.core/comment` outside of Clerk but shows the results like regular top-level forms in Clerk.

--- a/notebooks/viewers/context.clj
+++ b/notebooks/viewers/context.clj
@@ -1,9 +1,12 @@
 ;; # 🪬 Viewer Context
 
 (ns viewers.context
+  "Or how viewer API functions learn to take advantage of the document context"
+  {:nextjournal.clerk/visibility {:code :hide}}
   (:require [nextjournal.clerk :as clerk]
             [nextjournal.clerk.viewer :as viewer]))
 
+{::clerk/visibility {:code :show}}
 ;; A viewer's `:pred` function can perform viewer selection based on a value.
 
 ;; It would sometimes be useful to have more context available. Examples of this are:
@@ -27,10 +30,6 @@
 ;; metadata. Rejected this because it's invisible and doesn't work for
 ;; e.g. keywords.
 
-^::clerk/no-cache
-(clerk/add-viewers! [cljc-viewer])
-
-
 ;; Now what can we use this for? We can now, for example, create a
 ;; viewer in userspace that evalautes a given form in Clojure and sci,
 ;; allowing us to use it on both sides.
@@ -42,3 +41,31 @@
 (my-greet-fn "Clojure")
 
 (clerk/eval-cljs '(my-greet-fn "ClojureScript"))
+
+;; Or build a viewer which will display the namespace's name and docs:
+
+(def ns-viewer
+  {:pred {:wrapped (fn [{:keys [ns?]}] ns?)}
+   :transform-fn (fn [{:as wv :keys [form]}]
+                   (let [doc-ns (find-ns (second form))]
+                     (clerk/html [:blockquote.bg-sky-50.rounded.py-1
+                                  (clerk/md (str "## " (ns-name doc-ns) "\n" (:doc (meta doc-ns))))])))})
+
+;; In addition, transform-fns can hook onto the visibility of results to, say, override defaults
+(def even-number-viewer
+  (assoc viewer/number-viewer
+         :transform-fn (fn [{:as wv :nextjournal/keys [value]}]
+                         (cond-> wv (even? value) (assoc-in [:nextjournal/visibility :result] :show)))))
+
+;; given by e.g. a visibility marker
+;;
+;;    {::clerk/visibility {:result :hide}}
+
+{::clerk/visibility {:result :hide}}
+
+1
+2
+3
+
+^::clerk/no-cache
+(clerk/add-viewers! [cljc-viewer ns-viewer even-number-viewer])

--- a/notebooks/viewers/context.clj
+++ b/notebooks/viewers/context.clj
@@ -57,10 +57,10 @@
           :transform-fn comp
           (clerk/update-val (fn [cell]
                               (update-in cell [:settings ::clerk/visibility :result]
-                                         #(or (#{:show} %)
-                                              (if (or (:ns? cell) (-> cell :result :nextjournal/value (as-> n (when (number? n) (even? n)))))
-                                                :show
-                                                :hide)))))))
+                                         #(if (or (:ns? cell)
+                                                  (-> cell :result :nextjournal/value (as-> n (when (number? n) (even? n)))))
+                                            :show
+                                            %))))))
 
 ;; given by e.g. a visibility marker.
 ;;

--- a/notebooks/viewers/context.clj
+++ b/notebooks/viewers/context.clj
@@ -50,7 +50,7 @@
                      (clerk/html [:blockquote.bg-sky-50.rounded.py-1
                                   (clerk/md (str "## " (ns-name doc-ns) "\n" (:doc (meta doc-ns))))])))})
 
-;; By customizing the cell viewer we might override visibility at runtime: in this example we're
+;; By customizing the cell viewer we might override visibility at presentation time: in this example we're
 ;; - hiding all forms holding a defn (except the `^:cljc` ones)
 ;; - showing the namespace result (which is hidden by default otherwise)
 

--- a/notebooks/viewers/context.clj
+++ b/notebooks/viewers/context.clj
@@ -1,0 +1,44 @@
+;; # 🪬 Viewer Context
+
+(ns viewers.context
+  (:require [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.viewer :as viewer]))
+
+;; A viewer's `:pred` function can perform viewer selection based on a value.
+
+;; It would sometimes be useful to have more context available. Examples of this are:
+;;
+;; * Selecting a viewer based on the originating form
+;; * Selecting a different viewer based on additional context like `:path`
+;; * Bring Clerk's handling of out-of-band metadata like `::clerk/visibility` and `::clerk/width` into userspace
+
+;; To make this a backwards-compatible change, we can opt into these
+;; richer predicate functions using a map with a key:
+
+(def cljc-viewer
+  {:pred {:wrapped (fn [{:keys [form]}]
+                     (contains? (meta form) :cljc))}
+   :transform-fn (fn [{:keys [form]}]
+                   (clerk/eval-cljs form))})
+
+;; We should probably use a namespaced keyword to disambiguate it.
+
+;; Also considered letting the pred function opt in using
+;; metadata. Rejected this because it's invisible and doesn't work for
+;; e.g. keywords.
+
+^::clerk/no-cache
+(clerk/add-viewers! [cljc-viewer])
+
+
+;; Now what can we use this for? We can now, for example, create a
+;; viewer in userspace that evalautes a given form in Clojure and sci,
+;; allowing us to use it on both sides.
+
+^:cljc
+(defn my-greet-fn [x]
+  (str "Greetings from " x))
+
+(my-greet-fn "Clojure")
+
+(clerk/eval-cljs '(my-greet-fn "ClojureScript"))

--- a/notebooks/viewers/context.clj
+++ b/notebooks/viewers/context.clj
@@ -45,14 +45,13 @@
 ;; Or build a viewer which will display the namespace's name and docs:
 
 (def ns-viewer
-  {:pred {:wrapped (fn [{:keys [ns?]}] ns?)}
+  {:pred {:wrapped :ns?}
    :transform-fn (fn [{:as wv :keys [form]}]
                    (let [doc-ns (find-ns (second form))]
                      (clerk/html [:blockquote.bg-sky-50.rounded.py-1
                                   (clerk/md (str "## " (ns-name doc-ns) "\n" (:doc (meta doc-ns))))])))})
 
-;; In addition, transform-fns can hook onto the visibility of results to, say, override defaults or make the result of the
-;; ns cell show up
+;; In addition, by customizing the cell viewer we might override visibility defaults
 (def cell-viewer
   (update viewer/cell-viewer
           :transform-fn comp

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -347,6 +347,7 @@
                                                            (assoc-in state [:->analysis-info ana-key] analyzed))
                                                          (dissoc state :doc?)
                                                          (->ana-keys analyzed))
+                                           (parser/ns? form) (assoc-in [:blocks i :ns?] true)
                                            doc? (update-in [:blocks i] merge (dissoc analyzed :deps :no-cache? :ns-effect?))
                                            doc? (assoc-in [:blocks i :text-without-meta]
                                                           (parser/text-with-clerk-metadata-removed text (ns-resolver notebook-ns)))

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -52,6 +52,7 @@
          "viewers/by_val_meta"
          "viewers/caption"
          "viewers/code"
+         "viewers/context"
          "viewers/control_lab"
          "viewers/custom_markdown"
          "viewers/grid"

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -561,10 +561,11 @@
 
 (defn ->display [{:as cell :keys [settings]}]
   (let [{:keys [code result]} (:nextjournal.clerk/visibility settings)]
-    {:result? (or (not= :hide result)
-                  (-> cell :result :nextjournal/value (get-safe :nextjournal/value) viewer-eval?))
+    {:code? (not= :hide code)
      :fold? (= code :fold)
-     :code? (not= :hide code)}))
+     :result? (and (:result cell)
+                   (or (not= :hide result)
+                       (-> cell :result :nextjournal/value (get-safe :nextjournal/value) viewer-eval?)))}))
 
 #_(->display {:settings {:nextjournal.clerk/visibility {:code :show :result :show}}})
 #_(->display {:settings {:nextjournal.clerk/visibility {:code :fold :result :show}}})
@@ -627,7 +628,7 @@
               {:nextjournal/render-opts (assoc (select-keys cell [:loc])
                                                :id (processed-block-id (str id "-code")))}
               (dissoc cell :result)))
-      (and (:result cell) result?)
+      result?
       (conj (ensure-wrapped (set/rename-keys cell {:result ::result}))))))
 
 (def cell-viewer

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1202,7 +1202,7 @@
            [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
             {:href "https://clerk.vision"} "Clerk"]
            (let [default-index? (= 'nextjournal.clerk.index (some-> ns ns-name))]
-             (when (or file-path default-index?)
+             (when (or file-path default-index? url)
                [:<>
                 " from "
                 [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -614,9 +614,8 @@
 (defn update-if [m k f] (if (k m) (update m k f) m))
 #_(update-if {:n "42"} :n #(Integer/parseInt %))
 
-(defn transform-cell [{:as cell :keys [id result]}]
-  (let [cell (update-if cell :result apply-viewer-unwrapping-var-from-def)
-        {:keys [code? result? fold?]} (->display cell)
+(defn transform-cell [{:as cell :keys [id]}]
+  (let [{:keys [code? result? fold?]} (->display cell)
         eval? (-> cell :result :nextjournal/value (get-safe :nextjournal/value) viewer-eval?)]
     (cond-> []
       code?
@@ -647,7 +646,10 @@
                                                    ::doc doc} doc))]))
                         (partition-by (comp #{:image} :type) content)))
 
-    :code [(with-viewer `cell-viewer (assoc cell ::doc doc))]))
+    :code [(with-viewer `cell-viewer
+             (-> cell
+                 (assoc ::doc doc)
+                 (update-if :result apply-viewer-unwrapping-var-from-def)))]))
 
 #_(-> (nextjournal.clerk.eval/eval-string "(ns dang) {:nextjournal.clerk/visibility {:code :hide}} 1")
       nextjournal.clerk.view/doc->viewer

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -522,7 +522,7 @@
                             (select-keys (keys viewer-opts-normalization))
                             (set/rename-keys viewer-opts-normalization))
         {:as to-present :nextjournal/keys [auto-expand-results?]} (merge (dissoc (->opts wrapped-value) :!budget :nextjournal/budget)
-                                                                         (dissoc cell :result)
+                                                                         (dissoc cell :result ::doc) ;; TODO: reintroduce doc once we know why it OOMs the static build on CI (some walk issue probably)
                                                                          opts-from-block
                                                                          (ensure-wrapped-with-viewers (or viewers (get-viewers (get-*ns*))) value))
         presented-result (-> (present to-present)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -531,13 +531,11 @@
                                      (fn [{:as opts existing-id :id}]
                                        (cond-> opts
                                          auto-expand-results? (assoc :auto-expand-results? auto-expand-results?)
-                                         (seq path) (assoc :fragment-item? true)
+                                         (< 1 (count path)) (assoc :fragment-item? true)
                                          (not existing-id) (assoc :id (processed-block-id (str id "-result") path)))))
                              #?(:clj (->> (process-blobs blob-opts))))
         viewer-eval-result? (-> presented-result :nextjournal/value viewer-eval?)]
     #_(prn :presented-result viewer-eval? presented-result)
-    ;; TODO: adjust path for fragment-item?
-    (when (seq path) (prn :path path))
     (-> wrapped-value
         mark-presented
         (merge {:nextjournal/value (cond-> {:nextjournal/presented presented-result :nextjournal/blob-id blob-id}
@@ -620,7 +618,6 @@
   (let [cell (update-if cell :result apply-viewer-unwrapping-var-from-def)
         {:keys [code? result? fold?]} (->display cell)
         eval? (-> cell :result :nextjournal/value (get-safe :nextjournal/value) viewer-eval?)]
-    (prn :cell (keys cell))
     (cond-> []
       code?
       (conj (with-viewer (if fold? `folded-code-block-viewer `code-block-viewer)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -235,6 +235,10 @@
       ensure-wrapped
       (assoc :nextjournal/viewers viewers)))
 
+(def ^:dynamic *viewers* nil)
+
+(defmacro with-viewers* [vs & body] `(binding [*viewers* ~vs] ~@body))
+
 #_(->> "x^2" (with-viewer `latex-viewer) (with-viewers [{:name `latex-viewer :render-fn `mathjax-viewer}]))
 
 (defn get-safe
@@ -492,6 +496,7 @@
   ([scope] (get-viewers scope nil))
   ([scope value]
    (or (when value (->viewers value))
+       *viewers*
        (when scope (@!viewers (datafy-scope scope)))
        (get-default-viewers))))
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -536,6 +536,8 @@
                              #?(:clj (->> (process-blobs blob-opts))))
         viewer-eval-result? (-> presented-result :nextjournal/value viewer-eval?)]
     #_(prn :presented-result viewer-eval? presented-result)
+    ;; TODO: adjust path for fragment-item?
+    (when (seq path) (prn :path path))
     (-> wrapped-value
         mark-presented
         (merge {:nextjournal/value (cond-> {:nextjournal/presented presented-result :nextjournal/blob-id blob-id}

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -660,11 +660,6 @@
 
     :code [(with-viewer `cell-viewer (assoc cell ::doc doc))]))
 
-#_(-> (nextjournal.clerk.eval/eval-string "(ns dang) {:nextjournal.clerk/visibility {:code :hide}} 1")
-      nextjournal.clerk.view/doc->viewer
-      ->value :blocks)
-
-
 #_(:blocks (:nextjournal/value (nextjournal.clerk.view/doc->viewer @nextjournal.clerk.webserver/!doc)))
 
 #_(nextjournal.clerk.view/doc->viewer @nextjournal.clerk.webserver/!doc)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1879,7 +1879,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; examples
 (def example-viewer
-  {:transform-fn (fn [wrapped-value]
+  {:name `example-viewer
+   :transform-fn (fn [wrapped-value]
                    (-> wrapped-value
                        mark-preserve-keys
                        (assoc :nextjournal/viewer {:render-fn '(fn [{:keys [form val]} opts]
@@ -1891,7 +1892,8 @@
                        (update-in [:nextjournal/value :form] code)))})
 
 (def examples-viewer
-  {:transform-fn (update-val (fn [examples]
+  {:name `examples-viewer
+   :transform-fn (update-val (fn [examples]
                                (mapv (partial with-viewer example-viewer) examples)))
    :render-fn '(fn [examples opts]
                  [:div

--- a/test/nextjournal/clerk/eval_test.clj
+++ b/test/nextjournal/clerk/eval_test.clj
@@ -142,7 +142,8 @@
       eval/eval-string
       view/doc->viewer
       :nextjournal/value
-      :blocks))
+      :blocks
+      (->> (mapcat :nextjournal/value))))
 
 (deftest eval-string+doc->viewer
   (testing "assigns correct width from viewer function opts"

--- a/test/nextjournal/clerk/parser_test.clj
+++ b/test/nextjournal/clerk/parser_test.clj
@@ -160,9 +160,12 @@ par two"))))
 
 (deftest presenting-a-parsed-document
   (testing "presenting a parsed document doesn't produce garbage"
-    (is (match? [{:nextjournal/viewer {:name 'nextjournal.clerk.viewer/code-block-viewer}}
-                 {:nextjournal/viewer {:name 'nextjournal.clerk.viewer/code-block-viewer}}
-                 {:nextjournal/viewer {:name 'nextjournal.clerk.viewer/code-block-viewer}}]
+    (is (match? [{:nextjournal/viewer {:name 'nextjournal.clerk.viewer/cell-viewer}
+                  :nextjournal/value [{:nextjournal/viewer {:name 'nextjournal.clerk.viewer/code-block-viewer}}]}
+                 {:nextjournal/viewer {:name 'nextjournal.clerk.viewer/cell-viewer}
+                  :nextjournal/value [{:nextjournal/viewer {:name 'nextjournal.clerk.viewer/code-block-viewer}}]}
+                 {:nextjournal/viewer {:name 'nextjournal.clerk.viewer/cell-viewer}
+                  :nextjournal/value [{:nextjournal/viewer {:name 'nextjournal.clerk.viewer/code-block-viewer}}]}]
                 (-> (parser/parse-clojure-string {:doc? true} "(ns testing-presented-parsed) 123 :ahoi")
                     view/doc->viewer
                     :nextjournal/value

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -7,6 +7,7 @@
             [nextjournal.clerk.builder :as builder]
             [nextjournal.clerk.config :as config]
             [nextjournal.clerk.eval :as eval]
+            [nextjournal.clerk.eval-test :as eval-test]
             [nextjournal.clerk.view :as view]
             [nextjournal.clerk.viewer :as v]))
 
@@ -86,7 +87,7 @@
 (deftest default-viewers
   (testing "viewers have names matching vars"
     (doseq [[viewer-name viewer] (into {}
-                                       (map (juxt :name (comp deref resolve :name))) 
+                                       (map (juxt :name (comp deref resolve :name)))
                                        v/default-viewers)]
       (is (= viewer-name (:name viewer))))))
 
@@ -286,43 +287,43 @@
 
   (testing "Setting custom options on results via metadata"
     (is (= :full
-           (-> (eval/eval-string "^{:nextjournal.clerk/width :full} (nextjournal.clerk/html [:div])")
-               view/doc->viewer v/->value :blocks second
-               v/->value :nextjournal/presented :nextjournal/width)))
+           (-> (eval-test/eval+extract-doc-blocks "^{:nextjournal.clerk/width :full} (nextjournal.clerk/html [:div])")
+               second v/->value :nextjournal/presented :nextjournal/width)))
+
     (is (= [:rounded :bg-indigo-600 :font-bold]
-           (-> (eval/eval-string "^{:nextjournal.clerk/css-class [:rounded :bg-indigo-600 :font-bold]} (nextjournal.clerk/table [[1 2][3 4]])")
-               view/doc->viewer v/->value :blocks second
+           (-> (eval-test/eval+extract-doc-blocks "^{:nextjournal.clerk/css-class [:rounded :bg-indigo-600 :font-bold]} (nextjournal.clerk/table [[1 2][3 4]])")
+               second
                v/->value :nextjournal/presented :nextjournal/css-class))))
 
   (testing "Setting custom options on results via viewer API"
     (is (= :full
-           (-> (eval/eval-string "(nextjournal.clerk/html {:nextjournal.clerk/width :full} [:div])")
-               view/doc->viewer v/->value :blocks second
+           (-> (eval-test/eval+extract-doc-blocks "(nextjournal.clerk/html {:nextjournal.clerk/width :full} [:div])")
+               second
                v/->value :nextjournal/presented :nextjournal/width)))
     (is (= [:rounded :bg-indigo-600 :font-bold]
-           (-> (eval/eval-string "(nextjournal.clerk/table {:nextjournal.clerk/css-class [:rounded :bg-indigo-600 :font-bold]} [[1 2][3 4]])")
-               view/doc->viewer v/->value :blocks second
+           (-> (eval-test/eval+extract-doc-blocks "(nextjournal.clerk/table {:nextjournal.clerk/css-class [:rounded :bg-indigo-600 :font-bold]} [[1 2][3 4]])")
+               second
                v/->value :nextjournal/presented :nextjournal/css-class))))
 
   (testing "Settings propagation from ns to form"
     (is (= :full
-           (-> (eval/eval-string "(ns nextjournal.clerk.viewer-test.settings {:nextjournal.clerk/width :full}) (nextjournal.clerk/html [:div])")
-               view/doc->viewer v/->value :blocks (nth 2)
+           (-> (eval-test/eval+extract-doc-blocks "(ns nextjournal.clerk.viewer-test.settings {:nextjournal.clerk/width :full}) (nextjournal.clerk/html [:div])")
+               (nth 2)
                v/->value :nextjournal/presented :nextjournal/width)))
 
     (is (= :wide
-           (-> (eval/eval-string "(ns nextjournal.clerk.viewer-test.settings {:nextjournal.clerk/width :full}) (nextjournal.clerk/html {:nextjournal.clerk/width :wide} [:div])")
-               view/doc->viewer v/->value :blocks (nth 2)
+           (-> (eval-test/eval+extract-doc-blocks "(ns nextjournal.clerk.viewer-test.settings {:nextjournal.clerk/width :full}) (nextjournal.clerk/html {:nextjournal.clerk/width :wide} [:div])")
+               (nth 2)
                v/->value :nextjournal/presented :nextjournal/width)))
 
     (is (= :wide
-           (-> (eval/eval-string "(ns nextjournal.clerk.viewer-test.settings {:nextjournal.clerk/width :full}) ^{:nextjournal.clerk/width :wide} (nextjournal.clerk/html [:div])")
-               view/doc->viewer v/->value :blocks (nth 2)
+           (-> (eval-test/eval+extract-doc-blocks "(ns nextjournal.clerk.viewer-test.settings {:nextjournal.clerk/width :full}) ^{:nextjournal.clerk/width :wide} (nextjournal.clerk/html [:div])")
+               (nth 2)
                v/->value :nextjournal/presented :nextjournal/width)))
 
     (is (= :wide
-           (-> (eval/eval-string "(ns nextjournal.clerk.viewer-test.settings {:nextjournal.clerk/width :full}) {:nextjournal.clerk/width :wide} (nextjournal.clerk/html [:div])")
-               view/doc->viewer v/->value :blocks (nth 2)
+           (-> (eval-test/eval+extract-doc-blocks "(ns nextjournal.clerk.viewer-test.settings {:nextjournal.clerk/width :full}) {:nextjournal.clerk/width :wide} (nextjournal.clerk/html [:div])")
+               (nth 2)
                v/->value :nextjournal/presented :nextjournal/width))))
 
   (testing "Presented doc (with fragments) has unambiguous ids assigned to results"
@@ -401,9 +402,8 @@
 
 (deftest removed-metadata
   (is (= "(do 'this)"
-         (-> (eval/eval-string "(ns test.removed-metadata\n(:require [nextjournal.clerk :as c]))\n\n^::c/no-cache (do 'this)")
-             view/doc->viewer
-             v/->value :blocks second v/->value))))
+         (-> (eval-test/eval+extract-doc-blocks "(ns test.removed-metadata\n(:require [nextjournal.clerk :as c]))\n\n^::c/no-cache (do 'this)")
+             second v/->value))))
 
 (deftest col-viewer-map-args
   (testing "extracts first arg as viewer-opts"

--- a/test/nextjournal/clerk/webserver_test.clj
+++ b/test/nextjournal/clerk/webserver_test.clj
@@ -13,7 +13,7 @@
   (testing "lazy loading of simple range"
     (let [doc (let [doc (eval/eval-string "(range 100)")]
                 (with-meta doc (view/doc->viewer doc)))
-          {:nextjournal/keys [presented fetch-opts]} (-> doc view/doc->viewer :nextjournal/value :blocks second :nextjournal/value)
+          {:nextjournal/keys [presented fetch-opts]} (-> doc meta :nextjournal/value :blocks first :nextjournal/value second :nextjournal/value)
           {:nextjournal/keys [value]} presented
           {elision-viewer :nextjournal/viewer elision-fetch-opts :nextjournal/value} (peek value)
           {:keys [body]} (webserver/serve-blob doc (merge fetch-opts {:fetch-opts elision-fetch-opts}))]


### PR DESCRIPTION
* when a viewer's predicate is a map with a `:wrapped` key, its value is called against the whole wrapped value instead of just the value
* the contents of the cell are merged into the wrapped value on which viewer functions operate  
* a cell viewer is added to allow a.o. to control the visibility of result or code programmatically.