### PR TITLE
Fix showing elided Images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ Changes can be:
 
 * 🐞 Fix blank page when notebook contains latex errors in prose [#571](https://github.com/nextjournal/clerk/issues/571) @titonbarua and [#603](https://github.com/nextjournal/clerk/issues/603) @teodorlu
 
+* 🐞 Fix displaying images when expanding elided data [#612](https://github.com/nextjournal/clerk/issues/612) @a1exsh
+
 ## 0.15.957 (2023-09-28)
 
 * 🔌 Offline support

--- a/notebooks/pagination.clj
+++ b/notebooks/pagination.clj
@@ -90,3 +90,6 @@
  [:div
   [:h3 "Configuring budget inside " [:span.font-mono "clerk/html"]]
   {:nextjournal/value (reduce (fn [acc i] (vector i acc)) :fin (range 15 0 -1))}])
+
+;; images displayed correctly when expanding elided data
+(concat (range 20) (list (clerk/image "trees.png")))

--- a/notebooks/pagination.clj
+++ b/notebooks/pagination.clj
@@ -91,5 +91,5 @@
   [:h3 "Configuring budget inside " [:span.font-mono "clerk/html"]]
   {:nextjournal/value (reduce (fn [acc i] (vector i acc)) :fin (range 15 0 -1))}])
 
-;; images displayed correctly when expanding elided data
+;; Images are displayed correctly when expanding elided data:
 (concat (range 20) (list (clerk/image "trees.png")))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -908,13 +908,17 @@
    :transform-fn (comp mark-presented (update-val (comp demunge-ex-data
                                                         datafy/datafy)))})
 
+#?(:clj
+   (defn buffered-image->bytes [^BufferedImage image]
+     (.. (PngEncoder.)
+         (withBufferedImage image)
+         (withCompressionLevel 1)
+         (toBytes))))
+
 (def image-viewer
   {#?@(:clj [:pred #(instance? BufferedImage %)
              :transform-fn (fn [{image :nextjournal/value}]
-                             (-> {:nextjournal/value (.. (PngEncoder.)
-                                                         (withBufferedImage image)
-                                                         (withCompressionLevel 1)
-                                                         (toBytes))
+                             (-> {:nextjournal/value (buffered-image->bytes image)
                                   :nextjournal/content-type "image/png"
                                   :nextjournal/width (image-width image)}
                                  mark-presented))])

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -76,7 +76,7 @@
       (if (contains? desc :nextjournal/content-type)
         {:body (v/->value desc)
          :content-type (:nextjournal/content-type desc)}
-        {:body (v/->edn desc)}))
+        {:body (v/->edn (v/process-blobs {:blob-mode :lazy-load :blob-id blob-id} desc))}))
     {:status 404}))
 
 (defn extract-blob-opts [{:as _req :keys [uri query-string]}]

--- a/test/nextjournal/clerk/webserver_test.clj
+++ b/test/nextjournal/clerk/webserver_test.clj
@@ -2,12 +2,19 @@
   (:require [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing]]
             [nextjournal.clerk.eval :as eval]
+            [nextjournal.clerk.viewer :as viewer]
             [nextjournal.clerk.view :as view]
             [nextjournal.clerk.webserver :as webserver]))
 
 (deftest ->file-or-ns
   (is (= 'nextjournal.clerk.tap (webserver/->file-or-ns "'nextjournal.clerk.tap")))
   (is (= "notebooks/rule_30.clj" (webserver/->file-or-ns "notebooks/rule_30.clj"))))
+
+(defn stream-equal? [s1 s2]
+  (let [x1 (.read s1) x2 (.read s2)]
+    (if (and (not= -1 x1) (not= -1 x2))
+      (if (= x1 x2) (recur s1 s2) false)
+      (= x1 x2))))
 
 (deftest serve-blob
   (testing "lazy loading of simple range"
@@ -19,7 +26,48 @@
           {:keys [body]} (webserver/serve-blob doc (merge fetch-opts {:fetch-opts elision-fetch-opts}))]
       (is (= `nextjournal.clerk.viewer/elision-viewer (:name elision-viewer)))
       (is body)
-      (is (= (-> body webserver/read-msg :nextjournal/value first :nextjournal/value) 20)))))
+      (is (= (-> body webserver/read-msg :nextjournal/value first :nextjournal/value) 20))))
+
+  (testing "lazy loading of images"
+    (let [doc (let [doc (eval/eval-string "(ns nextjournal.clerk.webserver-test.lazy-load-image
+  {:nextjournal.clerk/no-cache true}
+  (:require [nextjournal.clerk :as clerk]))
+
+(clerk/image \"trees.png\")
+")]
+                (with-meta doc (view/doc->viewer doc)))
+          {:nextjournal/keys [presented fetch-opts]} (-> doc meta :nextjournal/value :blocks second :nextjournal/value second :nextjournal/value)
+          {:nextjournal/keys [value]} presented]
+      (is (= "image/png" (:nextjournal/content-type presented)))
+      (is (= (:blob-id fetch-opts) (:blob-id (:nextjournal/value presented))))
+      ;; the presented image has been processed to only contain their blob-id in the value
+      ;; serve blob resolve their original contents via the elision mechanism
+      (let [response-body (:body (webserver/serve-blob doc (merge fetch-opts {:fetch-opts value})))]
+        (is (bytes? response-body))
+        (is (= (seq (viewer/buffered-image->bytes (viewer/read-image "trees.png")))
+               (seq response-body)))))
+
+    (testing "lazy loading of elided images"
+      (let [doc (let [doc (eval/eval-string "(ns nextjournal.clerk.webserver-test.lazy-load-image
+  {:nextjournal.clerk/no-cache true}
+  (:require [nextjournal.clerk :as clerk]))
+
+(concat (range 20)
+        (list (clerk/image \"trees.png\")))")]
+                  (with-meta doc (view/doc->viewer doc)))
+            {:nextjournal/keys [presented fetch-opts]} (-> doc meta :nextjournal/value :blocks second :nextjournal/value second :nextjournal/value)
+            {:nextjournal/keys [value]} presented
+            {elision-fetch-opts :nextjournal/value v :nextjournal/viewer} (peek value)
+            ]
+        (is (= (:name viewer/elision-viewer) (:name v)))
+        (let [{:keys [body]} (webserver/serve-blob doc (merge fetch-opts {:fetch-opts elision-fetch-opts}))
+              {expanded-value :nextjournal/value}
+              (binding [*data-readers* (assoc viewer/data-readers 'object (fn [_v] [:__object__]))]
+                (read-string body))]
+          (is (= "image/png" (-> expanded-value first :nextjournal/content-type)))
+          ;; blobs contained inside fetched elisions are being processed
+          (is (= {:blob-id (:blob-id fetch-opts) :path [1 20]}
+                 (-> expanded-value first :nextjournal/value))))))))
 
 (deftest serve-file-test
   (testing "serving a file resource"

--- a/test/nextjournal/clerk/webserver_test.clj
+++ b/test/nextjournal/clerk/webserver_test.clj
@@ -10,12 +10,6 @@
   (is (= 'nextjournal.clerk.tap (webserver/->file-or-ns "'nextjournal.clerk.tap")))
   (is (= "notebooks/rule_30.clj" (webserver/->file-or-ns "notebooks/rule_30.clj"))))
 
-(defn stream-equal? [s1 s2]
-  (let [x1 (.read s1) x2 (.read s2)]
-    (if (and (not= -1 x1) (not= -1 x2))
-      (if (= x1 x2) (recur s1 s2) false)
-      (= x1 x2))))
-
 (deftest serve-blob
   (testing "lazy loading of simple range"
     (let [doc (let [doc (eval/eval-string "(range 100)")]
@@ -57,8 +51,7 @@
                   (with-meta doc (view/doc->viewer doc)))
             {:nextjournal/keys [presented fetch-opts]} (-> doc meta :nextjournal/value :blocks second :nextjournal/value second :nextjournal/value)
             {:nextjournal/keys [value]} presented
-            {elision-fetch-opts :nextjournal/value v :nextjournal/viewer} (peek value)
-            ]
+            {elision-fetch-opts :nextjournal/value v :nextjournal/viewer} (peek value)]
         (is (= (:name viewer/elision-viewer) (:name v)))
         (let [{:keys [body]} (webserver/serve-blob doc (merge fetch-opts {:fetch-opts elision-fetch-opts}))
               {expanded-value :nextjournal/value}


### PR DESCRIPTION
by replacing blobs by their blob-id on resolved elisions. This is performed on the root description of cell results, but was missing on resolved elisions.

Fix #612.

