### PR TITLE
Show plotly and vega examples with transparent background in book

### DIFF
--- a/book.clj
+++ b/book.clj
@@ -246,7 +246,9 @@
 ;; Clerk also has built-in support for Plotly's low-ceremony plotting.
 ;; See [Plotly's JavaScript docs](https://plotly.com/javascript/) for more examples and [options](https://plotly.com/javascript/configuration-options/).
 (clerk/plotly {:data [{:z [[1 2 3] [3 2 1]] :type "surface"}]
-               :layout {:margin {:l 20 :r 0 :b 20 :t 20}}
+               :layout {:margin {:l 20 :r 0 :b 20 :t 20}
+                        :paper_bgcolor "transparent"
+                        :plot_bgcolor "transparent"}
                :config {:displayModeBar false
                         :displayLogo false}})
 
@@ -258,6 +260,7 @@
            :transform [{:lookup "id" :from {:data {:url "https://vega.github.io/vega-datasets/data/unemployment.tsv"}
                                             :key "id" :fields ["rate"]}}]
            :projection {:type "albersUsa"} :mark "geoshape" :encoding {:color {:field "rate" :type "quantitative"}}
+           :background "transparent"
            :embed/opts {:actions false}})
 
 ;; You can provide a map of [embed options](https://github.com/vega/vega-embed#embed) to the vega viewer via the `:embed/opts` key.


### PR DESCRIPTION
Examples look better in dark mode, and unchanged in light mode:
<img width="1050" alt="Screenshot 2024-02-08 at 16 41 53" src="https://github.com/nextjournal/clerk/assets/1301852/28d01095-a4f2-42c2-a7fb-7702f9de8763">
