### PR TITLE
Fix typo "tranform-fn" to "transform-fn"

### DIFF
--- a/book.clj
+++ b/book.clj
@@ -548,7 +548,7 @@ v/default-viewers
 
 ;; #### ⚙️ Transform
 
-;; When writing your own viewer, the first extension point you should reach for is `:tranform-fn`.
+;; When writing your own viewer, the first extension point you should reach for is `:transform-fn`.
 
 #_ "exercise: wrap this in `v/present` and call it at the REPL"
 (v/with-viewer {:transform-fn v/inspect-wrapped-values}


### PR DESCRIPTION
Fixes a typo in the following sentence:

> ⚙️ Transform
When writing your own viewer, the first extension point you should reach for is `:tranform-fn`.

