### PR TITLE
Navbar improvements (Leaflet support)

### DIFF
--- a/notebooks/meta_toc.clj
+++ b/notebooks/meta_toc.clj
@@ -18,7 +18,7 @@
 
 (defn md-toc->navbar-items [current-notebook file {:keys [children]}]
   (mapv (fn [{:as item :keys [emoji attrs]}]
-          {:title (md.transform/->text item)
+          {:title (cond-> (md.transform/->text item) (seq emoji) (subs (count emoji)))
            :expanded? (= current-notebook file)
            :scroll-to-anchor? false
            :emoji emoji
@@ -37,7 +37,7 @@
                           (fn [wrapped-value]
                             (-> wrapped-value
                                 original-transform
-                                (assoc :nextjournal/opts {:expandable? true})
+                                (assoc :nextjournal/render-opts {:expandable-toc? true})
                                 (assoc-in [:nextjournal/value :toc]
                                           (meta-toc (:file (v/->value wrapped-value)) notebooks)))))))
 

--- a/src/nextjournal/clerk/render/navbar.cljs
+++ b/src/nextjournal/clerk/render/navbar.cljs
@@ -50,7 +50,7 @@
   (into
    [:div]
    (map-indexed
-    (fn [i {:as item :keys [emoji path title items]}]
+    (fn [i {:as item :keys [css-class emoji path title items]}]
       (let [label (or title (str/capitalize (last (str/split path #"/"))))
             expanded? (get-in @!expanded-at [:toc path])]
         [:div.text-base.leading-normal.dark:text-white
@@ -78,7 +78,7 @@
                             (swap! !expanded-at assoc :toc-open? false)))}
              (when emoji
                [:span.flex-shrink-0 emoji])
-             [:span label]]
+             [:span {:class css-class} label]]
             (when (and expandable-toc? expanded?)
               [:span.absolute.bottom-0.border-l.border-slate-300.dark:border-slate-600
                {:class "top-[25px] left-[10px]"}])]
@@ -91,7 +91,7 @@
                            (swap! !expanded-at assoc :toc-open? false)))}
             (when emoji
               [:span.flex-shrink-0 emoji])
-            [:span label]])
+            [:span {:class css-class} label]])
          (when (and (seq items) (or (not expandable-toc?) (and expandable-toc? expanded?)))
            [:div.relative
             {:class (str (if expandable-toc? "ml-[16px] " "ml-[19px] ")

--- a/src/nextjournal/clerk/render/navbar.cljs
+++ b/src/nextjournal/clerk/render/navbar.cljs
@@ -50,7 +50,7 @@
   (into
    [:div]
    (map-indexed
-    (fn [i {:as item :keys [css-class emoji path title items]}]
+    (fn [i {:as item :keys [href css-class emoji path title items]}]
       (let [label (or title (str/capitalize (last (str/split path #"/"))))
             expanded? (get-in @!expanded-at [:toc path])
             {:keys [expandable-toc?]} (merge render-opts item)]
@@ -71,7 +71,7 @@
                  :class (if expanded? "rotate-90" "rotate-0")}
                 [:path {:stroke-linecap "round" :stroke-linejoin "round" :d "M8.25 4.5l7.5 7.5-7.5 7.5"}]]])
             [:a.py-1.flex.flex-auto.gap-1.group-hover:text-indigo-700.dark:group-hover:text-white.hover:underline.decoration-indigo-300.dark:decoration-slate-400.underline-offset-2
-             {:href path
+             {:href (if (some? href) href path)
               :class (when (and expandable-toc? expanded?) "font-medium")
               :on-click (fn [event]
                           (navigate-or-scroll! event item render-opts)
@@ -85,7 +85,7 @@
                {:class "top-[25px] left-[10px]"}])]
            [:a.flex.flex-auto.gap-1.py-1.rounded.hover:bg-slate-200.dark:hover:bg-slate-900.hover:text-indigo-700.dark:hover:text-white.hover:underline.decoration-indigo-300.dark:decoration-slate-400.underline-offset-2.transition
             {:class "px-[6px] ml-[8px] mr-[4px]"
-             :href path
+             :href (if (some? href) href path)
              :on-click (fn [event]
                          (navigate-or-scroll! event item render-opts)
                          (when mobile-toc?

--- a/src/nextjournal/clerk/render/navbar.cljs
+++ b/src/nextjournal/clerk/render/navbar.cljs
@@ -99,7 +99,8 @@
             (when (and expandable-toc? expanded?)
               [:span.absolute.top-0.border-l.border-slate-300.dark:border-slate-600
                {:class "left-[2px] bottom-[8px]"}])
-            [render-items items render-opts]])]))
+            [render-items items (merge render-opts (select-keys item [:expandable-toc?]))]])]))
+
     items)))
 
 (def local-storage-key "clerk-navbar")

--- a/src/nextjournal/clerk/render/navbar.cljs
+++ b/src/nextjournal/clerk/render/navbar.cljs
@@ -46,13 +46,14 @@
           (.pushState js/history #js {} "" anchor))
         (scroll-to-anchor! anchor)))))
 
-(defn render-items [items {:as render-opts :keys [!expanded-at expandable-toc? mobile-toc?]}]
+(defn render-items [items {:as render-opts :keys [!expanded-at mobile-toc?]}]
   (into
    [:div]
    (map-indexed
     (fn [i {:as item :keys [css-class emoji path title items]}]
       (let [label (or title (str/capitalize (last (str/split path #"/"))))
-            expanded? (get-in @!expanded-at [:toc path])]
+            expanded? (get-in @!expanded-at [:toc path])
+            {:keys [expandable-toc?]} (merge render-opts item)]
         [:div.text-base.leading-normal.dark:text-white
          {:class "md:text-[14px]"}
          (if (seq items)
@@ -99,7 +100,7 @@
             (when (and expandable-toc? expanded?)
               [:span.absolute.top-0.border-l.border-slate-300.dark:border-slate-600
                {:class "left-[2px] bottom-[8px]"}])
-            [render-items items (merge render-opts (select-keys item [:expandable-toc?]))]])]))
+            [render-items items render-opts]])]))
 
     items)))
 

--- a/src/nextjournal/clerk/render/navbar.cljs
+++ b/src/nextjournal/clerk/render/navbar.cljs
@@ -71,7 +71,7 @@
                  :class (if expanded? "rotate-90" "rotate-0")}
                 [:path {:stroke-linecap "round" :stroke-linejoin "round" :d "M8.25 4.5l7.5 7.5-7.5 7.5"}]]])
             [:a.py-1.flex.flex-auto.gap-1.group-hover:text-indigo-700.dark:group-hover:text-white.hover:underline.decoration-indigo-300.dark:decoration-slate-400.underline-offset-2
-             {:href (if (some? href) href path)
+             {:href (or href path)
               :class (when (and expandable-toc? expanded?) "font-medium")
               :on-click (fn [event]
                           (navigate-or-scroll! event item render-opts)
@@ -85,7 +85,7 @@
                {:class "top-[25px] left-[10px]"}])]
            [:a.flex.flex-auto.gap-1.py-1.rounded.hover:bg-slate-200.dark:hover:bg-slate-900.hover:text-indigo-700.dark:hover:text-white.hover:underline.decoration-indigo-300.dark:decoration-slate-400.underline-offset-2.transition
             {:class "px-[6px] ml-[8px] mr-[4px]"
-             :href (if (some? href) href path)
+             :href (or href path)
              :on-click (fn [event]
                          (navigate-or-scroll! event item render-opts)
                          (when mobile-toc?


### PR DESCRIPTION
- allow to customize each navbar node href, leaving the `:path` key intact which is used for the expanded-at
- allow to customize the expandable behaviour at node level
- allow to customize label css