### PR TITLE
Ensure ex-data is always inspectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Changes can be:
   * `com.taoensso/nippy` to `3.4.0-beta1`
   * `io.github.nextjournal/markdown` to `0.5.146`
 
+* 🐜 Fix blank screen caused by react unmounting when an exception occurs during `clerk/show!`, fixes [#586](https://github.com/nextjournal/clerk/issues/586) @elken
+
 * 🐜 Make edn transmission resilient to symbols and keywords containing multiple slashes like `foo/bar/baz`. Those can be read by `read-string` but not in ClojureScript which is based on `tools.reader`.
 
 * 🐞 Fix caching behaviour of `clerk/image` and support overriding image-viewer by name

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -71,7 +71,7 @@
              {:keys [result time-ms]} (try (eval/time-ms (binding [paths/*build-opts* (webserver/get-build-opts)]
                                                            (eval/+eval-results blob->result (assoc doc :set-status-fn webserver/set-status!))))
                                            (catch Exception e
-                                             (throw (ex-info (str "`nextjournal.clerk/show!` encountered an eval error with: `" (pr-str file-or-ns) "`") {::doc (assoc doc :blob->result blob->result)} e))))]
+                                             (throw (ex-info (str "`nextjournal.clerk/show!` encountered an eval error with: `" (pr-str file-or-ns) "`") {::doc doc} e))))]
          (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
          (webserver/update-doc! result))
        (catch Exception e

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -71,7 +71,7 @@
              {:keys [result time-ms]} (try (eval/time-ms (binding [paths/*build-opts* (webserver/get-build-opts)]
                                                            (eval/+eval-results blob->result (assoc doc :set-status-fn webserver/set-status!))))
                                            (catch Exception e
-                                             (throw (ex-info (str "`nextjournal.clerk/show!` encountered an eval error with: `" (pr-str file-or-ns) "`") {::doc doc} e))))]
+                                             (throw (ex-info (str "`nextjournal.clerk/show!` encountered an eval error with: `" (pr-str file-or-ns) "`") {::doc (assoc doc :blob->result blob->result)} e))))]
          (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
          (webserver/update-doc! result))
        (catch Exception e

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -484,8 +484,7 @@
           [:div.font-bold "Unhandled " type])
         [:div.font-bold.mt-1 message]
         (when data
-          [:> ErrorBoundary
-           [:div.mt-1 [inspect data]]])])
+          [:div.mt-1 [inspect (viewer/inspect-wrapped-values data)]])])
      via))
    [:div.py-6.overflow-x-auto
     [:table.w-full

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -484,7 +484,8 @@
           [:div.font-bold "Unhandled " type])
         [:div.font-bold.mt-1 message]
         (when data
-          [:div.mt-1 [inspect data]])])
+          [:> ErrorBoundary
+           [:div.mt-1 [inspect data]]])])
      via))
    [:div.py-6.overflow-x-auto
     [:table.w-full

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -871,7 +871,6 @@
    :render-fn 'nextjournal.clerk.render/render-throwable
    :pred (fn [e] (instance? #?(:clj Throwable :cljs js/Error) e))
    :transform-fn (comp mark-presented (update-val (comp demunge-ex-data
-                                                        #(update % :via (partial mapv (fn [via] (update-in via [:data :nextjournal.clerk/doc] dissoc :blob->result))))
                                                         datafy/datafy)))})
 
 (def image-viewer

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -869,7 +869,9 @@
   {:name `throwable-viewer
    :render-fn 'nextjournal.clerk.render/render-throwable
    :pred (fn [e] (instance? #?(:clj Throwable :cljs js/Error) e))
-   :transform-fn (comp mark-presented (update-val (comp demunge-ex-data datafy/datafy)))})
+   :transform-fn (comp mark-presented (update-val (comp demunge-ex-data
+                                                        #(update % :via (partial mapv (fn [via] (update-in via [:data :nextjournal.clerk/doc] dissoc :blob->result))))
+                                                        datafy/datafy)))})
 
 (def image-viewer
   {#?@(:clj [:pred #(instance? BufferedImage %)

--- a/test/nextjournal/clerk/eval_test.clj
+++ b/test/nextjournal/clerk/eval_test.clj
@@ -240,4 +240,3 @@
              (catch Exception _ nil))
         (clerk/show! (java.io.StringReader. code))
         (is (= result-first-run (get-result)))))))
-

--- a/test/nextjournal/clerk/parser_test.clj
+++ b/test/nextjournal/clerk/parser_test.clj
@@ -3,7 +3,8 @@
             [matcher-combinators.matchers :as m]
             [matcher-combinators.test :refer [match?]]
             [nextjournal.clerk.analyzer-test :refer [analyze-string]]
-            [nextjournal.clerk.parser :as parser]))
+            [nextjournal.clerk.parser :as parser]
+            [nextjournal.clerk.view :as view]))
 
 (defmacro with-ns-binding [ns-sym & body]
   `(binding [*ns* (find-ns ~ns-sym)]
@@ -156,3 +157,13 @@ par two"))))
   (testing "unreadable forms"
     (is (= (parser/text-with-clerk-metadata-removed "^{:un :balanced :map} (do nothing)" clerk-ns-alias)
            "^{:un :balanced :map} (do nothing)"))))
+
+(deftest presenting-a-parsed-document
+  (testing "presenting a parsed document doesn't produce garbage"
+    (is (match? [{:nextjournal/viewer {:name 'nextjournal.clerk.viewer/code-block-viewer}}
+                 {:nextjournal/viewer {:name 'nextjournal.clerk.viewer/code-block-viewer}}
+                 {:nextjournal/viewer {:name 'nextjournal.clerk.viewer/code-block-viewer}}]
+                (-> (parser/parse-clojure-string {:doc? true} "(ns testing-presented-parsed) 123 :ahoi")
+                    view/doc->viewer
+                    :nextjournal/value
+                    :blocks)))))


### PR DESCRIPTION
Fix blank screen caused by react unmounting when an exception occurs during `clerk/show!`. Also make parsed (but not evaluated) documents representable.

Fix #586.