### PR TITLE
Fix page-size option throwing when set on strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Changes can be:
 
 * 🐜 Make edn transmission resilient to symbols and keywords containing multiple slashes like `foo/bar/baz`. Those can be read by `read-string` but not in ClojureScript which is based on `tools.reader`.
 
+* 🐞 Fix `:nextjournal.clerk/page-size` option throwing when set on string values, fixes [#584][https://github.com/nextjournal/clerk/issues/584]
+
 * 🐞 Fix caching behaviour of `clerk/image` and support overriding image-viewer by name
 
 * 🐞 Fix `unquote` in experimental cljs Clerk editor, fixes [#576](https://github.com/nextjournal/clerk/issues/576) @sritchie

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1519,9 +1519,6 @@
 #_(get-elision (present "abc"))
 #_(get-elision (present (str/join (repeat 1000 "abc"))))
 
-(defn get-fetch-opts-n [wrapped-value]
-  (-> wrapped-value ->fetch-opts :n))
-
 (defn present+paginate-children [{:as wrapped-value :nextjournal/keys [budget viewers preserve-keys?] :keys [!budget]}]
   (let [{:as fetch-opts :keys [offset n]} (->fetch-opts wrapped-value)
         xs (->value wrapped-value)
@@ -1544,9 +1541,9 @@
               (make-elision viewers fetch-opts))))))
 
 (defn present+paginate-string [{:as wrapped-value :nextjournal/keys [viewers viewer value]}]
-  (let [{:as elision :keys [n total path offset]} (and (:page-size viewer)
-                                                       (get-elision wrapped-value))]
-    (if (and n (< n total))
+  (let [paginate? (number? (-> wrapped-value ->fetch-opts :n))
+        {:as elision :keys [n total path offset]} (when paginate? (get-elision wrapped-value))]
+    (if (and paginate? n (< n total))
       (let [new-offset (min (+ (or offset 0) n) total)]
         (cond-> [(subs value (or offset 0) new-offset)]
           (pos? (- total new-offset)) (conj (let [fetch-opts (-> elision

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1541,9 +1541,9 @@
               (make-elision viewers fetch-opts))))))
 
 (defn present+paginate-string [{:as wrapped-value :nextjournal/keys [viewers viewer value]}]
-  (let [paginate? (number? (-> wrapped-value ->fetch-opts :n))
-        {:as elision :keys [n total path offset]} (when paginate? (get-elision wrapped-value))]
-    (if (and paginate? n (< n total))
+  (let [{:as elision :keys [n total path offset]} (when (number? (-> wrapped-value ->fetch-opts :n))
+                                                    (get-elision wrapped-value))]
+    (if (and elision n (< n total))
       (let [new-offset (min (+ (or offset 0) n) total)]
         (cond-> [(subs value (or offset 0) new-offset)]
           (pos? (- total new-offset)) (conj (let [fetch-opts (-> elision

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1513,7 +1513,8 @@
 
 (defn get-elision [wrapped-value]
   (let [{:as fetch-opts :keys [n]} (->fetch-opts wrapped-value)]
-    (merge fetch-opts (bounded-count-opts n (->value wrapped-value)))))
+    (when (number? n)
+      (merge fetch-opts (bounded-count-opts n (->value wrapped-value))))))
 
 #_(get-elision (present (range)))
 #_(get-elision (present "abc"))
@@ -1540,9 +1541,8 @@
       (conj (let [fetch-opts (assoc elision :offset new-offset)]
               (make-elision viewers fetch-opts))))))
 
-(defn present+paginate-string [{:as wrapped-value :nextjournal/keys [viewers viewer value]}]
-  (let [{:as elision :keys [n total path offset]} (when (number? (-> wrapped-value ->fetch-opts :n))
-                                                    (get-elision wrapped-value))]
+(defn present+paginate-string [{:as wrapped-value :nextjournal/keys [viewers value]}]
+  (let [{:as elision :keys [n total path offset]} (get-elision wrapped-value)]
     (if (and elision n (< n total))
       (let [new-offset (min (+ (or offset 0) n) total)]
         (cond-> [(subs value (or offset 0) new-offset)]

--- a/test/nextjournal/clerk/eval_test.clj
+++ b/test/nextjournal/clerk/eval_test.clj
@@ -180,6 +180,11 @@
                                       :nextjournal/hash string?}}]
                 (eval+extract-doc-blocks "(range)"))))
 
+  (testing "Skipping pagination for strings"
+    (is (= "012345678910111213141516171819202122232425262728293031323334353637383940414243444546474849"
+           (-> (eval+extract-doc-blocks "^{:nextjournal.clerk/page-size nil} (apply str (range 50))")
+               second :nextjournal/value :nextjournal/presented :nextjournal/value))))
+
   (testing "assigns folded visibility"
     (is (match? [{:nextjournal/viewer {:name `viewer/folded-code-block-viewer}
                   :nextjournal/value "{:some :map}"}
@@ -240,4 +245,3 @@
              (catch Exception _ nil))
         (clerk/show! (java.io.StringReader. code))
         (is (= result-first-run (get-result)))))))
-


### PR DESCRIPTION
 Fix `:nextjournal.clerk/page-size` option throwing when set on string values.

Fixes #584.