### PR TITLE
Wrapped value viewer

### DIFF
--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1327,6 +1327,11 @@
                     [nextjournal.clerk.render/inspect [(symbol (pr-str (type x))) @x]]]
                    [nextjournal.clerk.render/inspect x]))})
 
+(def wrapped-value-viewer
+  {:name `wrapped-value-viewer
+   :pred wrapped-value?
+   :transform-fn (update-val (get-safe :nextjournal/value))})
+
 (def default-viewers
   ;; maybe make this a sorted-map
   [header-viewer
@@ -1348,6 +1353,7 @@
    viewer-eval-viewer
    cell-viewer
    result-viewer
+   wrapped-value-viewer
    map-viewer
    var-viewer
    throwable-viewer

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -132,6 +132,12 @@
     (is (= :full
            (:nextjournal/width (v/apply-viewers (v/table {:nextjournal.clerk/width :full} {:a [1] :b [2] :c [3]})))))))
 
+(deftest presenting-wrapped-values
+  (testing "present is invariant on wrapped values"
+    (is (= (v/present (v/with-viewer v/number-viewer 123))
+           (v/present {:nextjournal/value (v/with-viewer v/number-viewer 123)})
+           (v/present {:nextjournal/value {:nextjournal/value (v/with-viewer v/number-viewer 123)}})))))
+
 (deftest present-exceptions
   (testing "can represent ex-data in a readable way"
     (binding [*data-readers* v/data-readers]


### PR DESCRIPTION
Closes #639. Closes #638.

Fixes presentation of wrapped values, so far: 

```clojure

(viewer/present {:nextjournal/value (clerk/with-viewer viewer/string-viewer "hello")})

;; => [{:path [],
;;      :nextjournal/value "hello",
;;      :nextjournal/viewer {:name nextjournal.clerk.viewer/map-viewer,
;;                           :render-fn #viewer-fnnextjournal.clerk.render/render-map,
;;                           :opening-paren "{",
;;                           :closing-paren ("}"),
;;                           :page-size 10,
;;                           :hash "5drSiYgxwbGAGQx15hZm4Ts9vK16be"}}
```

the inner value and the assigned viewer were out of sync. This change makes `viewer/present` invariant of further wrapping.