### PR TITLE
Catch and display KaTeX Errors in Markdown Prose

### DIFF
--- a/notebooks/viewers/tex.clj
+++ b/notebooks/viewers/tex.clj
@@ -18,6 +18,11 @@
 
 $${\\frac{d}{d t} \\frac{∂ L}{∂ \\dot{q}}}-\\frac{∂ L}{∂ q}=0.$$")
 
+;; ## Errors
+;; This is a parse error in prose $\phi\crash$ while this is in a result
+
+(clerk/tex "\\phi\\crash")
+
 ;; ## MathJax
 
 (v/with-viewer v/mathjax-viewer

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -909,7 +909,11 @@
 (defn render-katex [tex-string opts]
   (let [katex (hooks/use-d3-require "katex@0.16.9")]
     (if katex
-      [:> ErrorBoundary {:error-view (fn error-view [e] [:span.text-red-500.font-sans (.-message e)])}
+      [:> ErrorBoundary
+       {:error-view (fn [e]
+                      (if (instance? (.-ParseError katex) e)
+                        [:span.text-red-500.font-sans (.-message e)]
+                        [error-view e]))}
        [render-katex-inner katex tex-string opts]]
       default-loading-view)))
 


### PR DESCRIPTION
Add an error boundary around katex calls.

<img width="500" alt="Screenshot 2024-01-08 at 12 33 17" src="https://github.com/nextjournal/clerk/assets/1078464/a69e2fae-2d9b-4942-baba-f61478b38efd">


