### PR TITLE
Support empty tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes can be:
 
 ## Unreleased
 
+* 💫 Make `clerk/table` work with empty tables.
 ...
 
 ## 0.16.1016 (2024-06-05)

--- a/notebooks/viewers/table.clj
+++ b/notebooks/viewers/table.clj
@@ -8,6 +8,10 @@
             [nextjournal.clerk.viewer :as v]
             [honey.sql :as sql]))
 
+;; ## Empty table
+
+(clerk/table [])
+
 ;; ## SQL Queries
 (def query-results
   (let [_run-at #inst "2021-05-20T08:28:29.445-00:00"

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -294,6 +294,7 @@
     (and (map? data) (sequential? (first (vals data)))) (normalize-map-of-seq data)
     (and (sequential? data) (map? (first data))) (normalize-seq-of-map data)
     (and (sequential? data) (sequential? (first data))) (normalize-seq-of-seq data)
+    (empty? data) {:rows []}
     :else nil))
 
 (defn demunge-ex-data [ex-data]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1085,15 +1085,14 @@
                                                                                     (comp (map-indexed vector)
                                                                                           (keep #(when (number? (second %)) (first %))))
                                                                                     (not-empty (first rows)))})
-                         (assoc :nextjournal/value (if (empty? rows)
-                                                     (html [:span.italic "no data"])
-                                                     (cond->> []
-                                                       (seq rows) (cons (with-viewer `table-body-viewer (merge (-> applied-viewer
-                                                                                                                   (select-keys [:page-size])
-                                                                                                                   (set/rename-keys {:page-size :nextjournal/page-size}))
-                                                                                                               (select-keys wrapped-value [:nextjournal/page-size]))
-                                                                          (map (partial with-viewer `table-row-viewer) rows)))
-                                                       head (cons (with-viewer (:name table-head-viewer table-head-viewer) head))))))
+                         (assoc :nextjournal/value (cond->> [(with-viewer `table-body-viewer (merge (-> applied-viewer
+                                                                                                        (select-keys [:page-size])
+                                                                                                        (set/rename-keys {:page-size :nextjournal/page-size}))
+                                                                                                    (select-keys wrapped-value [:nextjournal/page-size]))
+                                                               (if (seq rows)
+                                                                 (map (partial with-viewer `table-row-viewer) rows)
+                                                                 [(html [:span.italic "this table has no rows"])]))]
+                                                     head (cons (with-viewer (:name table-head-viewer table-head-viewer) head)))))
                      (-> wrapped-value
                          mark-presented
                          (assoc :nextjournal/width :wide)


### PR DESCRIPTION
Shows "no data" for empty tables, instead of an error.

![2024-07-30-183954_985x193_scrot](https://github.com/user-attachments/assets/2bae4003-eb95-4ba6-bef6-7a063b860f19)

Alternatively just show nothing?

Closes #661 