### PR TITLE
Static Build: new `:package` option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,7 @@ jobs:
           clojure -J-Dclojure.main.report=stderr -X:demo:nextjournal/clerk :git/sha '"${{ github.sha }}"' :git/url '"https://github.com/nextjournal/clerk"' :paths '["book.clj" "CHANGELOG.md" "editor.clj"]'
 
       - name: 🏗 Build Clerk Static App with default Notebooks
-        run: clojure -J-Dclojure.main.report=stderr -X:demo:nextjournal/clerk :git/sha '"${{ github.sha }}"' :git/url '"https://github.com/nextjournal/clerk"' :bundle true
+        run: clojure -J-Dclojure.main.report=stderr -X:demo:nextjournal/clerk :git/sha '"${{ github.sha }}"' :git/url '"https://github.com/nextjournal/clerk"' :package :single-file
 
       - name: 📠 Copy book & static build to bucket under SHA
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Changes can be:
 
 * 💫 Redesign examples viewer to be more readable and in a way that doesn't force `display: flex` onto contents.
 
+* 💫 Introduce client-side routing for static builds to make page transitions smoother by default. In addition, the option `:bundle?` for `clerk/build!` is now deprecated in favour of setting a new option `:package` to `:single-file` (the default for it being `:directory`).
+
 * 🛠 Bump depdendencies
 
   * `com.taoensso/nippy` to `3.4.0-beta1`

--- a/notebooks/document_linking.clj
+++ b/notebooks/document_linking.clj
@@ -1,6 +1,7 @@
 ;; # 🖇️ Document Linking
 (ns document-linking
-  {:nextjournal.clerk/toc true}
+  {:nextjournal.clerk/no-cache true
+   :nextjournal.clerk/toc true}
   (:require [nextjournal.clerk :as clerk]))
 
 ;; ## `clerk/doc-url` helper

--- a/notebooks/links.md
+++ b/notebooks/links.md
@@ -9,14 +9,14 @@
 We have three different modes to consider for links:
 
 1. Interactive mode `serve!`
-2. Static build unbundled `(build! {:bundle false})`
-3. Static build bundled `(build! {:bundle true})`
+2. Static build `(build! {:package :directory})`
+3. Static build single-file `(build! {:package :single-file})`
 
 The behaviour when triggering links we want is:
 
 1. Interactive mode: trigger a js event `(clerk-eval 'nextjournal.clerk.webserver/navigate! ,,,)`, the doc will in turn be updated via the websocket
-2. Static build unbundled: not intercept the link, let the browser perform its normal navigation
-3. Static build bundled: trigger a js event to update the doc, update the browser's hash so the doc state is persisted on reload
+2. Static build: not intercept the link, let the browser perform its normal navigation
+3. Static build single-file: trigger a js event to update the doc, update the browser's hash so the doc state is persisted on reload
 
 We can allow folks to write normal (relative) links. The limitations here being that things like open in new tab would not work and we can't support a routing function. Both these limitations means we probably want to continue encouraging the use of a helper like `clerk/doc-url` going forward.
 
@@ -64,4 +64,3 @@ Links should work inside markdown as well.
 
 * [HTML](../notebooks/viewers/html) (relative link)
 * [HTML](clerk/doc-url,"notebooks/viewers/html") (doc url, currently not functional)
-

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -424,8 +424,7 @@
 
 (defn ^:private normalize-opts [opts]
   (deprecate+migrate-opts
-   (set/rename-keys opts #_(into {} (map (juxt identity #(keyword (str (name %) "?")))) [:bundle :browse :dashboard])
-                    {:bundle :bundle?, :browse :browse?, :dashboard :dashboard? :compile-css :compile-css? :ssr :ssr? :exclude-js :exclude-js?})))
+   (set/rename-keys opts {:bundle :bundle?, :browse :browse?, :dashboard :dashboard? :compile-css :compile-css? :ssr :ssr? :exclude-js :exclude-js?})))
 
 (defn ^:private started-via-bb-cli? [opts]
   (contains? (meta opts) :org.babashka/cli))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -417,7 +417,7 @@
 
 (defn deprecate+migrate-opts [{:as opts :keys [bundle?]}]
   (when (contains? opts :bundle?)
-    (println "The `:bundle(?)` option is deprecated and will be dropped in 1.0.0. Use `:package :single-file` instead."))
+    (println "\nThe `:bundle(?)` option is deprecated and will be dropped in 1.0.0. Use `:package :single-file` instead.\n"))
   (-> opts (dissoc :bundle?)
       (cond-> bundle?
         (assoc :package :single-page))))

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -360,8 +360,12 @@
                       :resource->url {"/js/viewer.js" "/viewer.js"}
                       :paths ["notebooks/cherry.clj"]
                       :out-path "build"})
-  (build-static-app! {:paths ["CHANGELOG.md"
+
+  ;; test doc-url links
+  (build-static-app! {:index "notebooks/document_linking.clj"
+                      :paths ["CHANGELOG.md"
                               "notebooks/markdown.md"
-                              "notebooks/viewers/html.clj"]
+                              "notebooks/viewers/html.clj"
+                              "notebooks/viewers/image.clj"]
                       :git/sha "d60f5417"
                       :git/url "https://github.com/nextjournal/clerk"}))

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -201,7 +201,8 @@
           (spit (fs/file out-path (str (or (not-empty path) "index") ".edn"))
                 (viewer/->edn doc))
           (spit out-html (view/->html (-> static-app-opts
-                                          (assoc :path->doc (hash-map path doc) :current-path path)
+                                          (dissoc :path->doc)
+                                          (assoc :current-path path)
                                           (cond-> ssr? ssr!)
                                           cleanup))))))
     (when browse?

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -294,7 +294,6 @@
                                                                             viewer/doc-url (partial doc-url opts file)]
                                                                     (let [doc (eval/eval-analyzed-doc doc)]
                                                                       (assoc doc :viewer (view/doc->viewer (assoc opts
-                                                                                                                  :static-build? true
                                                                                                                   :nav-path (if (instance? java.net.URL file)
                                                                                                                               (str "'" (:ns doc))
                                                                                                                               (str file)))

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -129,18 +129,10 @@
 (def builtin-index
   (io/resource "nextjournal/clerk/index.clj"))
 
-(defn validate-render-router! [{:as opts :keys [render-router bundle?]}]
-  (if bundle?
-    (when (not= render-router :bundle)
-      (throw (ex-info "Incompatible options: `:bundle?` implies `:render-router` is `:bundle`." {:opts opts})))
-    (when (not= render-router :fetch-edn)
-      (throw (ex-info "Only `:fetch-edn` value is currently allowed for the `:render-router` mode. A value of `:bundle` is currently implied by the `:bundle?` option." {:opts opts})))))
-
-(defn process-build-opts [{:as opts :keys [paths index expand-paths? render-router bundle?]}]
-  (when render-router
-    (validate-render-router! opts))
+(defn process-build-opts [{:as opts :keys [package index expand-paths?]}]
   (merge {:out-path default-out-path
-          :bundle? false
+          :package :directory
+          :render-router :fetch-edn
           :browse? false
           :report-fn (if @webserver/!server build-ui-reporter stdout-reporter)}
          (let [opts+index (cond-> opts
@@ -150,7 +142,7 @@
            (-> opts'
                (update :resource->url #(merge {} %2 %1) @config/!resource->url)
                (cond-> #_opts'
-                 (and bundle? (not render-router))
+                 (= :single-file package)
                  (assoc :render-router :bundle)
                  expand-paths?
                  (dissoc :expand-paths?)
@@ -163,10 +155,9 @@
 #_(process-build-opts {:paths ["notebooks/rule_30.clj"
                                "notebooks/markdown.md"] :expand-paths? true})
 
-(defn build-static-app-opts [{:as opts :keys [bundle? out-path browse? index]} docs]
+(defn build-static-app-opts [opts docs]
   (let [path->doc (into {} (map (juxt (comp str fs/strip-ext strip-index (partial viewer/map-index opts) :file) :viewer)) docs)]
     (assoc opts
-           :bundle? bundle?
            :path->doc path->doc
            :paths (vec (keys path->doc)))))
 
@@ -191,25 +182,24 @@
 
 (defn cleanup [build-opts]
   (select-keys build-opts
-               [:bundle? :render-router :path->doc :current-path :resource->url :exclude-js? :index :html]))
+               [:package :render-router :path->doc :current-path :resource->url :exclude-js? :index :html]))
 
 (defn write-static-app!
   [opts docs]
-  (let [{:keys [bundle? render-router out-path browse? ssr?]} opts
+  (let [{:keys [package out-path browse? ssr?]} opts
         index-html (str out-path fs/file-separator "index.html")
         {:as static-app-opts :keys [path->doc]} (build-static-app-opts opts docs)]
     (when-not (contains? (set (keys path->doc)) "")
       (throw (ex-info "Index must have been processed at this point" {:static-app-opts static-app-opts})))
     (when-not (fs/exists? (fs/parent index-html))
       (fs/create-dirs (fs/parent index-html)))
-    (if bundle?
+    (if (= :single-file package)
       (spit index-html (view/->html (cleanup static-app-opts)))
       (doseq [[path doc] path->doc]
         (let [out-html (fs/file out-path path "index.html")]
           (fs/create-dirs (fs/parent out-html))
-          (when (= :fetch-edn render-router)
-            (spit (fs/file out-path (str (or (not-empty path) "index") ".edn"))
-                  (viewer/->edn doc)))
+          (spit (fs/file out-path (str (or (not-empty path) "index") ".edn"))
+                (viewer/->edn doc))
           (spit out-html (view/->html (-> static-app-opts
                                           (assoc :path->doc (hash-map path doc) :current-path path)
                                           (cond-> ssr? ssr!)
@@ -262,14 +252,14 @@
 
 (defn doc-url
   ([opts file path] (doc-url opts file path nil))
-  ([opts file path fragment]
-   (if (:bundle? opts)
+  ([{:as opts :keys [package]} file path fragment]
+   (if (= :single-file package)
      (cond-> (str "#/" path)
        fragment (str ":" fragment))
      (str (viewer/relative-root-prefix-from (viewer/map-index opts file)) path
           (when fragment (str "#" fragment))))))
 
-(defn build-static-app! [{:as opts :keys [bundle?]}]
+(defn build-static-app! [opts]
   (let [{:as opts :keys [download-cache-fn upload-cache-fn report-fn compile-css? expanded-paths error]}
         (process-build-opts (assoc opts :expand-paths? true))
         start (System/nanoTime)
@@ -330,24 +320,21 @@
     (report-fn {:stage :finished :state state :duration duration :total-duration (eval/elapsed-ms start)})))
 
 (comment
-  (build-static-app! {:paths clerk-docs :bundle? true})
+  (build-static-app! {:paths clerk-docs :package :single-file})
   (build-static-app! {:paths ["notebooks/editor.clj"] :browse? true})
   (build-static-app! {:paths ["CHANGELOG.md" "notebooks/editor.clj"] :browse? true})
-  (build-static-app! {:paths ["index.clj" "notebooks/links.md" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true :browse? true})
-  (build-static-app! {:paths ["notebooks/links.md" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? true :browse? true})
-  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :bundle? false :browse? true})
+  (build-static-app! {:paths ["index.clj" "notebooks/links.md" "notebooks/rule_30.clj" "notebooks/markdown.md"] :browse? true})
+  (build-static-app! {:paths ["notebooks/links.md" "notebooks/rule_30.clj" "notebooks/markdown.md"] :package :single-file})
+  (build-static-app! {:paths ["index.clj" "notebooks/rule_30.clj" "notebooks/markdown.md"] :browse? true})
   (build-static-app! {:paths ["notebooks/viewers/**"]})
   (build-static-app! {:index "notebooks/rule_30.clj" :git/sha "bd85a3de12d34a0622eb5b94d82c9e73b95412d1" :git/url "https://github.com/nextjournal/clerk"})
   (reset! config/!resource->url @config/!asset-map)
   (swap! config/!resource->url dissoc "/css/viewer.css")
 
-  (build-static-app! {:bundle? true
-                      :render-router :bundle
-                      :browse true
+  (build-static-app! {:browse true
                       :index "notebooks/rule_30.clj"})
 
-  (build-static-app! {:render-router :fetch-edn
-                      :index "notebooks/document_linking.clj"
+  (build-static-app! {:index "notebooks/document_linking.clj"
                       :paths ["notebooks/viewers/html.clj" "notebooks/rule_30.clj"]})
 
   (build-static-app! {:ssr? true
@@ -361,7 +348,10 @@
                       ;; test against cljs release `bb build:js`
                       :resource->url {"/js/viewer.js" "./build/viewer.js"}
                       :index "notebooks/rule_30.clj"})
+
   (fs/delete-tree "public/build")
+  (print (:out (sh "tree public/build")))
+
   (build-static-app! {:compile-css? true
                       :index "notebooks/rule_30.clj"
                       :paths ["notebooks/hello.clj"
@@ -373,6 +363,5 @@
   (build-static-app! {:paths ["CHANGELOG.md"
                               "notebooks/markdown.md"
                               "notebooks/viewers/html.clj"]
-                      :bundle? true
                       :git/sha "d60f5417"
                       :git/url "https://github.com/nextjournal/clerk"}))

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -745,7 +745,6 @@
   (history-push-state {:path (subs js/location.pathname 1) :replace? true}))
 
 (defn fetch+set-state [edn-path]
-  (js/console.log "fetch" edn-path)
   (.. ^js (js/fetch edn-path)
       (then (fn [r]
                (if (.-ok r)

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -781,11 +781,8 @@
     (.pushState js/history #js {:edn_path edn-path} "" nil)))
 
 (defn popstate->fetch [^js e]
-  (js/console.log "popstate" (.. e -state)
-                  "edn-path" (.. e -state -edn_path))
   (when-some [edn-path (.. e -state -edn_path)]
     (.preventDefault e)
-    (js/console.log "fetching" )
     (fetch+set-state edn-path)))
 
 (defn setup-router! [{:as state :keys [render-router]}]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -107,12 +107,12 @@
 
 (declare clerk-eval)
 
-(defn render-notebook [{:as doc xs :blocks :keys [bundle? doc-css-class sidenotes? toc toc-visibility header footer]}
+(defn render-notebook [{:as doc xs :blocks :keys [package doc-css-class sidenotes? toc toc-visibility header footer]}
                        {:as render-opts :keys [!expanded-at expandable-toc?]}]
   (r/with-let [root-ref-fn (fn [el]
                              (when (and el (exists? js/document))
                                (code/setup-dark-mode!)
-                               (when-some [heading (when (and (exists? js/location) (not bundle?))
+                               (when-some [heading (when (and (exists? js/location) (= :directory package))
                                                      (try (some-> js/location .-hash not-empty js/decodeURI (subs 1) js/document.getElementById)
                                                           (catch js/Error _
                                                             (js/console.warn (str "Clerk render-notebook, invalid hash: "
@@ -124,7 +124,7 @@
      [:div.fixed.top-2.left-2.md:left-auto.md:right-2.z-10
       [dark-mode-toggle]]
      (when (and toc toc-visibility)
-       [navbar/view toc (assoc render-opts :set-hash? (not bundle?) :toc-visibility toc-visibility)])
+       [navbar/view toc (assoc render-opts :set-hash? (= :directory package) :toc-visibility toc-visibility)])
      [:div.flex-auto.w-screen.scroll-container
       (into
        [:> (.-div motion)
@@ -791,10 +791,10 @@
   (swap! !doc re-eval-viewer-fns)
   (mount))
 
-(defn ^:export init [{:as state :keys [bundle? path->doc current-path]}]
+(defn ^:export init [{:as state :keys [package path->doc current-path]}]
   (setup-router! state)
   (set-state! (if (static-app? state)
-                {:doc (get path->doc (or (if bundle?
+                {:doc (get path->doc (or (if (= :single-file package)
                                            (path-from-url-hash (->URL (.-href js/location)))
                                            current-path)
                                          ""))}

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -763,7 +763,7 @@
         (.. (fetch+set-state edn-path)
             (then (fn [{:keys [ok]}]
                     (when ok
-                      (.pushState js/history #js {:ednPath edn-path} ""
+                      (.pushState js/history #js {:edn_path edn-path} ""
                                   (cond-> path
                                     (not (str/ends-with? path "/"))
                                     (str "/")))))))))))     ;; a trailing slash is needed to make relative paths work
@@ -778,11 +778,12 @@
                        (seq current-path)
                        (str ".edn")))]
     (fetch+set-state edn-path)
-    (.pushState js/history #js {:ednPath edn-path} "" nil)))
+    (.pushState js/history #js {:edn_path edn-path} "" nil)))
 
 (defn popstate->fetch [^js e]
-  (js/console.log "popstate" (.-state e) "edn-path" (some-> e .-state .-ednPath))
-  (when-some [edn-path (some-> e .-state .-ednPath)]
+  (js/console.log "popstate" (.. e -state)
+                  "edn-path" (.. e -state -edn_path))
+  (when-some [edn-path (.. e -state -edn_path)]
     (.preventDefault e)
     (js/console.log "fetching" )
     (fetch+set-state edn-path)))

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -780,8 +780,9 @@
     (fetch+set-state edn-path)
     (.pushState js/history #js {:ednPath edn-path} "" nil)))
 
-(defn popstate->fetch [e]
-  (when-some [edn-path (some-> ^js e .-state .-ednPath)]
+(defn popstate->fetch [^js e]
+  (js/console.log "popstate" (.-state e) )
+  (when-some [edn-path (some-> e .-state .-ednPath)]
     (.preventDefault e)
     (fetch+set-state edn-path)))
 

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -777,8 +777,10 @@
                        (str "/index.edn")
                        (seq current-path)
                        (str ".edn")))]
-    (fetch+set-state edn-path)
-    (.pushState js/history #js {:edn_path edn-path} "" nil)))
+    (.then (fetch+set-state edn-path)
+           (fn [{:keys [ok]}]
+             (when ok
+               (.pushState js/history #js {:edn_path edn-path} "" nil))))))
 
 (defn popstate->fetch [^js e]
   (when-some [edn-path (.. e -state -edn_path)]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -781,9 +781,10 @@
     (.pushState js/history #js {:ednPath edn-path} "" nil)))
 
 (defn popstate->fetch [^js e]
-  (js/console.log "popstate" (.-state e) )
+  (js/console.log "popstate" (.-state e) "edn-path" (some-> e .-state .-ednPath))
   (when-some [edn-path (some-> e .-state .-ednPath)]
     (.preventDefault e)
+    (js/console.log "fetching" )
     (fetch+set-state edn-path)))
 
 (defn setup-router! [{:as state :keys [render-router]}]

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -563,7 +563,7 @@
    (when-let [error (get-in @!doc [:nextjournal/value :error])]
      [:div.fixed.top-0.left-0.w-full.h-full
       [inspect-presented error]])
-   (when @!doc
+   (when (:nextjournal/value @!doc)
      [inspect-presented @!doc])
    (into [:<>]
          (map (fn [[id state]]
@@ -749,8 +749,7 @@
 (defn delay-resolve [v] (new js/Promise (fn [res] (js/setTimeout #(res v) 100))))
 
 (defn read-response+show-progress [{:as state :keys [reader buffer content-length]}]
-  (set-state! {:doc {:status {:progress (if (zero? (count buffer)) 0.2 (/ (count buffer) content-length))}
-                     :nextjournal/viewer {:render-fn (constantly [:<>])}}})
+  (swap! !doc assoc :status {:progress (if (zero? (count buffer)) 0.2 (/ (count buffer) content-length))})
   (.. reader read
       ;; delay a bit for progress bar to be visible
       (then delay-resolve)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -511,12 +511,12 @@
 
 (defn transform-result [{:as wrapped-value :keys [path]}]
   (let [{:as _cell :keys [form id settings] ::keys [result doc]} (:nextjournal/value wrapped-value)
-        {:keys [static-build? package]} doc
+        {:keys [package]} doc
         {:nextjournal/keys [value blob-id viewers]} result
         blob-mode (cond
-                    (and (not static-build?) blob-id) :lazy-load
-                    (= :single-file package) :inline ;; TODO: provide a separte setting for this
-                    :else :file)
+                    (= :single-file package) :inline
+                    (= :directory package) :file
+                    blob-id :lazy-load)
         #?(:clj blob-opts :cljs _) (assoc doc :blob-mode blob-mode :blob-id blob-id)
         opts-from-block (-> settings
                             (select-keys (keys viewer-opts-normalization))
@@ -1162,7 +1162,7 @@
             ""
             (if (fs/exists? "index.clj") "index.clj" "'nextjournal.clerk.index"))))
 
-(defn header [{:as opts :keys [file file-path nav-path static-build? ns] :git/keys [url sha]}]
+(defn header [{:as opts :keys [file-path nav-path package ns] :git/keys [url sha]}]
   (html [:div.viewer.w-full.max-w-prose.px-8.not-prose.mt-3
          [:div.mb-8.text-xs.sans-serif.text-slate-400
           (when (and (not (route-index? opts))
@@ -1177,7 +1177,7 @@
               {:href (doc-url (index-path opts))} "Index"]
              [:span.mx-2 "•"]])
           [:span
-           (if static-build? "Generated with " "Served from ")
+           (if package "Generated with " "Served from ")
            [:a.font-medium.border-b.border-dotted.border-slate-300.hover:text-indigo-500.hover:border-indigo-500.dark:border-slate-500.dark:hover:text-white.dark:hover:border-white.transition
             {:href "https://clerk.vision"} "Clerk"]
            (let [default-index? (= 'nextjournal.clerk.index (some-> ns ns-name))]

--- a/test/nextjournal/clerk/builder_test.clj
+++ b/test/nextjournal/clerk/builder_test.clj
@@ -68,20 +68,20 @@
     ;; ----------------------------------------------------
     ;; path/to/notebook.clj |  path/to/notebok/[index.html]
     (is (= "./../../notebooks/rule_30" ;; NOTE: could also be just "rule_30.html"
-           (builder/doc-url {:bundle? false} "notebooks/viewer_api.clj" "notebooks/rule_30"))))
+           (builder/doc-url {} "notebooks/viewer_api.clj" "notebooks/rule_30"))))
 
   (testing "respects the mapped index"
     (is (= "./notebooks/rule_30"
-           (builder/doc-url {:bundle? false} "index.clj" "notebooks/rule_30")))
+           (builder/doc-url {} "index.clj" "notebooks/rule_30")))
 
     (is (= "./notebooks/rule_30"
-           (builder/doc-url {:bundle? false :index "notebooks/path/to/notebook.clj"}
+           (builder/doc-url { :index "notebooks/path/to/notebook.clj"}
                             "notebooks/path/to/notebook.clj" "notebooks/rule_30")))
 
     (is (= "./../../../../notebooks/rule_30"
-           (builder/doc-url {:bundle? false}
+           (builder/doc-url {}
                             "notebooks/path/to/notebook.clj" "notebooks/rule_30"))))
 
   (testing "bundle case"
     (is (= "#/notebooks/rule_30"
-           (builder/doc-url {:bundle? true} "index.clj" "notebooks/rule_30")))))
+           (builder/doc-url {:package :single-file} "index.clj" "notebooks/rule_30")))))

--- a/test/nextjournal/clerk/builder_test.clj
+++ b/test/nextjournal/clerk/builder_test.clj
@@ -54,11 +54,11 @@
   (testing "coerces index symbol arg and adds it to expanded-paths"
     (is (= ["book.clj"] (:expanded-paths (builder/process-build-opts {:index 'book.clj :expand-paths? true})))))
 
-  (testing "conform render-router options"
-    (is (= :bundle (:render-router (builder/process-build-opts {:bundle? true}))))
-    (is (= :fetch-edn (:render-router (builder/process-build-opts {:render-router :fetch-edn}))))
-    (is (thrown? clojure.lang.ExceptionInfo (builder/process-build-opts {:bundle? true :render-router :fetch-edn})))
-    (is (thrown? clojure.lang.ExceptionInfo (builder/process-build-opts {:render-router :foo})))))
+  (testing "package option default"
+    (is (match? {:package :directory :render-router :fetch-edn}
+                (builder/process-build-opts {})))
+    (is (match? {:package :single-file :render-router :bundle}
+                (builder/process-build-opts {:package :single-file})))))
 
 (deftest doc-url
   (testing "link to same dir unbundled"

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -86,7 +86,7 @@
 (deftest default-viewers
   (testing "viewers have names matching vars"
     (doseq [[viewer-name viewer] (into {}
-                                       (map (juxt :name (comp deref resolve :name))) 
+                                       (map (juxt :name (comp deref resolve :name)))
                                        v/default-viewers)]
       (is (= viewer-name (:name viewer))))))
 
@@ -259,18 +259,18 @@
     (let [test-doc (eval/eval-string ";; Some inline image ![alt](trees.png) here.")]
       (is (not-empty (tree-re-find (view/doc->viewer test-doc) #"_fs/trees.png")))))
 
-  (testing "Local images are inlined in bundled static builds"
+  (testing "Local images are inlined in single-file static builds"
     (let [test-doc (eval/eval-string ";; Some inline image ![alt](trees.png) here.")]
-      (is (not-empty (tree-re-find (view/doc->viewer {:bundle? true} test-doc) #"data:image/png;base64")))))
+      (is (not-empty (tree-re-find (view/doc->viewer {:package :single-file} test-doc) #"data:image/png;base64")))))
 
-  (testing "Local images are content addressed for unbundled static builds"
+  (testing "Local images are content addressed for default static builds"
     (let [test-doc (eval/eval-string ";; Some inline image ![alt](trees.png) here.")]
-      (is (not-empty (tree-re-find (view/doc->viewer {:bundle? false :out-path (str (fs/temp-dir))} test-doc) #"_data/.+\.png")))))
+      (is (not-empty (tree-re-find (view/doc->viewer {:package :directory :out-path (str (fs/temp-dir))} test-doc) #"_data/.+\.png")))))
 
   (testing "Doc options are propagated to blob processing"
     (let [test-doc (eval/eval-string "(java.awt.image.BufferedImage. 20 20 1)")]
       (is (not-empty (tree-re-find (view/doc->viewer {:static-build? true
-                                                      :bundle? true
+                                                      :package :single-file
                                                       :out-path builder/default-out-path} test-doc)
                                    #"data:image/png;base64")))
 

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -269,12 +269,11 @@
 
   (testing "Doc options are propagated to blob processing"
     (let [test-doc (eval/eval-string "(java.awt.image.BufferedImage. 20 20 1)")]
-      (is (not-empty (tree-re-find (view/doc->viewer {:static-build? true
-                                                      :package :single-file
+      (is (not-empty (tree-re-find (view/doc->viewer {:package :single-file
                                                       :out-path builder/default-out-path} test-doc)
                                    #"data:image/png;base64")))
 
-      (is (not-empty (tree-re-find (view/doc->viewer {:static-build? true
+      (is (not-empty (tree-re-find (view/doc->viewer {:package :directory
                                                       :out-path builder/default-out-path} test-doc)
                                    #"_data/.+\.png")))))
 

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -275,7 +275,6 @@
                                    #"data:image/png;base64")))
 
       (is (not-empty (tree-re-find (view/doc->viewer {:static-build? true
-                                                      :bundle? false
                                                       :out-path builder/default-out-path} test-doc)
                                    #"_data/.+\.png")))))
 


### PR DESCRIPTION
Introduce a new `:package` keyword for controlling `clerk/build!` artefacts. Deprecates `:bundle?` option. Clerk static apps now use client-side navigation by default for smoother page transitions.