### PR TITLE
Book: update reference to vl EDN gallery

### DIFF
--- a/book.clj
+++ b/book.clj
@@ -264,7 +264,7 @@
 ;;
 ;; Clerk handles conversion from EDN to JSON for you.
 ;; The official Vega-Lite examples are in JSON, but a Clojure/EDN version is available:
-;; [Carsten Behring's Vega gallery in EDN](https://github.clerk.garden/behrica/vl-galery/).
+;; [Carsten Behring's Vega gallery in EDN](https://vlgalleryedn.happytree-bf95e0f8.westeurope.azurecontainerapps.io/).
 
 ;; ### 🎼 Code
 


### PR DESCRIPTION
Hi! A while ago, I asked to add a link to a Vega Lite gallery with examples in EDN. The author of the example gallery has made a new version, and encourages people to use the new version instead. From https://github.com/behrica/vl-galery :

![image](https://github.com/nextjournal/clerk/assets/5285452/017cf650-163b-4088-a528-713aa8beb5c3)

This PR updates the link to the new address.