### PR TITLE
Handle Errors from KaTeX gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,9 @@ Changes can be:
 
 * 🐞  Swallow git errors in shell-out-str instead of printing them to stdout/err
 
-* 🐞 Fixes an issue in fragments which showed definitions as vars instead of their values
+* 🐞 Fix an issue in fragments which showed definitions as vars instead of their values
+
+* 🐞 Fix blank page when notebook contains latex errors in prose [#571](https://github.com/nextjournal/clerk/issues/571) @titonbarua and [#603](https://github.com/nextjournal/clerk/issues/603) @teodorlu
 
 ## 0.15.957 (2023-09-28)
 

--- a/notebooks/viewers/tex.clj
+++ b/notebooks/viewers/tex.clj
@@ -18,6 +18,13 @@
 
 $${\\frac{d}{d t} \\frac{∂ L}{∂ \\dot{q}}}-\\frac{∂ L}{∂ q}=0.$$")
 
+;; ## Errors
+;; Katex will try to render as much as possible of the latex source, highlighting in red broken commands, like in $\phi\crash\psi$. The same happens cell results
+
+(clerk/tex "\\phi\\crash\\psi")
+
+;; Certain classes of errors get some extra information by hovering over the broken source: $\phi x^^2 \psi$.
+
 ;; ## MathJax
 
 (v/with-viewer v/mathjax-viewer

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -905,7 +905,7 @@
 (defn render-katex [tex-string {:keys [inline?]}]
   (let [katex (hooks/use-d3-require "katex@0.16.4")]
     (if katex
-      [:span {:dangerouslySetInnerHTML {:__html (.renderToString katex tex-string (j/obj :displayMode (not inline?)))}}]
+      [:span {:dangerouslySetInnerHTML {:__html (.renderToString katex tex-string (j/obj :displayMode (not inline?) :throwOnError false))}}]
       default-loading-view)))
 
 (defn render-mathjax [value]


### PR DESCRIPTION
Closes #603 and closes #571.

<img width="500" alt="Screenshot 2024-01-08 at 12 57 29" src="https://github.com/nextjournal/clerk/assets/1078464/e43bca4f-c952-4ee4-90f5-526129ccef5d">
