### PR TITLE
Analyzer Improvements

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -52,6 +52,10 @@
                  :main-opts ["-m" "shadow.cljs.devtools.cli"]
                  :exec-fn nextjournal.clerk.dev-launcher/start}
 
+           :profile {:exec-fn user/profile
+                     :exec-args {:phase :analysis}
+                     :jvm-opts ["-Dclojure.main.report=stdout"]}
+
            :test {:extra-deps {nubank/matcher-combinators {:mvn/version "3.5.1"}
                                org.clojure/test.check {:mvn/version "1.1.1"}
                                lambdaisland/kaocha {:mvn/version "1.66.1034"}

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -83,5 +83,5 @@
       (println (format "Elapsed mean time: %f msec" mean)))))
 
 ;; clj -X:dev:profile :phase :analysis
-;; Elapsed mean time: 1700 msec (main)
-;; Elapsed mean time: 1575 msec (analyzer-improvements)
+;; Elapsed mean time: ~1700 msec (iMac i9, main)
+;; Elapsed mean time: ~1700 msec (iMac i9, analyzer-improvements)

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -83,7 +83,5 @@
       (println (format "Elapsed mean time: %f msec" mean)))))
 
 ;; clj -X:dev:profile :phase :analysis
-;; Elapsed mean time: 4300,223637 msec (main)
-;; Elapsed mean time: 4866,353578 msec (analyzer-improvements)
-;; Elapsed mean time: 4594,642337 msec (analyzer-improvements - dep reverse map lookup)
-;; Elapsed mean time: 3784,830730 msec (analyzer-improvements - dep reverse map lookup / single entry last wins)
+;; Elapsed mean time: 1700 msec (main)
+;; Elapsed mean time: 2200 msec (analyzer-improvements)

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -48,15 +48,14 @@
   (do (require 'kaocha.repl)
       (kaocha.repl/run :unit))
 
-  (require '[clj-async-profiler.core :as prof]
-           'nextjournal.clerk.eval-test
-           'nextjournal.clerk.viewer-test
-           'nextjournal.clerk.analyzer-test)
-  (prof/profile
-   (time (clojure.test/run-tests 'nextjournal.clerk.eval-test
-                                 'nextjournal.clerk.viewer-test
-                                 'nextjournal.clerk.analyzer-test)))
-  ;; ~16.6s
+  (do
+    (clerk/clear-cache!)
+    (reset! analyzer/!file->analysis-cache {})
+    (prof/profile
+      (-> (parser/parse-file {:doc? true} "book.clj")
+              analyzer/build-graph
+              analyzer/hash))
+    nil)
   (prof/serve-ui 8080))
 
 (defmacro with-ex-data [sym body do-block]
@@ -84,4 +83,4 @@
 
 ;; clj -X:dev:profile :phase :analysis
 ;; Elapsed mean time: ~1700 msec (iMac i9, main)
-;; Elapsed mean time: ~1700 msec (iMac i9, analyzer-improvements)
+;; Elapsed mean time: ~1670 msec (iMac i9, analyzer-improvements)

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,7 +1,6 @@
 (ns user
   (:require [clj-async-profiler.core :as prof]
             [clojure.java.io :as io]
-            [clojure.string :as str]
             [nextjournal.clerk :as clerk]
             [nextjournal.clerk.analyzer :as analyzer]
             [nextjournal.clerk.eval :as eval]
@@ -76,8 +75,7 @@
           (eval/time-ms
            (dotimes [_i times]
              (doseq [doc (shuffle test-docs)]
-               (-> (analyzer/build-graph doc) analyzer/hash))
-             (prn :done _i)))
+               (-> (analyzer/build-graph doc) analyzer/hash))))
           mean (/ time-ms (* times (count test-docs)))]
       (println (format "Elapsed mean time: %f msec" mean)))))
 

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -69,13 +69,16 @@
 
 (defmethod profile :analysis [_opts]
   (let [test-docs [(parser/parse-file {:doc? true} (io/resource "clojure/core.clj"))
+                   (parser/parse-file {:doc? true} (io/resource "nextjournal/clerk/analyzer.clj"))
+                   (parser/parse-file {:doc? true} (io/resource "nextjournal/clerk.clj"))
                    #_ more?]
         times 5]
     (let [{:keys [time-ms]}
           (eval/time-ms
            (dotimes [_i times]
              (doseq [doc (shuffle test-docs)]
-               (-> (analyzer/build-graph doc) analyzer/hash))))
+               (-> (analyzer/build-graph doc) analyzer/hash))
+             (prn :done/pass _i)))
           mean (/ time-ms (* times (count test-docs)))]
       (println (format "Elapsed mean time: %f msec" mean)))))
 

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -84,4 +84,4 @@
 
 ;; clj -X:dev:profile :phase :analysis
 ;; Elapsed mean time: 1700 msec (main)
-;; Elapsed mean time: 2200 msec (analyzer-improvements)
+;; Elapsed mean time: 1575 msec (analyzer-improvements)

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -386,8 +386,6 @@
                              ;; `->analysis-info` :: { BlockId => Map }
                              ;; `var->block-id`   :: { Sym => Set<BlockId> }
                              (cond-> (-> state
-                                         (dissoc :doc?)
-
                                          (assoc-in [:->analysis-info block-id] analyzed)
                                          (track-var->block+redefs analyzed)
                                          (update :blocks conj (-> block
@@ -406,6 +404,8 @@
                                   :redefs #{}
                                   :blocks []))
                        (:blocks doc))
+
+         true (dissoc :doc?)
          doc? (-> parser/add-block-settings
                   parser/add-open-graph-metadata
                   parser/filter-code-blocks-without-form))))))

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -535,12 +535,14 @@
   (memoize (fn [f]
              {:jar f :hash (sha1-base58 (io/input-stream f))})))
 
-(defn ^:private merge-analysis-info [state {:as analyzed-doc :keys [->analysis-info]}]
+(defn ^:private merge-analysis-info [state {:as _analyzed-doc :keys [->analysis-info var->block-id]}]
   (reduce (fn [s {:as analyzed :keys [deps]}]
             (if (seq deps)
               (reduce (partial analyze-deps analyzed) s deps)
               s))
-          (update state :->analysis-info merge ->analysis-info)
+          (-> state
+              (update :->analysis-info merge ->analysis-info)
+              (update :var->block-id merge var->block-id))
           (vals ->analysis-info)))
 
 #_(merge-analysis-info {:->analysis-info {:a :b}} {:->analysis-info {:c :d}})

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -426,7 +426,7 @@
 
                                (and doc? (not (contains? state :ns))) (merge (parser/->doc-settings form) {:ns *ns*})))))
 
-                       (-> state (merge doc) (dissoc :doc?) (assoc :blocks []))
+                       (-> state (merge doc) (assoc :blocks []))
                        (:blocks doc))
 
          true analyze-doc-deps

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -261,6 +261,14 @@
 (def dep->keys*
   (memoize
    (fn [->analysis-info dep]
+     ;; TODO: do with a reverse lookup map
+     ;; this reverse lookup is needed in case vars are produced by "anonymous" forms, since only block ids are allowed as graph nodes
+     ;; we can have multiple keys for a single dep in case of forward declarations
+     ;; TODO: adjust for cases like
+     ;;  (def a 1)
+     ;;  (inc a)
+     ;;  (def a 2)
+     ;;  (inc a)
      (or (not-empty
           (keep (fn [[key {:keys [var vars]}]]
                   (when (contains? (cond-> (set vars) var (conj var)) dep)

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -244,16 +244,6 @@
                             (dep/depend dep rec-var)))
         (assoc-in [:->analysis-info rec-var :form] rec-form))))
 
-(defn ->key [{:as codeblock :keys [var id]}]
-  ;; TODO: remove calls
-  #_(if var var id)
-  id)
-
-(defn ->ana-keys [{:as analyzed :keys [form vars id]}]
-  ;; TODO: remove calls
-  #_(if (seq vars) vars [(->key analyzed)])
-  [(->key analyzed)])
-
 #_(->> (nextjournal.clerk.eval/eval-string "(rand-int 100) (rand-int 100) (rand-int 100)") :blocks (mapv #(-> % :result :nextjournal/value)))
 
 (def dep->keys*

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -389,8 +389,8 @@
                                (and doc? (not (contains? state :ns))) (merge (parser/->doc-settings form) {:ns *ns*})))))
 
                        (-> state
-                           (assoc :blocks [])
-                           (cond-> doc? (merge doc)))
+                           (cond-> doc? (merge doc))
+                           (assoc :blocks []))
                        (:blocks doc))
 
          true analyze-doc-deps

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -230,14 +230,13 @@
 (defn- circular-dependency-error? [e]
   (-> e ex-data :reason #{::dep/circular-dependency}))
 
-(defn- analyze-circular-dependency [state vars form dep {:as _data :keys [node dependency]}]
+(defn- analyze-circular-dependency [state vars form dep {:keys [node dependency]}]
   (let [rec-form (concat '(do) [form (get-in state [:->analysis-info dependency :form])])
         rec-var (symbol (str/join "+" (sort (conj vars dep))))
         var (first vars)] ;; TODO: reduce below
     (when (not= dep dependency) (println :dep-mismatch dep dependency))
     (when (not= var node) (println :node-mismatch var node))
     (-> state
-        (update :fixed-circular-deps assoc var rec-var dep rec-var)
         (update :graph #(-> %
                             (dep/remove-edge dependency node)
                             (dep/depend var rec-var)

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -253,8 +253,8 @@
   (let [rec-form (concat '(do) [form (get-in state [:->analysis-info dependency :form])])
         rec-var (symbol (str/join "+" (sort (conj vars dep))))
         var (first vars)] ;; TODO: reduce below
-    (when (not= dep dependency) (println :dep-mismatch dep dependency))
-    (when (not= var node) (println :node-mismatch var node))
+    ;;(when (not= dep dependency) (println :dep-mismatch dep dependency))
+    ;;(when (not= var node) (println :node-mismatch var node))
     (-> state
         (update :graph #(-> %
                             (dep/remove-edge dependency node)

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -268,9 +268,8 @@
      ;;  (def a 2)
      ;;  (inc a)
      (or (not-empty
-          (keep (fn [[key {:keys [var vars]}]]
-                  (when (contains? (cond-> (set vars) var (conj var)) dep)
-                    key)) ->analysis-info))
+          (keep (fn [[key {:keys [vars]}]]
+                  (when (contains? vars dep) key)) ->analysis-info))
          ;; this will introduce also deref-deps as nodes in the graph
          (list dep)))))
 

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -164,11 +164,12 @@
     (update :nextjournal/viewers eval)))
 
 (defn read+eval-cached [{:as doc :keys [blob->result ->analysis-info ->hash]} codeblock]
-  (let [{:keys [form _vars var]} codeblock
-        {:as form-info :keys [ns-effect? no-cache? freezable?]} (->analysis-info (analyzer/->key codeblock))
+  (let [{:keys [id form _vars var]} codeblock
+        _ (assert id (format "Missing id on codeblock: '%s'." (pr-str codeblock)))
+        {:as form-info :keys [ns-effect? no-cache? freezable?]} (->analysis-info id)
         no-cache?      (or ns-effect? no-cache?)
-        hash           (when-not no-cache? (or (get ->hash (analyzer/->key codeblock))
-                                               (prn :hash/key-missing (analyzer/->key codeblock))
+        hash           (when-not no-cache? (or (get ->hash id)
+                                               (prn :hash/key-missing id)
                                                (analyzer/hash-codeblock ->hash doc codeblock)))
         digest-file    (when hash (->cache-file (str "@" hash)))
         cas-hash       (when (and digest-file (fs/exists? digest-file)) (slurp digest-file))

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -70,7 +70,8 @@
 
                            :else
                            (throw (ex-info "Unable to resolve into a variable" {:data var})))]
-    {:nextjournal.clerk/var-from-def resolved-var}))
+    {:nextjournal.clerk/var-from-def resolved-var
+     :nextjournal.clerk/var-snapshot @resolved-var}))
 
 (defn ^:private lookup-cached-result [introduced-var hash cas-hash]
   (when-let [cached-value (try (thaw-from-cas cas-hash)
@@ -169,7 +170,6 @@
         {:as form-info :keys [ns-effect? no-cache? freezable?]} (->analysis-info id)
         no-cache?      (or ns-effect? no-cache?)
         hash           (when-not no-cache? (or (get ->hash id)
-                                               (prn :hash/key-missing id)
                                                (analyzer/hash-codeblock ->hash doc codeblock)))
         digest-file    (when hash (->cache-file (str "@" hash)))
         cas-hash       (when (and digest-file (fs/exists? digest-file)) (slurp digest-file))

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -163,12 +163,13 @@
     viewers
     (update :nextjournal/viewers eval)))
 
-(defn read+eval-cached [{:as _doc :keys [blob->result ->analysis-info ->hash]} codeblock]
-  (let [{:keys [form vars var]} codeblock
-        {:as form-info :keys [ns-effect? no-cache? freezable?]} (->analysis-info (if (seq vars) (first vars) (analyzer/->key codeblock)))
+(defn read+eval-cached [{:as doc :keys [blob->result ->analysis-info ->hash]} codeblock]
+  (let [{:keys [form _vars var]} codeblock
+        {:as form-info :keys [ns-effect? no-cache? freezable?]} (->analysis-info (analyzer/->key codeblock))
         no-cache?      (or ns-effect? no-cache?)
         hash           (when-not no-cache? (or (get ->hash (analyzer/->key codeblock))
-                                               (analyzer/hash-codeblock ->hash codeblock)))
+                                               (prn :hash/key-missing (analyzer/->key codeblock))
+                                               (analyzer/hash-codeblock ->hash doc codeblock)))
         digest-file    (when hash (->cache-file (str "@" hash)))
         cas-hash       (when (and digest-file (fs/exists? digest-file)) (slurp digest-file))
         cached-result-in-memory (get blob->result hash)

--- a/src/nextjournal/clerk/graph_visualizer.clj
+++ b/src/nextjournal/clerk/graph_visualizer.clj
@@ -1,5 +1,5 @@
 (ns nextjournal.clerk.graph-visualizer
-  {:no-doc true}
+  {:no-doc true :nextjournal.clerk/no-cache true}
   (:require [arrowic.core :as arrowic]
             [nextjournal.clerk :as clerk]
             [nextjournal.clerk.analyzer :as analyzer]

--- a/src/nextjournal/clerk/graph_visualizer.clj
+++ b/src/nextjournal/clerk/graph_visualizer.clj
@@ -10,6 +10,7 @@
    (arrowic/as-svg
     (arrowic/with-graph (arrowic/create-graph)
       (let [vars->verticies (into {} (map (juxt identity arrowic/insert-vertex!)) (keys ->analysis-info))]
+        (assert (not-empty vars->verticies))
         (doseq [var (keys ->analysis-info)]
           (doseq [dep (dep/immediate-dependencies graph var)]
             (when (and (vars->verticies var)
@@ -17,14 +18,22 @@
               (arrowic/insert-edge! (vars->verticies var) (vars->verticies dep))))))))))
 
 
-(defn graph-file [file]
-  (-> (analyzer/analyze-file {:graph (dep/graph)} file )
-      analyzer/build-graph
-      dep-svg))
+(defn graph-file
+  ([file] (graph-file {} file))
+  ([{:keys [key-filter-fn] :or {key-filter-fn identity}} file]
+   (-> (analyzer/analyze-file {:graph (dep/graph)} file)
+       analyzer/build-graph
+       (update :->analysis-info
+               (partial into {}
+                        (filter (comp key-filter-fn key))))
+       dep-svg)))
 
 ^{::clerk/width :full}
 (graph-file "src/nextjournal/clerk/classpath.clj")
 
-
 ^{::clerk/width :full}
-(graph-file "src/nextjournal/clerk/parser.cljc")
+(graph-file {:key-filter-fn (comp #{"nextjournal.clerk.parser"
+                                    "nextjournal.clerk.analyzer"
+                                    "nextjournal.clerk.classpath"
+                                    "nextjournal.clerk.config"} namespace)}
+            "src/nextjournal/clerk/analyzer.clj")

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -411,7 +411,8 @@
 (def var-from-def-viewer
   {:name `var-from-def-viewer
    :pred var-from-def?
-   :transform-fn (update-val (comp deref :nextjournal.clerk/var-from-def))})
+   :transform-fn (update-val (some-fn :nextjournal.clerk/var-snapshot
+                                      (comp deref :nextjournal.clerk/var-from-def)))})
 
 (defn apply-viewer-unwrapping-var-from-def
   "Applies the `viewer` (if set) to the given result `result`. In case

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -201,7 +201,6 @@
 
 (defn analyze-string [s]
   (-> (parser/parse-clojure-string {:doc? true} s)
-      ana/analyze-doc
       ana/build-graph))
 
 (deftest hash-test

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -210,7 +210,15 @@
          {:jar
           #"repository/weavejester/dependency/0.2.1/dependency-0.2.1.jar",
           :hash "5dsZiMRBpbMfWTafMoHEaNdGfEYxpx"}
-         (ana/hash-jar (ana/find-location 'weavejester.dependency/graph))))))
+         (ana/hash-jar (ana/find-location 'weavejester.dependency/graph)))))
+
+  (testing "an edge-case with a particular sorting of the graph nodes"
+    (is (-> (analyze-string "
+(do
+  (declare b)
+  (def a 1))
+
+(inc a)") ana/hash))))
 
 (deftest analyze-doc
   (testing "reading a bad block shows block and file info in raised exception"
@@ -314,7 +322,6 @@ my-uuid")]
           analyzed-after (ana/hash (analyze-string test-string))]
       (is (not= (get-in analyzed-before [:->hash test-var])
                 (get-in analyzed-after [:->hash test-var]))))))
-
 
 (deftest hash-deref-deps
   (testing "transitive dep gets new hash"

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -1,6 +1,5 @@
 (ns nextjournal.clerk.analyzer-test
   (:require [babashka.fs :as fs]
-            [clojure.set :as set]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [matcher-combinators.matchers :as m]
@@ -343,10 +342,8 @@ my-uuid")]
 
 
 (deftest circular-dependency
-  (is (match? {:graph {:dependencies {'circular/b (partial set/subset? #{'clojure.core/str (symbol "circular/a+circular/b")})
-                                      ;; 👆the block (def b …) depends on a, the var a originates from _both_
-                                      ;; * the anonymous block (declare a)
-                                      ;; * and the actual definition (def a …)
+  (is (match? {:graph {:dependencies {'circular/b #{'clojure.core/str
+                                                    (symbol "circular/a+circular/b")}
                                       'circular/a #{#_'clojure.core/declare 'clojure.core/str (symbol "circular/a+circular/b")}}}
                :->analysis-info {'circular/a any?
                                  'circular/b any?

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -332,3 +332,24 @@ my-uuid")]
           runtime-hash (get-in runtime-doc [:->hash 'nextjournal.clerk.test.deref-dep/foo+2])]
       (is (match? {:deref-deps #{`(deref nextjournal.clerk.test.deref-dep/!state)}} block-with-deref-dep))
       (is (not= static-hash runtime-hash)))))
+
+(deftest forms-do-not-depend-on-forward-declaration-forms
+  (let [ana-1 (-> "(ns nextjournal.clerk.analyzer-test.forward-declarations)
+
+(declare x)
+(defn foo [] (inc (x)))
+(defn x [] 0)
+"
+                  analyze-string ana/hash)
+        block-3-id (-> ana-1 :blocks (nth 2) :id)
+        hash-1 (-> ana-1 :->hash block-3-id)
+        ana-2 (-> "(ns nextjournal.clerk.analyzer-test.forward-declarations)
+
+(declare x y)
+(defn foo [] (inc (x)))
+(defn x [] 0)
+"
+                  analyze-string ana/hash)
+        hash-2 (-> ana-2 :->hash block-3-id)]
+
+    (is (= hash-1 hash-2))))

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -266,7 +266,17 @@
           hash-2 (-> ana-2 :->hash block-id)]
 
       (is hash-1) (is hash-2)
-      (is (not= hash-1 hash-2)))))
+      (is (not= hash-1 hash-2))))
+
+  (testing "redefinitions (and their dependents) are never cached"
+    (let [{:keys [->analysis-info]} (analyze-string "(ns nextjournal.clerk.analyzer-test.redefs)
+(def a 0)
+(def b (inc a))
+(def a 1)
+")]
+      (is (:no-cache? (get ->analysis-info 'nextjournal.clerk.analyzer-test.redefs/a)))
+      (is (:no-cache? (get ->analysis-info 'nextjournal.clerk.analyzer-test.redefs/b)))
+      (is (:no-cache? (get ->analysis-info 'nextjournal.clerk.analyzer-test.redefs/a#2))))))
 
 (deftest analyze-doc
   (testing "reading a bad block shows block and file info in raised exception"

--- a/test/nextjournal/clerk/builder_test.clj
+++ b/test/nextjournal/clerk/builder_test.clj
@@ -11,8 +11,8 @@
 
 (deftest url-canonicalize
   (testing "canonicalization of file components into url components"
-    (let [dice (str/join (File/separator) ["notebooks" "dice.clj"])]
-      (is (= (#'builder/path-to-url-canonicalize dice) (str/replace dice  (File/separator) "/"))))))
+    (let [dice (str/join File/separator ["notebooks" "dice.clj"])]
+      (is (= (#'builder/path-to-url-canonicalize dice) (str/replace dice File/separator "/"))))))
 
 (deftest static-app
   (let [url* (volatile! nil)
@@ -21,8 +21,8 @@
                                                    (vreset! url* path))]
       (testing "browser receives canonical url in this system arch"
         (fs/with-temp-dir [temp {}]
-          (let [expected (-> (str/join (java.io.File/separator) [(.toString temp) "index.html"])
-                             (str/replace (java.io.File/separator) "/"))]
+          (let [expected (-> (str/join File/separator [(.toString temp) "index.html"])
+                             (str/replace File/separator "/"))]
             (builder/build-static-app! {:browse? true
                                         :paths ["notebooks/hello.clj"]
                                         :out-path temp})

--- a/test/nextjournal/clerk/eval_test.clj
+++ b/test/nextjournal/clerk/eval_test.clj
@@ -221,6 +221,20 @@
     (intern (create-ns 'existing-var) 'foo :bar)
     (is (eval/eval-string "(in-ns 'existing-var) foo"))))
 
+(deftest eval+cache!
+  (testing "edge case where some form is not evaluated"
+    (is (eval+extract-doc-blocks "(ns repro-crash-when-not-all-forms-are-evaluated
+  {:nextjournal.clerk/no-cache true})
+
+(do
+  (def b 2)
+  (declare a))
+
+(def a 1)
+
+(+ a b)
+"))))
+
 (clerk/defcached my-expansive-thing
   (do (Thread/sleep 1 #_10000) 42))
 

--- a/test/nextjournal/clerk/eval_test.clj
+++ b/test/nextjournal/clerk/eval_test.clj
@@ -135,7 +135,14 @@
                 (eval/eval-string "{:a (range)}"))))
 
   (testing "can handle failing hash computation for deref-dep"
-    (eval/eval-string "(ns test-deref-hash (:require [nextjournal.clerk :as clerk])) (defonce !state (atom [(clerk/md \"_hi_\")])) @!state")))
+    (eval/eval-string "(ns test-deref-hash (:require [nextjournal.clerk :as clerk])) (defonce !state (atom [(clerk/md \"_hi_\")])) @!state"))
+
+  (testing "won't eval forward declarations"
+    (is (thrown? Exception
+                 (eval/eval-string "(ns test-forward-declarations {:nextjournal.clerk/no-cache true})
+(declare delayed-def)
+(inc delayed-def)
+(def delayed-def 123)")))))
 
 (defn eval+extract-doc-blocks [code-str]
   (-> code-str


### PR DESCRIPTION
* Simplify Graph nodes (each code block appears in the graph just once by its block-id)
* Simplify hash of deps (only graph dependencies are used to compute the hash of a block)
* Improve assertion on missing hash for dependencies
* Take var snapshots during eval 
* Don't make expressions depend on forward declarations, but only on actual definitions
* Handle var redefinitions (all blocks with redefined vars are not cached)

Fixes #454 
Fixes #628
Fixes #66
Fixes #634 