### PR TITLE
Redesign Examples viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Changes can be:
 
 * 💫 Support using Markdown syntax in `clerk/caption` text
 
+* 💫 Redesign examples viewer to be more readable and in a way that doesn't force `display: flex` onto contents.
+
 * 🛠 Bump depdendencies
 
   * `com.taoensso/nippy` to `3.4.0-beta1`

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1860,12 +1860,10 @@
                    (-> wrapped-value
                        mark-preserve-keys
                        (assoc :nextjournal/viewer {:render-fn '(fn [{:keys [form val]} opts]
-                                                                 [:div.flex.flex-wrap
-                                                                  {:class "py-[7px]"}
-                                                                  [:div [:div.bg-slate-100.px-2.rounded
-                                                                         (nextjournal.clerk.render/inspect-presented opts form)]]
-                                                                  [:div.flex.mt-1
-                                                                   [:div.mx-2.font-sans.text-xs.text-slate-500 {:class "mt-[2px]"} "⇒"]
+                                                                 [:div.mb-3.last:mb-0
+                                                                  [:div.bg-slate-100.dark:bg-slate-800.px-4.py-2.border-l-2.border-slate-200.dark:border-slate-700
+                                                                   (nextjournal.clerk.render/inspect-presented opts form)]
+                                                                  [:div.pt-2.px-4.border-l-2.border-transparent
                                                                    (nextjournal.clerk.render/inspect-presented opts val)]])})
                        (update-in [:nextjournal/value :form] code)))})
 
@@ -1873,6 +1871,7 @@
   {:transform-fn (update-val (fn [examples]
                                (mapv (partial with-viewer example-viewer) examples)))
    :render-fn '(fn [examples opts]
-                 (into [:div.border-l-2.border-slate-300.pl-4
-                        [:div.uppercase.tracking-wider.text-xs.font-sans.text-slate-500.mt-4.mb-2 "Examples"]]
-                       (nextjournal.clerk.render/inspect-children opts) examples))})
+                 [:div
+                  [:div.uppercase.tracking-wider.text-xs.font-sans.font-bold.text-slate-500.dark:text-white.mb-2.mt-3 "Examples"]
+                  (into [:div]
+                        (nextjournal.clerk.render/inspect-children opts) examples)])})


### PR DESCRIPTION
I’ve had my fair share of annoyances with the examples viewer lately. Mostly with it forcing `display: flex` onto the rendered contents, messing with using `clerk/html`. Also, more often than not, I’m dealing with wider example results making the `[code] ⇒ [result]` layout more annoying than helpful. Here's a redesign that tries to deal with it in a block-based layout while still looking succinctly different to the code-viewer.

![CleanShot 2023-12-05 at 10 49 35@2x](https://github.com/nextjournal/clerk/assets/1944/f2c77d7e-4218-4dc6-9a8a-0c1b69262500)

![CleanShot 2023-12-05 at 10 49 40@2x](https://github.com/nextjournal/clerk/assets/1944/d92d7dae-1eba-48d4-bc6a-319959eef420)
