### PR TITLE
Read config values from ENV, Java properties and CLI args

### DIFF
--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -561,14 +561,14 @@
   * the form of an anonymous expression"
   ([]
    (swap! webserver/!doc dissoc :blob->result)
-   (if (fs/exists? config/cache-dir)
-     (do (fs/delete-tree config/cache-dir)
-         (prn :cache-dir/deleted config/cache-dir))
-     (prn :cache-dir/does-not-exist config/cache-dir)))
+   (if (fs/exists? (config/cache-dir))
+     (do (fs/delete-tree (config/cache-dir))
+         (prn :cache-dir/deleted (config/cache-dir)))
+     (prn :cache-dir/does-not-exist (config/cache-dir))))
   ([sym-or-form]
    (if-let [{:as block :keys [id result]} (first (analyzer/find-blocks @webserver/!doc sym-or-form))]
      (let [{:nextjournal/keys [blob-id]} result
-           cache-file (fs/file config/cache-dir (str "@" blob-id))
+           cache-file (fs/file (config/cache-dir) (str "@" blob-id))
            cached-in-memory? (contains? (:blob->result @webserver/!doc) blob-id)
            cached-on-fs? (fs/exists? cache-file)]
        (if-not (or cached-in-memory? cached-on-fs?)

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -461,6 +461,7 @@
                                       :coerce :boolean}}
                       :order [:host :port :browse :watch-paths :show-filter-fn :paths :paths-fn :index]}}
   [config]
+  (config/load! config)
   (if (:help config)
     (if-let [format-opts (and (started-via-bb-cli? config) (requiring-resolve 'babashka.cli/format-opts))]
       (println "Start the Clerk webserver with an optional a file watcher.\n\nOptions:"
@@ -535,6 +536,7 @@
                              :git/url {:desc "Git url to use for the backlink."}}
                       :order [:paths :paths-fn :index :browse :dashbaord :compile-css :ssr :bundle :out-path :git/sha :git/url]}}
   [build-opts]
+  (config/load! build-opts)
   (if (:help build-opts)
     (if-let [format-opts (and (started-via-bb-cli? build-opts) (requiring-resolve 'babashka.cli/format-opts))]
       (println "Start the Clerk webserver with an optional a file watcher.\n\nOptions:"

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -41,9 +41,9 @@
          (println (format "WARN: Failed parsing value %s for %s. Using default %s." val path default))
          default)))))
 
-(def cache-dir (get-config [:cache-dir] ".clerk/cache"))
+(defn cache-dir [] (get-config [:cache-dir] ".clerk/cache"))
 
-(def cache-disabled? (get-config [:disable-cache] false))
+(defn cache-disabled? [] (get-config [:disable-cache] false))
 
 (def resource-manifest-from-props (get-config [:resource-manifest] nil {:parse read-string}))
 

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -26,7 +26,7 @@
 #_(-> [(clojure.java.io/file "notebooks") (find-ns 'user)] nippy/freeze nippy/thaw)
 
 (defn ->cache-file [hash]
-  (str config/cache-dir fs/file-separator hash))
+  (str (config/cache-dir) fs/file-separator hash))
 
 (defn wrapped-with-metadata [value hash]
   (cond-> {:nextjournal/value value}
@@ -135,7 +135,7 @@
           no-cache? (or ns-effect?
                         no-cache?
                         (boolean (seq @!interned-vars))
-                        config/cache-disabled?)]
+                        (config/cache-disabled?))]
       (when (and (not no-cache?)
                  (not ns-effect?)
                  freezable?
@@ -187,7 +187,7 @@
                           cas-hash :no-cas-file
                           :else :no-digest-file)
            :hash hash :cas-hash cas-hash :form form :var var :ns-effect? ns-effect?)
-    (fs/create-dirs config/cache-dir)
+    (fs/create-dirs (config/cache-dir))
     (cond-> (or (when (and cached-result? cached-result-in-memory)
                   (wrapped-with-metadata (:nextjournal/value cached-result-in-memory) hash))
                 (when (and cached-result? freezable?)


### PR DESCRIPTION
Some work towards unifying where configuration is read from.

Specifically this allows specifying the clerk cache location on the command line or with `exec-args`.