### PR TITLE
Simplify handling of Fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Changes can be:
 
 * 🐞  Swallow git errors in shell-out-str instead of printing them to stdout/err
 
+* 🐞 Fixes an issue in fragments which showed definitions as vars instead of their values
+
 ## 0.15.957 (2023-09-28)
 
 * 🔌 Offline support

--- a/notebooks/example.clj
+++ b/notebooks/example.clj
@@ -14,4 +14,5 @@
   (macroexpand '(example (+ 1 2)))
   (clerk/html [:h1 "👋"])
   (range)
-  (javax.imageio.ImageIO/read (java.net.URL. "https://nextjournal.com/data/QmeyvaR3Q5XSwe14ZS6D5WBQGg1zaBaeG3SeyyuUURE2pq?filename=thermos.gif&content-type=image/gif")))
+  (def my-var 'should-display-its-value)
+  (clerk/image "trees.png"))

--- a/notebooks/fragments.clj
+++ b/notebooks/fragments.clj
@@ -15,6 +15,7 @@
                          :dice (shuffle (range 1 7))})))
  (clerk/image "trees.png")
  (clerk/plotly {::clerk/width :full} {:data [{:y [1 3 2]}]})
+ (def my-var 'should-display-its-value)
  (clerk/html {::clerk/width :full} [:div.h-20.bg-amber-200])
  (clerk/fragment (clerk/html {::clerk/width :full} [:div.h-20.bg-amber-300])
                  (clerk/html {::clerk/width :full} [:div.h-20.bg-amber-400])

--- a/notebooks/fragments.clj
+++ b/notebooks/fragments.clj
@@ -24,6 +24,13 @@
                  (clerk/with-viewer {} {::clerk/budget 5}
                    (reduce (fn [acc i] (vector i acc)) :fin (range 15 0 -1)))))
 
+;; ## Clerk comments
+;; The `clerk/comment` macro only evaluates forms in the context of a clerk evaluation and expands to a fragment. It expands to an empty form otherwise.
+(clerk/comment
+  (clerk/md "This is not evaluated, when Clojure loads the file.")
+  (clerk/plotly {::clerk/width :full} {:data [{:y [1 3 2]}]})
+  (def my-other-var 42))
+
 ;; ## Collapsible Sections
 ;; Fragments allow to hide (and in future versions of Clerk, probably fold) chunks of prose interspersed with results. That is, by using the usual visibility annotation
 ;;

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -85,12 +85,6 @@
 
 #_(rewrite-defcached '(nextjournal.clerk/defcached foo :bar))
 
-(defn deflike? [form]
-  (and (seq? form) (symbol? (first form)) (str/starts-with? (name (first form)) "def")))
-
-#_(deflike? '(defonce foo :bar))
-#_(deflike? '(rdef foo :bar))
-
 (defn auto-resolves [ns]
   (as-> (ns-aliases ns) $
     (assoc $ :current (ns-name *ns*))
@@ -166,7 +160,7 @@
                    nodes)
 
         var (when (and (= 1 (count vars))
-                       (deflike? form))
+                       (parser/deflike? form))
               (first vars))
         def-node (when var
                    (first (filter (comp #{:def} :op) nodes)))

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -188,6 +188,12 @@
 #_(->doc-settings '(ns foo {:nextjournal.clerk/budget nil :nextjournal.clerk/width :full}))
 #_(->doc-settings '^{:nextjournal.clerk/toc :boom} (ns foo)) ;; TODO: error
 
+(defn deflike? [form]
+  (and (seq? form) (symbol? (first form)) (str/starts-with? (name (first form)) "def")))
+
+#_(deflike? '(defonce foo :bar))
+#_(deflike? '(rdef foo :bar))
+
 (defn markdown? [{:as block :keys [type]}]
   (contains? #{:markdown} type))
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -622,20 +622,20 @@
 
 (defn maybe-wrap-var-from-def [val form]
   (cond->> val
-    (and (var? val) (list? form) (#{'def 'defonce} (first form)))
+    (and (var? val) (parser/deflike? form))
     (hash-map :nextjournal.clerk/var-from-def)))
 
 (defn fragment-seq
   ([cell] (fragment-seq (:form cell) cell))
   ([form {:as cell :keys [result]}]
-   (if-some [fgmt (-> result :nextjournal/value (get-safe :nextjournal.clerk/fragment))]
+   (if-some [fragment (-> result :nextjournal/value (get-safe :nextjournal.clerk/fragment))]
      (mapcat (fn [r i]
                (fragment-seq
                 (when (list? form) (get (vec form) (inc i)))
                 (-> cell
                     (assoc ::fragment-item? true)
                     (assoc-in [:result :nextjournal/value] r))))
-             fgmt (range (count fgmt)))
+             fragment (range (count fragment)))
      (list (update-in cell [:result :nextjournal/value] maybe-wrap-var-from-def form)))))
 
 (defn cell->result-viewer [cell]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -514,7 +514,7 @@
                                    (str "-" (str/join "-" path))))))
 
 (defn transform-result [{:as wrapped-value :keys [path]}]
-  (let [{:as cell :keys [form id settings result] ::keys [doc]} (:nextjournal/value wrapped-value)
+  (let [{:as cell :keys [form id settings result] ::keys [fragment-item? doc]} (:nextjournal/value wrapped-value)
         {:keys [package]} doc
         {:nextjournal/keys [value blob-id viewers]} result
         blob-mode (cond
@@ -534,6 +534,7 @@
                                      (fn [{:as opts existing-id :id}]
                                        (cond-> opts
                                          auto-expand-results? (assoc :auto-expand-results? auto-expand-results?)
+                                         fragment-item? (assoc :fragment-item? true)
                                          (not existing-id) (assoc :id (processed-block-id (str id "-result") path)))))
                              #?(:clj (->> (process-blobs blob-opts))))
         viewer-eval-result? (-> presented-result :nextjournal/value viewer-eval?)]
@@ -623,7 +624,9 @@
   (if-some [fgmt (-> result (get-safe :nextjournal/value) (get-safe :nextjournal.clerk/fragment))]
     (mapcat (fn [r]
               (fragment-tree-seq
-               (assoc-in cell [:result :nextjournal/value] r))) fgmt)
+               (-> cell
+                   (assoc ::fragment-item? true)
+                   (assoc-in [:result :nextjournal/value] r)))) fgmt)
     (list cell)))
 
 (defn cell->result-viewer [cell]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -625,12 +625,12 @@
     (and (var? val) (list? form) (#{'def 'defonce} (first form)))
     (hash-map :nextjournal.clerk/var-from-def)))
 
-(defn fragment-tree-seq
-  ([cell] (fragment-tree-seq (:form cell) cell))
+(defn fragment-seq
+  ([cell] (fragment-seq (:form cell) cell))
   ([form {:as cell :keys [result]}]
    (if-some [fgmt (-> result :nextjournal/value (get-safe :nextjournal.clerk/fragment))]
      (mapcat (fn [r i]
-               (fragment-tree-seq
+               (fragment-seq
                 (when (list? form) (get (vec form) (inc i)))
                 (-> cell
                     (assoc ::fragment-item? true)
@@ -641,7 +641,7 @@
 (defn cell->result-viewer [cell]
   (-> cell
       (update-if :result apply-viewer-unwrapping-var-from-def)
-      fragment-tree-seq
+      fragment-seq
       (->> (mapv (partial with-viewer
                           (cond-> result-viewer
                             (hidden-viewer-eval-result? cell)

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -338,6 +338,14 @@
       (is (every? (every-pred not-empty string?) ids))
       (is (distinct? ids))))
 
+  (testing "Fragments renders values from def vars"
+    (is (= 3
+           (-> (eval-test/eval+extract-doc-blocks "(ns nextjournal.clerk.viewer-test.fragments (:require [nextjournal.clerk :as clerk]))
+(clerk/fragment
+ 1 2 (def x 3))")
+               last :nextjournal/value :nextjournal/presented :nextjournal/value))))
+
+
   (testing "Fragments emit distinct results for all of their (nested) children"
     (is (= 6
            (count

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -338,13 +338,29 @@
       (is (every? (every-pred not-empty string?) ids))
       (is (distinct? ids))))
 
-  (testing "Fragments renders values from def vars"
+  (testing "Clerk fragments and comments render values from def vars"
     (is (= 3
            (-> (eval-test/eval+extract-doc-blocks "(ns nextjournal.clerk.viewer-test.fragments (:require [nextjournal.clerk :as clerk]))
 (clerk/fragment
  1 2 (def x 3))")
-               last :nextjournal/value :nextjournal/presented :nextjournal/value))))
+               last :nextjournal/value :nextjournal/presented :nextjournal/value)))
+    (is (= 3
+           (-> (eval-test/eval+extract-doc-blocks "(ns nextjournal.clerk.viewer-test.fragments (:require [nextjournal.clerk :as clerk]))
+(clerk/comment
+ 1 2 (def x 3))")
+               last :nextjournal/value :nextjournal/presented :nextjournal/value)))
 
+    (is (= 4
+           (-> (eval-test/eval+extract-doc-blocks "(ns nextjournal.clerk.viewer-test.fragments (:require [nextjournal.clerk :as clerk]))
+(clerk/comment
+ 1 2 (clerk/comment 3 (def x 4)))")
+               last :nextjournal/value :nextjournal/presented :nextjournal/value)))
+
+    (is (= 4
+           (-> (eval-test/eval+extract-doc-blocks "(ns nextjournal.clerk.viewer-test.fragments (:require [nextjournal.clerk :as clerk]))
+(clerk/fragment
+ 1 (clerk/comment 2 (clerk/fragment 3 (def x 4))))")
+               last :nextjournal/value :nextjournal/presented :nextjournal/value))))
 
   (testing "Fragments emit distinct results for all of their (nested) children"
     (is (= 6


### PR DESCRIPTION
Use the recently introduced cell-viewer to simplify the handling of fragments. In particular, fragments are now eagerly unwinded _before_ the presentation of each document block. This also makes the application of the result viewer explicit, that is no longer based on a predicate matching qualified keys.

This also fixes the display of defined values in fragments (#600) with the exception of expressions like: 

```clojure
(clerk/fragment [ 1 2 (def x 3) ])
(apply clerk/fragment [(def x 1) 2 3])
(apply clerk/fragment (list (def x 1) 2 3))
```

Fixes #599.
Fixes #600.