### PR TITLE
Fix error display by hoisting nested wrapped values

### DIFF
--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1457,10 +1457,10 @@
     x))
 
 (defn apply-viewers* [wrapped-value]
-  (when (empty? (->viewers wrapped-value))
-    (throw (ex-info "cannot apply empty viewers" {:wrapped-value wrapped-value})))
   (let [hoisted-wrapped-value (hoist-nested-wrapped-value wrapped-value)
         viewers (->viewers hoisted-wrapped-value)
+        _ (when (empty? viewers)
+            (throw (ex-info "cannot apply empty viewers" {:wrapped-value wrapped-value})))
         {:as viewer viewers-to-add :add-viewers :keys [render-fn transform-fn]} (viewer-for viewers hoisted-wrapped-value)
         transformed-value (cond-> (ensure-wrapped-with-viewers viewers
                                                                (cond-> (-> hoisted-wrapped-value

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1473,7 +1473,7 @@
 (defn flatten-wrapper [x]
   (if (and (wrapped-value? x)
            (wrapped-value? (get-safe x :nextjournal/value)))
-    (merge-with (fn [v1 v2] (if (vector? v2) (concat v2 v1) v2)) ;; preserve :nextjournal/viewers
+    (merge-with (fn [v1 v2] (if (vector? v2) (vec (concat v2 v1)) v2)) ;; preserve :nextjournal/viewers
                 x (flatten-wrapper (get-safe x :nextjournal/value)))
     x))
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1473,8 +1473,7 @@
 (defn flatten-wrapper [x]
   (if (and (wrapped-value? x)
            (wrapped-value? (get-safe x :nextjournal/value)))
-    (merge-with (fn [v1 v2] (if (vector? v2) (vec (concat v2 v1)) v2)) ;; preserve :nextjournal/viewers
-                x (flatten-wrapper (get-safe x :nextjournal/value)))
+    (merge x (flatten-wrapper (get-safe x :nextjournal/value)))
     x))
 
 #_(flatten-wrapper {:nextjournal/value {:nextjournal/value 1}})

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -141,7 +141,11 @@
   (testing "present is invariant on wrapped values"
     (is (= (v/present (v/with-viewer v/number-viewer 123))
            (v/present {:nextjournal/value (v/with-viewer v/number-viewer 123)})
-           (v/present {:nextjournal/value {:nextjournal/value (v/with-viewer v/number-viewer 123)}})))))
+           (v/present {:nextjournal/value {:nextjournal/value (v/with-viewer v/number-viewer 123)}})))
+
+    (is (= (v/present (v/with-viewer v/html-viewer [:h1 "ahoi"]))
+           (v/present {:nextjournal/value (v/with-viewer v/html-viewer [:h1 "ahoi"])})
+           (v/present {:nextjournal/value {:nextjournal/value (v/with-viewer v/html-viewer [:h1 "ahoi"])}})))))
 
 (deftest present-exceptions
   (testing "can represent ex-data in a readable way"

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -132,6 +132,12 @@
     (is (= :full
            (:nextjournal/width (v/apply-viewers (v/table {:nextjournal.clerk/width :full} {:a [1] :b [2] :c [3]})))))))
 
+(deftest presenting-wrapped-values
+  (testing "present is invariant on wrapped values"
+    (is (= (v/present (v/with-viewer v/number-viewer 123))
+           (v/present {:nextjournal/value (v/with-viewer v/number-viewer 123)})
+           (v/present {:nextjournal/value {:nextjournal/value (v/with-viewer v/number-viewer 123)}})))))
+
 (deftest present-exceptions
   (testing "can represent ex-data in a readable way"
     (binding [*data-readers* v/data-readers]

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -133,6 +133,11 @@
            (:nextjournal/width (v/apply-viewers (v/table {:nextjournal.clerk/width :full} {:a [1] :b [2] :c [3]})))))))
 
 (deftest presenting-wrapped-values
+  (testing "apply-viewers is invariant on wrapped values"
+    (is (= (v/apply-viewers (v/with-viewer v/number-viewer 123))
+           (v/apply-viewers {:nextjournal/value (v/with-viewer v/number-viewer 123)})
+           (v/apply-viewers {:nextjournal/value {:nextjournal/value (v/with-viewer v/number-viewer 123)}}))))
+
   (testing "present is invariant on wrapped values"
     (is (= (v/present (v/with-viewer v/number-viewer 123))
            (v/present {:nextjournal/value (v/with-viewer v/number-viewer 123)})


### PR DESCRIPTION
Runtime errors could lead to a malformed document that would result in a react error leading to the page unmounting and showing a white screen of death. The malformed document was caused by nested wrapped values which we hoist here.

Fixes #639 and fixes #638.