### PR TITLE
Use widely available scrollIntoView instead of non-standard variant

### DIFF
--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -113,7 +113,7 @@
                              (catch js/Error _
                                (js/console.warn (str "Clerk render-notebook, invalid hash: "
                                                      (.-hash js/location))))))]
-    (js/requestAnimationFrame #(.scrollIntoViewIfNeeded heading))))
+    (js/requestAnimationFrame #(.scrollIntoView heading))))
 
 (defn render-notebook [{xs :blocks :keys [package doc-css-class sidenotes? toc toc-visibility header footer]}
                        {:as render-opts :keys [!expanded-at]}]


### PR DESCRIPTION
Fix #624. 

@philippamarkovics any drawback in using the standard [`scrollIntoView`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) here.