### PR TITLE
Make edn transmission resilient to symbols and keywords with more than one slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Changes can be:
   * `com.taoensso/nippy` to `3.4.0-beta1`
   * `io.github.nextjournal/markdown` to `0.5.146`
 
+* 🐜 Make edn transmission resilient to symbols and keywords containing multiple slashes like `foo/bar/baz`. Those can be read by `read-string` but not in ClojureScript which is based on `tools.reader`.
+
 * 🐞 Fix caching behaviour of `clerk/image` and support overriding image-viewer by name
 
 * 🐞 Fix `unquote` in experimental cljs Clerk editor, fixes [#576](https://github.com/nextjournal/clerk/issues/576) @sritchie

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -386,6 +386,12 @@
     (is (= "#viewer-eval (symbol \"~\")"
            (pr-str (symbol "~")))))
 
+  (testing "symbols and keywords with two slashes readable by `read-string` but not `tools.reader/read-string` print as viewer-eval"
+    (is (= "#viewer-eval (symbol \"foo\" \"bar/baz\")"
+           (pr-str (read-string "foo/bar/baz"))))
+    (is (= "#viewer-eval (keyword \"foo\" \"bar/baz\")"
+           (pr-str (read-string ":foo/bar/baz")))))
+
   (testing "splicing reader conditional prints normally (issue #338)"
     (is (= "?@" (pr-str (symbol "?@")))))
 


### PR DESCRIPTION
Symbols and keywords with more than one slash like `foo/bar/baz` can be read by `read-string` but not in ClojureScript which is based on `tools.reader`. This changes the `roundtrippable?` check to read using tools.reader to ensure a symbol will be tagged as a string in case it's not readable, fixing a read exception that could occur when reading in the browser.