### PR TITLE
Static App: Client-side routing

### DIFF
--- a/notebooks/meta_toc.clj
+++ b/notebooks/meta_toc.clj
@@ -154,4 +154,4 @@
   ;; Test actual cross-doc toc
   (viewer/reset-viewers! :default (viewer/add-viewers [(notebook-viewer {:paths paths})]))
   (reset! viewer/!viewers {})
-  (clerk/build! {:xhr? true :paths paths}))
+  (clerk/build! {:client-side-routing? true :paths paths}))

--- a/notebooks/meta_toc.clj
+++ b/notebooks/meta_toc.clj
@@ -1,47 +1,156 @@
 ;; # 📕 Meta Table of Contents
 (ns meta-toc
-  {:nextjournal.clerk/toc true}
-  (:require [nextjournal.clerk :as clerk]
+  {:nextjournal.clerk/toc true
+   :nextjournal.clerk/no-cache true}
+  (:require [babashka.fs :as fs]
+            [clojure.edn]
+            [clojure.string :as str]
+            [nextjournal.clerk :as clerk]
             [nextjournal.clerk.parser :as parser]
-            [nextjournal.markdown.transform :as md.transform]
-            [nextjournal.clerk.viewer :as v]))
-
-;; This assembles the table of contents programmatically from a
-;; collection of notebooks.
+            [nextjournal.clerk.viewer :as viewer]
+            [nextjournal.markdown.transform :as md.transform]))
 
 ;; ## Notebooks
-(def notebooks
-  ["notebooks/how_clerk_works.clj"
-   "notebooks/cherry.clj"
-   "notebooks/tracer.clj"
-   "notebooks/document_linking.clj"])
+(def paths
+  ["notebooks/rule_30.clj"
+   "notebooks/visibility.clj"
+   "notebooks/viewer_api.clj"
+   "notebooks/viewer_classes.clj"])
 
-(defn md-toc->navbar-items [current-notebook file {:keys [children]}]
-  (mapv (fn [{:as item :keys [emoji attrs]}]
-          {:title (cond-> (md.transform/->text item) (seq emoji) (subs (count emoji)))
-           :expanded? (= current-notebook file)
-           :scroll-to-anchor? false
+;; TODO: something closer to a ns
+(defn path->title [path]
+  (-> path fs/file-name (str/replace #"\.(clj(c?)|md)$" "") (str/split #"_")
+      (->> (map str/capitalize)
+           (str/join " "))))
+#_(path->title "src/ductile/clerk/doc.clj")
+
+(defn md-toc->navbar-item [path {:as item :keys [children emoji attrs]}]
+  (cond-> {:title (cond-> (or (not-empty (md.transform/->text item)) (path->title path))
+                          (seq emoji) (subs (count emoji)))
+           :expanded? true
            :emoji emoji
-           :path (clerk/doc-url file (:id attrs))
-           :items (md-toc->navbar-items current-notebook file item)}) children))
+           :path (str "#" (:id attrs))}
+          (seq children)
+          (assoc :items (mapv (comp #(assoc % :expandable-toc? false)
+                                    (partial md-toc->navbar-item path)) children))))
 
-(defn meta-toc [current-notebook paths]
-  (into []
-        (mapcat (comp (fn [{:keys [toc file]}] (md-toc->navbar-items current-notebook file toc))
-                      (partial parser/parse-file {:doc? true})))
-        paths))
+(defn path->doc-info [path]
+  (let [{:keys [title toc]} (parser/parse-file {:doc? true} path)]
+    {:path path
+     :toc toc
+     ;; enforce only ATX-1 as title
+     :title (or (not-empty (-> toc :children first md.transform/->text))
+                (path->title path))}))
 
-(def book-viewer
-  (update v/notebook-viewer
+#_(:toc (parser/parse-file {:doc? true} "roadmap/compound.md"))
+#_(->> (parser/parse-file {:doc? true} "src/ductile/clerk/doc.clj")
+       :toc :children
+       (mapv (partial md-toc->navbar-item "src/ductile/clerk/doc.clj")))
+
+(defn doc-path->path-in-registry [registry folder-path]
+  (let [index-of-matching (fn [r] (first (keep-indexed #(when (str/starts-with? folder-path (:path %2)) %1) (:items r))))]
+    (loop [r registry
+           nav-path [:items]]
+      (if-some [idx (index-of-matching r)]
+        (recur (get-in r (conj nav-path idx))
+               (conj nav-path idx :items))
+        nav-path))))
+
+(defn normalize-atx1s [[first & rest]]
+  (cond-> first
+          (seq rest)
+          (update :items
+                  (fnil into [])
+                  (mapv #(assoc % :expandable-toc? false) rest))))
+
+(defn remove-ext [s] (str/replace s #"\.(clj|md)$" ""))
+#_(remove-ext "src/doc/clerk.mdx")
+
+(defn add-collection [{:keys [index current-notebook]} registry [parent-path coll]]
+  (if (str/blank? parent-path)
+    (assoc registry :items coll)
+    (update-in registry
+               (doc-path->path-in-registry registry parent-path)
+               (fnil conj []) {:title (path->title parent-path)
+                               :expanded? (or (= current-notebook index)
+                                              (str/starts-with? (str current-notebook) parent-path))
+                               :folder? true
+                               :href "#"
+                               :path parent-path
+                               :items (mapv (fn [{:as item :keys [toc path]}]
+                                              (-> item
+                                                  (update :path (comp clerk/doc-url remove-ext))
+                                                  (dissoc :toc)
+                                                  (as-> item
+                                                        (if (= current-notebook path)
+                                                          (assoc (if-some [cs (seq (:children toc))]
+                                                                   (normalize-atx1s (mapv (partial md-toc->navbar-item path) cs))
+                                                                   item) :css-class "font-bold")
+                                                          item)))) coll)})))
+
+#_(def current-notebook "src/ductile/clerk/doc.clj")
+#_(def add-collection* (partial add-collection current-notebook))
+#_(-> {}
+      (add-collection* ["roadmap" [{:title "Compound" :path "roadmap/compound.clj"}
+                                   {:path "roadmap/billing.clj" :title "z"}
+                                   {:title "EDI" :path "roadmap/edi.clj"}]])
+      (add-collection* ["roadmap/ars" [{:title "xxx" :path "roadmap/ars/billing.clj"}
+                                       {:title "xx" :path "roadmap/ars/compound.clj"}]]))
+
+(defn intersect? [p1 p2] (or (str/starts-with? p1 p2) (str/starts-with? p2 p1)))
+
+(defn compare-path-length-then-order [paths p1 p2]
+  (if (not (intersect? (str (fs/parent p1)) (str (fs/parent p2))))
+    (compare (.indexOf paths p1) (.indexOf paths p2))
+    (let [d (compare (count (seq (fs/path p1)))
+                     (count (seq (fs/path p2))))]
+      (if (zero? d)
+        (compare (.indexOf paths p1) (.indexOf paths p2))
+        d))))
+
+(defn meta-toc [{:as opts :keys [paths]}]
+  (->> paths
+       (map path->doc-info)
+       (group-by (comp str fs/parent fs/path :path))
+       (sort-by (comp :path first val) (partial compare-path-length-then-order paths))
+       (reduce (partial add-collection opts) {})
+       :items))
+
+#_(meta-toc {:current-notebook "src/ductile/clerk/doc.clj"
+             :paths ductile.clerk/leaflet-paths})
+
+(defn next-path [paths x dir] (when-some [i (.indexOf paths x)] (get (vec paths) (+ i dir))))
+(defn update-header [[tag & contents] {:keys [current-notebook paths]}]
+  (let [sorted-paths (sort (partial compare-path-length-then-order paths) paths)
+        prev-path (next-path sorted-paths current-notebook -1)
+        next-path (next-path sorted-paths current-notebook +1)]
+    (vec
+      (cons tag
+            (cond-> ()
+                    prev-path
+                    (into [[:span.mx-2 "•"]
+                           [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
+                            {:href (viewer/doc-url (remove-ext prev-path))} "Prev"]])
+                    true
+                    (concat contents)
+                    next-path
+                    (concat [[:span.mx-2 "•"]
+                             [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
+                              {:href (viewer/doc-url (remove-ext next-path))} "Next"]]))))))
+
+(defn notebook-viewer [opts]
+  (update viewer/notebook-viewer
           :transform-fn (fn [original-transform]
                           (fn [wrapped-value]
-                            (-> wrapped-value
-                                original-transform
-                                (assoc :nextjournal/render-opts {:expandable-toc? true})
-                                (assoc-in [:nextjournal/value :toc]
-                                          (meta-toc (:file (v/->value wrapped-value)) notebooks)))))))
+                            (let [opts (assoc opts :current-notebook (:file (viewer/->value wrapped-value)))]
+                              (-> wrapped-value
+                                  original-transform
+                                  (assoc :nextjournal/render-opts {:expandable-toc? true})
+                                  (assoc-in [:nextjournal/value :toc-visibility] true)
+                                  (assoc-in [:nextjournal/value :toc] (meta-toc opts))
+                                  (update-in [:nextjournal/value :header :nextjournal/value 1] update-header opts)))))))
 
-#_(clerk/add-viewers! [book-viewer])
-
-;; Test actual cross-doc toc
-(clerk/add-viewers! [book-viewer])
+(comment
+  ;; Test actual cross-doc toc
+  (viewer/reset-viewers! :default (viewer/add-viewers [(notebook-viewer {:paths paths})]))
+  (reset! viewer/!viewers {}))

--- a/notebooks/meta_toc.clj
+++ b/notebooks/meta_toc.clj
@@ -1,157 +1,51 @@
 ;; # 📕 Meta Table of Contents
 (ns meta-toc
-  {:nextjournal.clerk/toc true
-   :nextjournal.clerk/no-cache true}
-  (:require [babashka.fs :as fs]
-            [clojure.edn]
-            [clojure.string :as str]
-            [nextjournal.clerk :as clerk]
+  {:nextjournal.clerk/toc true}
+  (:require [nextjournal.clerk :as clerk]
             [nextjournal.clerk.parser :as parser]
             [nextjournal.clerk.viewer :as viewer]
-            [nextjournal.markdown.transform :as md.transform]))
+            [nextjournal.markdown.transform :as md.transform]
+            [nextjournal.clerk.viewer :as v]))
+
+;; This assembles the table of contents programmatically from a
+;; collection of notebooks.
 
 ;; ## Notebooks
-(def paths
-  ["notebooks/rule_30.clj"
-   "notebooks/visibility.clj"
-   "notebooks/viewer_api.clj"
-   "notebooks/viewer_classes.clj"])
+(def notebooks
+  ["notebooks/how_clerk_works.clj"
+   "notebooks/cherry.clj"
+   "notebooks/tracer.clj"
+   "notebooks/document_linking.clj"])
 
-;; TODO: something closer to a ns
-(defn path->title [path]
-  (-> path fs/file-name (str/replace #"\.(clj(c?)|md)$" "") (str/split #"_")
-      (->> (map str/capitalize)
-           (str/join " "))))
-#_(path->title "src/ductile/clerk/doc.clj")
-
-(defn md-toc->navbar-item [path {:as item :keys [children emoji attrs]}]
-  (cond-> {:title (cond-> (or (not-empty (md.transform/->text item)) (path->title path))
-                          (seq emoji) (subs (count emoji)))
-           :expanded? true
+(defn md-toc->navbar-items [current-notebook file {:keys [children]}]
+  (mapv (fn [{:as item :keys [emoji attrs]}]
+          {:title (cond-> (md.transform/->text item) (seq emoji) (subs (count emoji)))
+           :expanded? (= current-notebook file)
+           :scroll-to-anchor? false
            :emoji emoji
-           :path (str "#" (:id attrs))}
-          (seq children)
-          (assoc :items (mapv (comp #(assoc % :expandable-toc? false)
-                                    (partial md-toc->navbar-item path)) children))))
+           :path (clerk/doc-url file (:id attrs))
+           :items (md-toc->navbar-items current-notebook file item)}) children))
 
-(defn path->doc-info [path]
-  (let [{:keys [title toc]} (parser/parse-file {:doc? true} path)]
-    {:path path
-     :toc toc
-     ;; enforce only ATX-1 as title
-     :title (or (not-empty (-> toc :children first md.transform/->text))
-                (path->title path))}))
+(defn meta-toc [current-notebook paths]
+  (into []
+        (mapcat (comp (fn [{:keys [toc file]}] (md-toc->navbar-items current-notebook file toc))
+                      (partial parser/parse-file {:doc? true})))
+        paths))
 
-#_(:toc (parser/parse-file {:doc? true} "roadmap/compound.md"))
-#_(->> (parser/parse-file {:doc? true} "src/ductile/clerk/doc.clj")
-       :toc :children
-       (mapv (partial md-toc->navbar-item "src/ductile/clerk/doc.clj")))
-
-(defn doc-path->path-in-registry [registry folder-path]
-  (let [index-of-matching (fn [r] (first (keep-indexed #(when (str/starts-with? folder-path (:path %2)) %1) (:items r))))]
-    (loop [r registry
-           nav-path [:items]]
-      (if-some [idx (index-of-matching r)]
-        (recur (get-in r (conj nav-path idx))
-               (conj nav-path idx :items))
-        nav-path))))
-
-(defn normalize-atx1s [[first & rest]]
-  (cond-> first
-          (seq rest)
-          (update :items
-                  (fnil into [])
-                  (mapv #(assoc % :expandable-toc? false) rest))))
-
-(defn remove-ext [s] (str/replace s #"\.(clj|md)$" ""))
-#_(remove-ext "src/doc/clerk.mdx")
-
-(defn add-collection [{:keys [index current-notebook]} registry [parent-path coll]]
-  (if (str/blank? parent-path)
-    (assoc registry :items coll)
-    (update-in registry
-               (doc-path->path-in-registry registry parent-path)
-               (fnil conj []) {:title (path->title parent-path)
-                               :expanded? (or (= current-notebook index)
-                                              (str/starts-with? (str current-notebook) parent-path))
-                               :folder? true
-                               :href "#"
-                               :path parent-path
-                               :items (mapv (fn [{:as item :keys [toc path]}]
-                                              (-> item
-                                                  (update :path (comp clerk/doc-url remove-ext))
-                                                  (dissoc :toc)
-                                                  (as-> item
-                                                        (if (= current-notebook path)
-                                                          (assoc (if-some [cs (seq (:children toc))]
-                                                                   (normalize-atx1s (mapv (partial md-toc->navbar-item path) cs))
-                                                                   item) :css-class "font-bold")
-                                                          item)))) coll)})))
-
-#_(def current-notebook "src/ductile/clerk/doc.clj")
-#_(def add-collection* (partial add-collection current-notebook))
-#_(-> {}
-      (add-collection* ["roadmap" [{:title "Compound" :path "roadmap/compound.clj"}
-                                   {:path "roadmap/billing.clj" :title "z"}
-                                   {:title "EDI" :path "roadmap/edi.clj"}]])
-      (add-collection* ["roadmap/ars" [{:title "xxx" :path "roadmap/ars/billing.clj"}
-                                       {:title "xx" :path "roadmap/ars/compound.clj"}]]))
-
-(defn intersect? [p1 p2] (or (str/starts-with? p1 p2) (str/starts-with? p2 p1)))
-
-(defn compare-path-length-then-order [paths p1 p2]
-  (if (not (intersect? (str (fs/parent p1)) (str (fs/parent p2))))
-    (compare (.indexOf paths p1) (.indexOf paths p2))
-    (let [d (compare (count (seq (fs/path p1)))
-                     (count (seq (fs/path p2))))]
-      (if (zero? d)
-        (compare (.indexOf paths p1) (.indexOf paths p2))
-        d))))
-
-(defn meta-toc [{:as opts :keys [paths]}]
-  (->> paths
-       (map path->doc-info)
-       (group-by (comp str fs/parent fs/path :path))
-       (sort-by (comp :path first val) (partial compare-path-length-then-order paths))
-       (reduce (partial add-collection opts) {})
-       :items))
-
-#_(meta-toc {:current-notebook "src/ductile/clerk/doc.clj"
-             :paths ductile.clerk/leaflet-paths})
-
-(defn next-path [paths x dir] (when-some [i (.indexOf paths x)] (get (vec paths) (+ i dir))))
-(defn update-header [[tag & contents] {:keys [current-notebook paths]}]
-  (let [sorted-paths (sort (partial compare-path-length-then-order paths) paths)
-        prev-path (next-path sorted-paths current-notebook -1)
-        next-path (next-path sorted-paths current-notebook +1)]
-    (vec
-      (cons tag
-            (cond-> ()
-                    prev-path
-                    (into [[:span.mx-2 "•"]
-                           [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
-                            {:href (viewer/doc-url (remove-ext prev-path))} "Prev"]])
-                    true
-                    (concat contents)
-                    next-path
-                    (concat [[:span.mx-2 "•"]
-                             [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
-                              {:href (viewer/doc-url (remove-ext next-path))} "Next"]]))))))
-
-(defn notebook-viewer [opts]
-  (update viewer/notebook-viewer
+(def book-viewer
+  (update v/notebook-viewer
           :transform-fn (fn [original-transform]
                           (fn [wrapped-value]
-                            (let [opts (assoc opts :current-notebook (:file (viewer/->value wrapped-value)))]
-                              (-> wrapped-value
-                                  original-transform
-                                  (assoc :nextjournal/render-opts {:expandable-toc? true})
-                                  (assoc-in [:nextjournal/value :toc-visibility] true)
-                                  (assoc-in [:nextjournal/value :toc] (meta-toc opts))
-                                  (update-in [:nextjournal/value :header :nextjournal/value 1] update-header opts)))))))
+                            (-> wrapped-value
+                                original-transform
+                                (assoc :nextjournal/render-opts {:expandable-toc? true})
+                                (assoc-in [:nextjournal/value :toc]
+                                          (meta-toc (:file (v/->value wrapped-value)) notebooks)))))))
+
+(clerk/add-viewers! [book-viewer])
 
 (comment
   ;; Test actual cross-doc toc
-  (viewer/reset-viewers! :default (viewer/add-viewers [(notebook-viewer {:paths paths})]))
-  (reset! viewer/!viewers {})
+  (viewer/reset-viewers! :default (viewer/add-viewers [book-viewer]))
+  (viewer/reset-viewers! :default (viewer/get-default-viewers))
   (clerk/build! {:client-side-routing? true :paths paths}))

--- a/notebooks/meta_toc.clj
+++ b/notebooks/meta_toc.clj
@@ -48,4 +48,4 @@
   ;; Test actual cross-doc toc
   (viewer/reset-viewers! :default (viewer/add-viewers [book-viewer]))
   (viewer/reset-viewers! :default (viewer/get-default-viewers))
-  (clerk/build! {:client-side-routing? true :paths notebooks}))
+  (clerk/build! {:render-router :fetch-edn :paths notebooks}))

--- a/notebooks/meta_toc.clj
+++ b/notebooks/meta_toc.clj
@@ -48,4 +48,4 @@
   ;; Test actual cross-doc toc
   (viewer/reset-viewers! :default (viewer/add-viewers [book-viewer]))
   (viewer/reset-viewers! :default (viewer/get-default-viewers))
-  (clerk/build! {:client-side-routing? true :paths paths}))
+  (clerk/build! {:client-side-routing? true :paths notebooks}))

--- a/notebooks/meta_toc.clj
+++ b/notebooks/meta_toc.clj
@@ -153,4 +153,5 @@
 (comment
   ;; Test actual cross-doc toc
   (viewer/reset-viewers! :default (viewer/add-viewers [(notebook-viewer {:paths paths})]))
-  (reset! viewer/!viewers {}))
+  (reset! viewer/!viewers {})
+  (clerk/build! {:xhr? true :paths paths}))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -417,7 +417,7 @@
 
 (defn ^:private normalize-opts [opts]
   (set/rename-keys opts #_(into {} (map (juxt identity #(keyword (str (name %) "?")))) [:bundle :browse :dashboard])
-                   {:bundle :bundle?, :browse :browse?, :dashboard :dashboard? :compile-css :compile-css? :ssr :ssr? :exclude-js :exclude-js?}))
+                   {:bundle :bundle?, :browse :browse?, :dashboard :dashboard? :compile-css :compile-css? :ssr :ssr? :exclude-js :exclude-js? :client-side-routing :client-side-routing?}))
 
 (defn ^:private started-via-bb-cli? [opts]
   (contains? (meta opts) :org.babashka/cli))
@@ -491,12 +491,13 @@
   Passing at least one of the above is required. When both `:paths`
   and `:paths-fn` are given, `:paths` takes precendence.
 
-  - `:bundle`      - if true results in a single self-contained html file including inlined images
-  - `:compile-css` - if true compiles css file containing only the used classes
-  - `:ssr`         - if true runs react server-side-rendering and includes the generated markup in the html
-  - `:browse`      - if true will open browser with the built file on success
-  - `:dashboard`   - if true will start a server and show a rich build report in the browser (use with `:bundle` to open browser)
-  - `:out-path`  - a relative path to a folder to contain the static pages (defaults to `\"public/build\"`)
+  - `:bundle`              - if true results in a single self-contained html file including inlined images
+  - `:client-side-routing` - if true navigation across documents is handled by the client (the `:bundle` option must not be true for this to have effect)
+  - `:compile-css`         - if true compiles css file containing only the used classes
+  - `:ssr`                 - if true runs react server-side-rendering and includes the generated markup in the html
+  - `:browse`              - if true will open browser with the built file on success
+  - `:dashboard`           - if true will start a server and show a rich build report in the browser (use with `:bundle` to open browser)
+  - `:out-path`            - a relative path to a folder to contain the static pages (defaults to `\"public/build\"`)
   - `:git/sha`, `:git/url` - when both present, each page displays a link to `(str url \"blob\" sha path-to-notebook)`
   "
   {:org.babashka/cli {:spec {:paths {:desc "Paths to notebooks toc include in the build, supports glob patterns."
@@ -505,6 +506,7 @@
                                         :coerce :symbol}
                              :index {:desc "Override the name of the index file (default `index.clj|md`), will be added to paths."}
                              :bundle {:desc "Flag to build a self-contained html file inlcuding inlined images"}
+                             :client-side-routing {:desc "Flag to tell the client to handle navigation across document links. Has an effect only when the `:bundle` flag is not used."}
                              :browse {:desc "Opens the browser on boot when set."}
                              :dashboard {:desc "Flag to serve a dashboard with the build progress."}
                              :out-path {:desc "Path to an build output folder, defaults to \"public/build\"."}

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -437,7 +437,7 @@
 
   When both `:paths` and `:paths-fn` are given, `:paths` takes precendence.
 
-  Can be called multiple times and Clerk will happily serve you according to the latest config."
+  Can be called multiple times and Clerk will happily serve you according to the latest config."  
   {:org.babashka/cli {:spec {:watch-paths {:desc "Paths on which to watch for changes and show a changed document."
                                            :coerce []}
                              :paths {:desc "Restricts serving to the given paths, supports glob patterns. Will disable Clerk's homepage when set."
@@ -498,16 +498,12 @@
 
   Passing at least one of the above is required. When both `:paths` and `:paths-fn` are given, `:paths` takes precendence.
 
-  - `:bundle`              - if true results in a single self-contained html file including inlined images
-  - `:render-router`       - a keyword which determines how navigation among built notebooks behaves, possible values are:
-                               `:fetch-edn` when clicking a link, target document data is fetched and swapped when request
-                               completes. This is the only allowed value at the moment. By default, this setting is not
-                               enabled (no client-side routing is taking place).
-  - `:compile-css`         - if true compiles css file containing only the used classes
-  - `:ssr`                 - if true runs react server-side-rendering and includes the generated markup in the html
-  - `:browse`              - if true will open browser with the built file on success
-  - `:dashboard`           - if true will start a server and show a rich build report in the browser (use with `:bundle` to open browser)
-  - `:out-path`            - a relative path to a folder to contain the static pages (defaults to `\"public/build\"`)
+  - `:bundle`      - if true results in a single self-contained html file including inlined images
+  - `:compile-css` - if true compiles css file containing only the used classes
+  - `:ssr`         - if true runs react server-side-rendering and includes the generated markup in the html
+  - `:browse`      - if true will open browser with the built file on success
+  - `:dashboard`   - if true will start a server and show a rich build report in the browser (use with `:bundle` to open browser)
+  - `:out-path`    - a relative path to a folder to contain the static pages (defaults to `\"public/build\"`)
   - `:git/sha`, `:git/url` - when both present, each page displays a link to `(str url \"blob\" sha path-to-notebook)`
   "
   {:org.babashka/cli {:spec {:paths {:desc "Paths to notebooks toc include in the build, supports glob patterns."
@@ -516,9 +512,6 @@
                                         :coerce :symbol}
                              :index {:desc "Override the name of the index file (default `index.clj|md`), will be added to paths."}
                              :bundle {:desc "Flag to build a self-contained html file inlcuding inlined images"}
-                             :render-router {:desc "A keyword to select the routing mode"
-                                             :coerce :keyword
-                                             :validate #{:serve :bundle :fetch-edn}}
                              :browse {:desc "Opens the browser on boot when set."}
                              :dashboard {:desc "Flag to serve a dashboard with the build progress."}
                              :out-path {:desc "Path to an build output folder, defaults to \"public/build\"."}

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -417,7 +417,7 @@
 
 (defn ^:private normalize-opts [opts]
   (set/rename-keys opts #_(into {} (map (juxt identity #(keyword (str (name %) "?")))) [:bundle :browse :dashboard])
-                   {:bundle :bundle?, :browse :browse?, :dashboard :dashboard? :compile-css :compile-css? :ssr :ssr? :exclude-js :exclude-js? :client-side-routing :client-side-routing?}))
+                   {:bundle :bundle?, :browse :browse?, :dashboard :dashboard? :compile-css :compile-css? :ssr :ssr? :exclude-js :exclude-js?}))
 
 (defn ^:private started-via-bb-cli? [opts]
   (contains? (meta opts) :org.babashka/cli))
@@ -499,7 +499,10 @@
   Passing at least one of the above is required. When both `:paths` and `:paths-fn` are given, `:paths` takes precendence.
 
   - `:bundle`              - if true results in a single self-contained html file including inlined images
-  - `:client-side-routing` - if true navigation across document links is handled by the client (the `:bundle` flag must not be set for this to have effect)
+  - `:render-router`       - a keyword which determines how navigation among built notebooks behaves, possible values are:
+                               `:fetch-edn` when clicking a link, target document data is fetched and swapped when request
+                               completes. This is the only allowed value at the moment. By default, this setting is not
+                               enabled (no client-side routing is taking place).
   - `:compile-css`         - if true compiles css file containing only the used classes
   - `:ssr`                 - if true runs react server-side-rendering and includes the generated markup in the html
   - `:browse`              - if true will open browser with the built file on success
@@ -513,7 +516,9 @@
                                         :coerce :symbol}
                              :index {:desc "Override the name of the index file (default `index.clj|md`), will be added to paths."}
                              :bundle {:desc "Flag to build a self-contained html file inlcuding inlined images"}
-                             :client-side-routing {:desc "Flag to tell the client to handle navigation across document links. Has an effect only when the `:bundle` flag is not used."}
+                             :render-router {:desc "A keyword to select the routing mode"
+                                             :coerce :keyword
+                                             :validate #{:serve :bundle :fetch-edn}}
                              :browse {:desc "Opens the browser on boot when set."}
                              :dashboard {:desc "Flag to serve a dashboard with the build progress."}
                              :out-path {:desc "Path to an build output folder, defaults to \"public/build\"."}

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -346,12 +346,15 @@
                       :paths ["notebooks/hello.clj"
                               "notebooks/markdown.md"]})
 
-  (build-static-app! {:xhr? true
-                      :paths ["notebooks/meta_toc.clj"
-                              "notebooks/rule_30.clj"
-                              "notebooks/visibility.clj"
-                              "notebooks/viewer_api.clj"
-                              "notebooks/viewer_classes.clj"]})
+  (let [paths ["notebooks/meta_toc.clj"
+               "notebooks/rule_30.clj"
+               "notebooks/nested/cherry.clj"
+               "notebooks/viewer_api.clj"]]
+    (reset! viewer/!viewers {})
+    (viewer/reset-viewers! :default (viewer/add-viewers [(meta-toc/notebook-viewer {:paths paths})]))
+    (build-static-app! {:xhr? true
+                        :resource->url {"/js/viewer.js" "http://localhost:7777/js/viewer.js"}
+                        :paths paths}))
 
   (build-static-app! {;; test against cljs release `bb build:js`
                       :resource->url {"/js/viewer.js" "/viewer.js"}

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -345,17 +345,6 @@
                       :index "notebooks/rule_30.clj"
                       :paths ["notebooks/hello.clj"
                               "notebooks/markdown.md"]})
-
-  (let [paths ["notebooks/meta_toc.clj"
-               "notebooks/rule_30.clj"
-               "notebooks/nested/cherry.clj"
-               "notebooks/viewer_api.clj"]]
-    (reset! viewer/!viewers {})
-    (viewer/reset-viewers! :default (viewer/add-viewers [(meta-toc/notebook-viewer {:paths paths})]))
-    (build-static-app! {:xhr? true
-                        :resource->url {"/js/viewer.js" "http://localhost:7777/js/viewer.js"}
-                        :paths paths}))
-
   (build-static-app! {;; test against cljs release `bb build:js`
                       :resource->url {"/js/viewer.js" "/viewer.js"}
                       :paths ["notebooks/cherry.clj"]

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -197,7 +197,7 @@
         (let [out-html (fs/file out-path path "index.html")]
           (fs/create-dirs (fs/parent out-html))
           (when client-side-routing?
-            (spit (str (fs/path out-path (str (or (not-empty path) "index") ".edn")))
+            (spit (fs/file out-path (str (or (not-empty path) "index") ".edn"))
                   (viewer/->edn doc)))
           (spit out-html (view/->html (-> static-app-opts
                                           (assoc :path->doc (hash-map path doc) :current-path path)

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -180,11 +180,11 @@
 
 (defn cleanup [build-opts]
   (select-keys build-opts
-               [:bundle? :xhr? :path->doc :current-path :resource->url :exclude-js? :index :html]))
+               [:bundle? :client-side-routing? :path->doc :current-path :resource->url :exclude-js? :index :html]))
 
 (defn write-static-app!
   [opts docs]
-  (let [{:keys [bundle? xhr? out-path browse? ssr?]} opts
+  (let [{:keys [bundle? client-side-routing? out-path browse? ssr?]} opts
         index-html (str out-path fs/file-separator "index.html")
         {:as static-app-opts :keys [path->doc]} (build-static-app-opts opts docs)]
     (when-not (contains? (set (keys path->doc)) "")
@@ -196,7 +196,7 @@
       (doseq [[path doc] path->doc]
         (let [out-html (fs/file out-path path "index.html")]
           (fs/create-dirs (fs/parent out-html))
-          (when xhr?
+          (when client-side-routing?
             (spit (str (fs/path out-path (str (or (not-empty path) "index") ".edn")))
                   (viewer/->edn doc)))
           (spit out-html (view/->html (-> static-app-opts

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -757,12 +757,12 @@
         (-> (js/fetch edn-path)
             (.then (fn [r]
                      (if (.-ok r)
-                       (.then (.text r)
-                              (fn [edn]
-                                (set-state! {:doc (read-string edn)})
-                                (.pushState js/history #js {} "" (str path "/")))) ;; 👈 trailing slash is needed to make relative paths work
-                       (js/console.error "EDN not found" r))))
-            (.catch (fn [e] (js/console.log "Fetch failed" e ))))))))
+                       (.text r)
+                       (throw (ex-info "Not Found" {:response r})))))
+            (.then (fn [edn]
+                     (set-state! {:doc (read-string edn)})
+                     (.pushState js/history #js {} "" (str path "/")))) ;; 👈 trailing slash is needed to make relative paths work
+            (.catch (fn [e] (js/console.error "Fetch failed" e ))))))))
 
 (defn setup-router! [state]
   (when (and (exists? js/document) (exists? js/window))

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -770,16 +770,17 @@
     (doseq [listener (:listeners @!router)]
       (gevents/unlistenByKey listener))
     (reset! !router
-            (assoc state :listeners
-                   (case render-router
-                     :bundle
-                     [(gevents/listen js/window gevents/EventType.HASHCHANGE (partial handle-hashchange state) false)]
-                     :fetch-edn
-                     [(gevents/listen js/document gevents/EventType.CLICK click->xhr-request false)]
-                     :serve
-                     [(gevents/listen js/document gevents/EventType.CLICK handle-anchor-click false)
-                      (gevents/listen js/window gevents/EventType.POPSTATE handle-history-popstate false)
-                      (gevents/listen js/window gevents/EventType.LOAD handle-initial-load false)])))))
+            (when render-router
+              (assoc state :listeners
+                     (case render-router
+                       :bundle
+                       [(gevents/listen js/window gevents/EventType.HASHCHANGE (partial handle-hashchange state) false)]
+                       :fetch-edn
+                       [(gevents/listen js/document gevents/EventType.CLICK click->xhr-request false)]
+                       :serve
+                       [(gevents/listen js/document gevents/EventType.CLICK handle-anchor-click false)
+                        (gevents/listen js/window gevents/EventType.POPSTATE handle-history-popstate false)
+                        (gevents/listen js/window gevents/EventType.LOAD handle-initial-load false)]))))))
 
 
 (defn ^:export mount []
@@ -790,8 +791,8 @@
   (swap! !doc re-eval-viewer-fns)
   (mount))
 
-(defn ^:export init [{:as state :keys [bundle? path->doc render-router current-path]}]
-  (when render-router (setup-router! state))
+(defn ^:export init [{:as state :keys [bundle? path->doc current-path]}]
+  (setup-router! state)
   (set-state! (if (static-app? state)
                 {:doc (get path->doc (or (if bundle?
                                            (path-from-url-hash (->URL (.-href js/location)))

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -750,10 +750,7 @@
     (when-not (ignore-anchor-click? e url)
       (.preventDefault e)
       (let [path (.-pathname url)
-            edn-path (str path
-                          (when (str/ends-with? path "/") "index")
-                          ".edn")]
-        (js/console.log "pathname" path "path to EDN" edn-path)
+            edn-path (str path (when (str/ends-with? path "/") "index") ".edn")]
         (-> (js/fetch edn-path)
             (.then (fn [r]
                      (if (.-ok r)
@@ -761,7 +758,10 @@
                        (throw (ex-info "Not Found" {:response r})))))
             (.then (fn [edn]
                      (set-state! {:doc (read-string edn)})
-                     (.pushState js/history #js {} "" (str path "/")))) ;; 👈 trailing slash is needed to make relative paths work
+                     (.pushState js/history #js {} ""
+                                 (cond-> path
+                                   (not (str/ends-with? path "/"))
+                                   (str "/"))))) ;; trailing slash is needed to make relative paths work
             (.catch (fn [e] (js/console.error "Fetch failed" e ))))))))
 
 (defn setup-router! [state]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -772,7 +772,7 @@
             (assoc state :listeners
                    (cond (and (static-app? state) (:bundle? state))
                          [(gevents/listen js/window gevents/EventType.HASHCHANGE (partial handle-hashchange state) false)]
-                         (and (static-app? state) (:xhr? state))
+                         (and (static-app? state) (:client-side-routing? state))
                          [(gevents/listen js/document gevents/EventType.CLICK click->xhr-request false)]
                          (not (static-app? state))
                          [(gevents/listen js/document gevents/EventType.CLICK handle-anchor-click false)

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -270,6 +270,7 @@
            :headers {"Content-Type" "text/html" "Cache-Control" "no-store"}
            :body (view/->html {:doc (view/doc->viewer @!doc)
                                :resource->url @config/!resource->url
+                               :render-router :serve
                                :conn-ws? true})})
         {:status 404
          :headers {"Content-Type" "text/plain"}

--- a/test/nextjournal/clerk/builder_test.clj
+++ b/test/nextjournal/clerk/builder_test.clj
@@ -44,8 +44,13 @@
            (:index (builder/process-build-opts {:paths ["notebooks/rule_30.clj"] :expand-paths? true})))))
 
   (testing "coerces index symbol arg and adds it to expanded-paths"
-    (is (= ["book.clj"] (:expanded-paths (builder/process-build-opts {:index 'book.clj :expand-paths? true}))))))
+    (is (= ["book.clj"] (:expanded-paths (builder/process-build-opts {:index 'book.clj :expand-paths? true})))))
 
+  (testing "conform render-router options"
+    (is (= :bundle (:render-router (builder/process-build-opts {:bundle? true}))))
+    (is (= :fetch-edn (:render-router (builder/process-build-opts {:render-router :fetch-edn}))))
+    (is (thrown? clojure.lang.ExceptionInfo (builder/process-build-opts {:bundle? true :render-router :fetch-edn})))
+    (is (thrown? clojure.lang.ExceptionInfo (builder/process-build-opts {:render-router :foo})))))
 
 (deftest doc-url
   (testing "link to same dir unbundled"


### PR DESCRIPTION
Add an experimental `:render-router` option (name subject to change) to  `clerk/build!` with an (also experimental) `:fetch-edn` option. When set, it will bring in a client-side router to request edn files and swap out the body, instead of doing slower full-page reloads.