### PR TITLE
Ensure ex-data is always presentable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Changes can be:
 
 * 🐜 Fix blank screen caused by react unmounting when an exception occurs during `clerk/show!`, fixes [#586](https://github.com/nextjournal/clerk/issues/586) @elken
 
+* 🐜 Fix crash using file watcher with `:show-filter-fn` in notebooks with exceptions, fixes [#616](https://github.com/nextjournal/clerk/issues/616).
+
 * 🐜 Make edn transmission resilient to symbols and keywords containing multiple slashes like `foo/bar/baz`. Those can be read by `read-string` but not in ClojureScript which is based on `tools.reader`.
 
 * 🐞 Fix `:nextjournal.clerk/page-size` option throwing when set on string values, fixes [#584][https://github.com/nextjournal/clerk/issues/584]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Changes can be:
 
 * 🐜 Fix blank screen caused by react unmounting when an exception occurs during `clerk/show!`, fixes [#586](https://github.com/nextjournal/clerk/issues/586) @elken
 
-* 🐜 Fix crash using file watcher with `:show-filter-fn` in notebooks with exceptions, fixes [#616](https://github.com/nextjournal/clerk/issues/616).
+* 🐜 Fix browser crashing when file watcher is used with `:show-filter-fn` option in notebooks with exceptions, fixes [#616](https://github.com/nextjournal/clerk/issues/616).
 
 * 🐜 Make edn transmission resilient to symbols and keywords containing multiple slashes like `foo/bar/baz`. Those can be read by `read-string` but not in ClojureScript which is based on `tools.reader`.
 

--- a/notebooks/pagination.clj
+++ b/notebooks/pagination.clj
@@ -93,3 +93,10 @@
 
 ;; Images are displayed correctly when expanding elided data:
 (concat (range 20) (list (clerk/image "trees.png")))
+
+;; Elisions in exception data are fetched correctly:
+(ex-info "Boink 💥"
+         {:boom (fn boom [x] x)
+          :range (range 30)
+          :image (clerk/image "trees.png")}
+         (RuntimeException. "no way"))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -75,7 +75,7 @@
          (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
          (webserver/update-doc! result))
        (catch Exception e
-         (webserver/update-doc! (assoc (-> e ex-data ::doc) :error e))
+         (webserver/update-doc! (-> e ex-data ::doc (assoc :error e) (update :ns #(or % (find-ns 'user)))))
          (throw e))))))
 
 #_(show! "notebooks/exec_status.clj")

--- a/src/nextjournal/clerk/paths.clj
+++ b/src/nextjournal/clerk/paths.clj
@@ -2,8 +2,7 @@
   "Clerk's paths expansion and paths-fn handling."
   (:require [babashka.fs :as fs]
             [clojure.edn :as edn]
-            [clojure.string :as str]
-            [nextjournal.clerk.git :as git])
+            [clojure.string :as str])
   (:import [java.net URL]))
 
 (defn ^:private ensure-not-empty [build-opts {:as opts :keys [error expanded-paths]}]
@@ -122,19 +121,6 @@
 #_(index-paths)
 #_(index-paths {:paths ["CHANGELOG.md"]})
 #_(index-paths {:paths-fn "boom"})
-
-(defn process-paths [{:as opts :keys [paths paths-fn index]}]
-  (merge (if (or paths paths-fn index)
-           (expand-paths opts)
-           opts)
-         (git/read-git-attrs)))
-
-#_(process-paths {:paths ["notebooks/rule_30.clj"]})
-#_(process-paths {:paths ["notebooks/rule_30.clj"] :index "notebooks/links.md"})
-#_(process-paths {:paths ["notebooks/no_rule_30.clj"]})
-#_(v/route-index? (process-paths @!server))
-#_(route-index (process-paths @!server) "")
-
 
 (defn path-in-cwd
   "Turns `file` into a unixified (forward slashed) path if the is in the cwd,

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -491,7 +491,7 @@
           [:div.font-bold "Unhandled " type])
         [:div.font-bold.mt-1 message]
         (when data
-          [:div.mt-1 [inspect (viewer/inspect-wrapped-values data)]])])
+          [:div.mt-1 [inspect-presented data]])])
      via))
    [:div.py-6.overflow-x-auto
     [:table.w-full

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -577,8 +577,9 @@
       [connection-status status])
     (when-let [status (:status @!doc)]
       [exec-status status])]
-   (when-let [wrapped-value (get-in @!doc [:nextjournal/value :error])]
+   (when-let [{:as wrapped-value :nextjournal/keys [blob-id]} (get-in @!doc [:nextjournal/value :error])]
      (let [!expanded-at (r/atom {})]
+       ^{:key blob-id}
        [with-fetch-fn wrapped-value
         (fn [presented-value]
           [:div.fixed.top-0.left-0.w-full.h-full

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1267,6 +1267,10 @@
    :transform-fn transform-toc
    :render-fn 'nextjournal.clerk.render.navbar/render-items})
 
+(defn present-error [error]
+  {:nextjournal/presented (present error)
+   :nextjournal/blob-id (str "exception:" (hash error))})
+
 (defn process-blocks [viewers {:as doc :keys [ns]}]
   (-> doc
       (assoc :atom-var-name->state (atom-var-name->state doc))
@@ -1291,7 +1295,7 @@
                     :toc-visibility
                     :header
                     :footer])
-      (update-if :error present)
+      (update-if :error present-error)
       (assoc :sidenotes? (boolean (seq (:footnotes doc))))
       #?(:clj (cond-> ns (assoc :scope (datafy-scope ns))))))
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -912,14 +912,13 @@
       (update :path (fnil conj []) path-segment)))
 
 (defn present-ex-data [parent throwable-map]
-  (update-if throwable-map :via
-             (fn [exs]
-               (mapv (fn [i ex]
-                       (update-if ex :data
-                                  (fn [data]
-                                    (present (inherit-opts parent data i)))))
-                     (range (count exs))
-                     exs))))
+  (let [present-child (fn [idx data] (present (inherit-opts parent data idx)))]
+    (-> throwable-map
+        (update-if :data (partial present-child 0))
+        (update-if :via (fn [exs]
+                          (mapv (fn [i ex] (update-if ex :data (partial present-child (inc i))))
+                                (range (count exs))
+                                exs))))))
 
 (def throwable-viewer
   {:name `throwable-viewer

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1268,7 +1268,7 @@
 
 (defn present-error [error]
   {:nextjournal/presented (present error)
-   :nextjournal/blob-id (str "exception:" (hash error))})
+   :nextjournal/blob-id (str (gensym "error"))})
 
 (defn process-blocks [viewers {:as doc :keys [ns]}]
   (-> doc

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -177,10 +177,10 @@
 (defn get-build-opts
   ([] (get-build-opts @!server))
   ([{:as opts :keys [paths paths-fn index]}]
-   (-> (if (or paths paths-fn index)
-         (paths/expand-paths opts)
-         opts)
-       (merge (git/read-git-attrs)))))
+   (merge (git/read-git-attrs)
+          (if (or paths paths-fn index)
+            (paths/expand-paths opts)
+            opts))))
 
 #_(get-build-opts)
 #_(get-build-opts {:paths ["notebooks/rule_30.clj"]})

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -180,7 +180,6 @@
     (-> (if (or paths paths-fn index)
              (paths/expand-paths opts)
              opts)
-        (select-keys [:index :paths :expanded-paths :error])
         (merge (git/read-git-attrs)))))
 
 #_(get-build-opts)

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -177,10 +177,10 @@
 (defn get-build-opts
   ([] (get-build-opts @!server))
   ([{:as opts :keys [paths paths-fn index]}]
-    (-> (if (or paths paths-fn index)
-             (paths/expand-paths opts)
-             opts)
-        (merge (git/read-git-attrs)))))
+   (-> (if (or paths paths-fn index)
+         (paths/expand-paths opts)
+         opts)
+       (merge (git/read-git-attrs)))))
 
 #_(get-build-opts)
 #_(get-build-opts {:paths ["notebooks/rule_30.clj"]})

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -132,6 +132,21 @@
     (is (= :full
            (:nextjournal/width (v/apply-viewers (v/table {:nextjournal.clerk/width :full} {:a [1] :b [2] :c [3]})))))))
 
+(deftest present-exceptions
+  (binding [*data-readers* v/data-readers]
+    (is (-> (eval-test/eval+extract-doc-blocks "(ex-info \"💥\"  {:foo 123 :boom (fn boom [x] x)} (RuntimeException. \"no way\"))")
+            second :nextjournal/value :nextjournal/presented
+            v/->edn
+            read-string))))
+
+(deftest present-functions
+  (binding [*data-readers* v/data-readers]
+    (is (-> (eval-test/eval+extract-doc-blocks "(fn boom [x] x)")
+            second :nextjournal/value :nextjournal/presented
+            #_#_
+            v/->edn
+            read-string))))
+
 (deftest datafy-scope
   (is (= (ns-name *ns*)
          (v/datafy-scope *ns*)

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -133,18 +133,26 @@
            (:nextjournal/width (v/apply-viewers (v/table {:nextjournal.clerk/width :full} {:a [1] :b [2] :c [3]})))))))
 
 (deftest present-exceptions
-  (binding [*data-readers* v/data-readers]
-    (is (-> (eval-test/eval+extract-doc-blocks "(ex-info \"💥\"  {:foo 123 :boom (fn boom [x] x)} (RuntimeException. \"no way\"))")
-            second :nextjournal/value :nextjournal/presented
-            v/->edn
-            read-string))))
+  (testing "can represent ex-data in a readable way"
+    (binding [*data-readers* v/data-readers]
+
+      (is (-> (eval-test/eval+extract-doc-blocks "(ex-info \"💥\"  {:foo 123 :boom (fn boom [x] x)})")
+              second :nextjournal/value :nextjournal/presented
+              v/->edn
+              read-string))
+
+      (is (-> (eval-test/eval+extract-doc-blocks "(ex-info \"💥\"  {:foo 123 :boom (fn boom [x] x)} (RuntimeException. \"no way\"))")
+              second :nextjournal/value :nextjournal/presented
+              v/->edn
+              read-string)))))
 
 (deftest present-functions
-  (binding [*data-readers* v/data-readers]
-    (is (-> (eval-test/eval+extract-doc-blocks "(fn boom [x] x)")
-            second :nextjournal/value :nextjournal/presented
-            v/->edn
-            read-string))))
+  (testing "can represent functions in a readable way"
+    (binding [*data-readers* v/data-readers]
+      (is (-> (eval-test/eval+extract-doc-blocks "(fn boom [x] x)")
+              second :nextjournal/value :nextjournal/presented
+              v/->edn
+              read-string)))))
 
 (deftest datafy-scope
   (is (= (ns-name *ns*)

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -143,7 +143,6 @@
   (binding [*data-readers* v/data-readers]
     (is (-> (eval-test/eval+extract-doc-blocks "(fn boom [x] x)")
             second :nextjournal/value :nextjournal/presented
-            #_#_
             v/->edn
             read-string))))
 


### PR DESCRIPTION
Ensure exceptions with ex-data are always inspectable.

Fixes #622. Fixes #616. Better fix for #586 than #587.

<img width="600" alt="Screenshot 2024-01-22 at 18 12 10" src="https://github.com/nextjournal/clerk/assets/1078464/3ddaf64f-b900-4e8d-8dd4-2128279f4cc4">

