### PR TITLE
Viewers can provide CLJS code in .cljs files

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -46,7 +46,7 @@
                               io.github.nextjournal/cas-client {:git/sha "22ef8360689cd3938e43a3223023ab1b9711818f"}
                               org.slf4j/slf4j-nop {:mvn/version "2.0.7"}
                               org.babashka/cli {:mvn/version "0.5.40"}
-                              io.github.babashka/sci.nrepl {:git/sha "75f379c685bbd58c3e23f531339eb144e104937d"}}
+                              io.github.babashka/sci.nrepl {:git/sha "630062b76a4a9ca7d2565fd494d7baaf3460554b"}}
                  :extra-paths ["dev" "notebooks"]
                  :jvm-opts ["-Dclerk.resource_manifest={\"/js/viewer.js\" \"/js/viewer.js\"}"
                             "-Dclerk.render_repl={}"

--- a/deps.edn
+++ b/deps.edn
@@ -35,7 +35,6 @@
                                :jvm-opts ["-Dclojure.main.report=stdout"]
                                :nextjournal.clerk/aliases [:demo]}
 
-           
            :sci {:extra-deps {io.github.nextjournal/clerk.render {:local/root "render"}}}
 
            :dev {:extra-deps {org.clojure/clojure {:mvn/version "1.12.0-beta1"} ;; for `:as-alias` & `add-lib` support but only in dev

--- a/notebooks/eval_cljs.clj
+++ b/notebooks/eval_cljs.clj
@@ -1,6 +1,7 @@
 ;; # 📑 Eval CLJS
 (ns eval-cljs
-  (:require [nextjournal.clerk :as clerk]))
+  (:require [nextjournal.clerk :as clerk]
+            [viewers.viewer-with-cljs-source :as wcs]))
 
 ;; Let's load some .cljs code from a file!
 ;; Because we want to re-render this notebook when the .cljs code changes, we use `::clerk/no-cache`
@@ -23,3 +24,6 @@
    :transition {:duration 2
                 :repeat 12345
                 :repeatType "reverse"}})
+
+(clerk/with-viewer wcs/my-cool-viewer
+  [1 2 3])

--- a/notebooks/eval_cljs.clj
+++ b/notebooks/eval_cljs.clj
@@ -25,5 +25,6 @@
                 :repeat 12345
                 :repeatType "reverse"}})
 
+^{::clerk/no-cache true}
 (clerk/with-viewer wcs/my-cool-viewer
   [1 2 3])

--- a/notebooks/eval_cljs.clj
+++ b/notebooks/eval_cljs.clj
@@ -27,4 +27,4 @@
 
 ^{::clerk/no-cache true}
 (clerk/with-viewer wcs/my-cool-viewer
-  [1 2 3])
+  [1 2 3 4])

--- a/notebooks/viewers/viewer_lib.cljs
+++ b/notebooks/viewers/viewer_lib.cljs
@@ -2,5 +2,5 @@
 
 (defn my-already-defined-function [x]
   [:div
-   "Inspected value >>>>>>>>>>>>>>>"
+   "Inspected value :)"
    [:div [nextjournal.clerk/inspect x]]] )

--- a/notebooks/viewers/viewer_lib.cljs
+++ b/notebooks/viewers/viewer_lib.cljs
@@ -1,6 +1,8 @@
-(ns viewers.viewer-lib)
+(ns viewers.viewer-lib
+  (:require [nextjournal.clerk :as clerk]))
 
 (defn my-already-defined-function [x]
   [:div
    "Inspected value :)"
-   [:div [nextjournal.clerk/inspect x]]] )
+   [:div [clerk/inspect x]]])
+

--- a/notebooks/viewers/viewer_lib.cljs
+++ b/notebooks/viewers/viewer_lib.cljs
@@ -1,0 +1,6 @@
+(ns viewers.viewer-lib)
+
+(defn my-already-defined-function [x]
+  [:div
+   "Inspected value >>>>>>>>>>>>>>>"
+   [:div [nextjournal.clerk/inspect x]]] )

--- a/notebooks/viewers/viewer_with_cljs_source.clj
+++ b/notebooks/viewers/viewer_with_cljs_source.clj
@@ -5,9 +5,9 @@
  'viewers.viewer-with-cljs-source
  'my-already-defined-function
  '(fn [x]
-    (prn :x x)
-    (prn :> (nextjournal.clerk/->value x))
-    [nextjournal.clerk.render/inspect x]))
+    [:div
+     [:p "This is a custom pre-defined viewer function!"]
+     [nextjournal.clerk.render/inspect x]]))
 
 (def my-cool-viewer
   {:render-fn `my-already-defined-function

--- a/notebooks/viewers/viewer_with_cljs_source.clj
+++ b/notebooks/viewers/viewer_with_cljs_source.clj
@@ -1,0 +1,12 @@
+(ns viewers.viewer-with-cljs-source
+  (:require [nextjournal.clerk :as clerk]))
+
+(clerk/reg-sci-snippet!
+ (pr-str '(do (ns viewers.viewer-with-cljs-source)
+              (defn my-already-defined-function [{:keys [x]}]
+                (prn :x x)
+                x))))
+
+(def my-cool-viewer
+  {:render-fn `my-already-defined-function
+   :transform-fn (fn [x] x)})

--- a/notebooks/viewers/viewer_with_cljs_source.clj
+++ b/notebooks/viewers/viewer_with_cljs_source.clj
@@ -3,23 +3,6 @@
 
 (clerk/require-cljs 'viewers.viewer-with-cljs-source)
 
-#_(clerk/intern-sci-var
- 'viewers.viewer-with-cljs-source
- 'my-already-defined-function
- '(fn [x]
-    [:div
-     "Inspected value!!!!!!"
-     [:div [nextjournal.clerk/inspect x]]]))
-
-#_(clerk/intern-sci-var
- 'viewers.viewer-with-cljs-source
- 'my-already-defined-function2
- `(fn [x#]
-    [:div
-     [:p "This is a custom pre-defined viewer function!"]
-     [:div
-      [my-already-defined-function x#]]]))
-
 (def my-cool-viewer
   {:render-fn `my-already-defined-function2
    :transform-fn (fn [x] x)})

--- a/notebooks/viewers/viewer_with_cljs_source.clj
+++ b/notebooks/viewers/viewer_with_cljs_source.clj
@@ -1,11 +1,13 @@
 (ns viewers.viewer-with-cljs-source
   (:require [nextjournal.clerk :as clerk]))
 
-(clerk/reg-sci-snippet!
- (pr-str '(do (ns viewers.viewer-with-cljs-source)
-              (defn my-already-defined-function [{:keys [x]}]
-                (prn :x x)
-                x))))
+(clerk/intern-sci-var
+ 'viewers.viewer-with-cljs-source
+ 'my-already-defined-function
+ '(fn [x]
+    (prn :x x)
+    (prn :> (nextjournal.clerk/->value x))
+    [nextjournal.clerk.render/inspect x]))
 
 (def my-cool-viewer
   {:render-fn `my-already-defined-function

--- a/notebooks/viewers/viewer_with_cljs_source.clj
+++ b/notebooks/viewers/viewer_with_cljs_source.clj
@@ -1,15 +1,17 @@
 (ns viewers.viewer-with-cljs-source
   (:require [nextjournal.clerk :as clerk]))
 
-(clerk/intern-sci-var
+(clerk/require-cljs 'viewers.viewer-with-cljs-source)
+
+#_(clerk/intern-sci-var
  'viewers.viewer-with-cljs-source
  'my-already-defined-function
  '(fn [x]
     [:div
-     "Inspected value:"
+     "Inspected value!!!!!!"
      [:div [nextjournal.clerk/inspect x]]]))
 
-(clerk/intern-sci-var
+#_(clerk/intern-sci-var
  'viewers.viewer-with-cljs-source
  'my-already-defined-function2
  `(fn [x#]

--- a/notebooks/viewers/viewer_with_cljs_source.clj
+++ b/notebooks/viewers/viewer_with_cljs_source.clj
@@ -1,8 +1,8 @@
 (ns viewers.viewer-with-cljs-source
   (:require [nextjournal.clerk :as clerk]))
 
-(clerk/require-cljs 'viewers.viewer-with-cljs-source)
+(clerk/require-cljs '[viewers.viewer-with-cljs-source :as cljs-view])
 
 (def my-cool-viewer
-  {:render-fn `my-already-defined-function2
+  {:render-fn `cljs-view/my-already-defined-function2
    :transform-fn (fn [x] x)})

--- a/notebooks/viewers/viewer_with_cljs_source.clj
+++ b/notebooks/viewers/viewer_with_cljs_source.clj
@@ -6,9 +6,18 @@
  'my-already-defined-function
  '(fn [x]
     [:div
+     "Inspected value:"
+     [:div [nextjournal.clerk/inspect x]]]))
+
+(clerk/intern-sci-var
+ 'viewers.viewer-with-cljs-source
+ 'my-already-defined-function2
+ `(fn [x#]
+    [:div
      [:p "This is a custom pre-defined viewer function!"]
-     [nextjournal.clerk.render/inspect x]]))
+     [:div
+      [my-already-defined-function x#]]]))
 
 (def my-cool-viewer
-  {:render-fn `my-already-defined-function
+  {:render-fn `my-already-defined-function2
    :transform-fn (fn [x] x)})

--- a/notebooks/viewers/viewer_with_cljs_source.cljs
+++ b/notebooks/viewers/viewer_with_cljs_source.cljs
@@ -1,11 +1,13 @@
 (ns viewers.viewer-with-cljs-source
-  (:require [viewers.viewer-lib :as lib]))
+  (:require [viewers.viewer-lib :as lib]
+            [clojure.string :as str]))
 
-(defn my-already-defined-function2 [x#]
+(defn my-already-defined-function2 [x]
   [:div
    [:p "This is a custom pre-defined viewer function! :)"]
    [:div
-    [lib/my-already-defined-function x#]]])
+    [:div "str:" (str/join "," (range 10))]
+    [lib/my-already-defined-function x]]])
 
 ;;;; Scratch
 

--- a/notebooks/viewers/viewer_with_cljs_source.cljs
+++ b/notebooks/viewers/viewer_with_cljs_source.cljs
@@ -1,18 +1,15 @@
-(ns viewers.viewer-with-cljs-source)
-
-(comment
-  (nextjournal.clerk.render/re-render)
-  )
-
-(defn my-already-defined-function [x]
-  [:div
-   "Inspected value >>>>>>>>>>>>>>>"
-   [:div [nextjournal.clerk/inspect x]]] )
+(ns viewers.viewer-with-cljs-source
+  (:require [viewers.viewer-lib :as lib]))
 
 (defn my-already-defined-function2 [x#]
   [:div
    [:p "This is a custom pre-defined viewer function!"]
    [:div
-    [my-already-defined-function x#]]])
+    [lib/my-already-defined-function x#]]])
 
+;;;; Scratch
+
+(comment
+  (nextjournal.clerk.render/re-render)
+  )
 

--- a/notebooks/viewers/viewer_with_cljs_source.cljs
+++ b/notebooks/viewers/viewer_with_cljs_source.cljs
@@ -3,9 +3,11 @@
 
 (defn my-already-defined-function2 [x#]
   [:div
-   [:p "This is a custom pre-defined viewer function!"]
+   [:p "This is a custom pre-defined viewer function! :)"]
    [:div
     [lib/my-already-defined-function x#]]])
+
+(prn :dude)
 
 ;;;; Scratch
 

--- a/notebooks/viewers/viewer_with_cljs_source.cljs
+++ b/notebooks/viewers/viewer_with_cljs_source.cljs
@@ -8,16 +8,16 @@
   (let [state (hooks/use-state 0)
         [native-state set-state!] (React/useState 0)]
     [:div
-     [:p "This is a custom pre-defined viewer function! :)"]
+     [:p "This is a custom pre-defined viewer function!"]
      [:div
       [:div "str:" (str/join "," (range 10))]
       [lib/my-already-defined-function x]
       [:div
-       [:button.bg-sky-600 {:on-click #(swap! state inc)}
+       [:button.bg-sky-700 {:on-click #(swap! state inc)}
         "Click me: " @state]]
       [:div
-       [:button.bg-sky-600 {:on-click #(set-state! (inc native-state))}
-        "Click me: " native-state]]]]))
+       [:button.bg-sky-500 {:on-click #(set-state! (inc native-state))}
+        "Click me:" native-state]]]]))
 
 ;;;; Scratch
 

--- a/notebooks/viewers/viewer_with_cljs_source.cljs
+++ b/notebooks/viewers/viewer_with_cljs_source.cljs
@@ -1,0 +1,18 @@
+(ns viewers.viewer-with-cljs-source)
+
+(comment
+  (nextjournal.clerk.render/re-render)
+  )
+
+(defn my-already-defined-function [x]
+  [:div
+   "Inspected value >>>>>>>>>>>>>>>"
+   [:div [nextjournal.clerk/inspect x]]] )
+
+(defn my-already-defined-function2 [x#]
+  [:div
+   [:p "This is a custom pre-defined viewer function!"]
+   [:div
+    [my-already-defined-function x#]]])
+
+

--- a/notebooks/viewers/viewer_with_cljs_source.cljs
+++ b/notebooks/viewers/viewer_with_cljs_source.cljs
@@ -7,8 +7,6 @@
    [:div
     [lib/my-already-defined-function x#]]])
 
-(prn :dude)
-
 ;;;; Scratch
 
 (comment

--- a/notebooks/viewers/viewer_with_cljs_source.cljs
+++ b/notebooks/viewers/viewer_with_cljs_source.cljs
@@ -1,13 +1,23 @@
 (ns viewers.viewer-with-cljs-source
   (:require [viewers.viewer-lib :as lib]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [nextjournal.clerk.render.hooks :as hooks]
+            ["react" :as React]))
 
 (defn my-already-defined-function2 [x]
-  [:div
-   [:p "This is a custom pre-defined viewer function! :)"]
-   [:div
-    [:div "str:" (str/join "," (range 10))]
-    [lib/my-already-defined-function x]]])
+  (let [state (hooks/use-state 0)
+        [native-state set-state!] (React/useState 0)]
+    [:div
+     [:p "This is a custom pre-defined viewer function! :)"]
+     [:div
+      [:div "str:" (str/join "," (range 10))]
+      [lib/my-already-defined-function x]
+      [:div
+       [:button.bg-sky-600 {:on-click #(swap! state inc)}
+        "Click me: " @state]]
+      [:div
+       [:button.bg-sky-600 {:on-click #(set-state! (inc native-state))}
+        "Click me: " native-state]]]]))
 
 ;;;; Scratch
 

--- a/notebooks/viewers/viewer_with_cljs_source.cljs
+++ b/notebooks/viewers/viewer_with_cljs_source.cljs
@@ -23,5 +23,8 @@
 
 (comment
   (nextjournal.clerk.render/re-render)
+  (add-watch #'my-already-defined-function2 ::my-already-defined-function2
+             (fn [_ _ _ _]
+               (nextjournal.clerk.render/re-render)))
   )
 

--- a/render/deps.edn
+++ b/render/deps.edn
@@ -2,10 +2,13 @@
  :deps {applied-science/js-interop {:mvn/version "0.3.3"}
         binaryage/devtools {:mvn/version "1.0.3"}
         cider/cider-nrepl {:mvn/version "0.28.3"}
-        org.babashka/sci {:mvn/version "0.8.41"}
+        org.babashka/sci {:git/url "https://github.com/babashka/sci"
+                          :git/sha "c556f4474303c61da72e7a07eef496dcbf66a56e"}
         reagent/reagent {:mvn/version "1.2.0"}
-        io.github.babashka/sci.configs {:git/sha "0702ea5a21ad92e6d7cca6d36de84271083ea68f"}
+        io.github.babashka/sci.configs {:git/sha "0702ea5a21ad92e6d7cca6d36de84271083ea68f"
+                                        :exclusions [org.babashka/sci]}
         io.github.nextjournal/clojure-mode {:git/sha "1f55406087814a0dda6806396aa596dbe13ea302"}
         thheller/shadow-cljs {:mvn/version "2.23.1"}
         io.github.squint-cljs/cherry {;; :local/root "/Users/borkdude/dev/cherry"
-                                      :git/sha "ac89d93f136ee8fab91f62949de5b5822ba08b3c"}}}
+                                      :git/sha "ac89d93f136ee8fab91f62949de5b5822ba08b3c"
+                                      :exclusions [org.babashka/sci]}}}

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -20,11 +20,11 @@
 (defonce ^:private !last-file (atom nil))
 (defonce ^:private !watcher (atom nil))
 
-(defn require-cljs [& nss]
+(defn require-cljs
+  "Load (SCI) cljs code from namespaces and transitive dependencies on the
+  classpath. Calling this allows you to refer to functions by symbols in `:render-fn`"
+  [& nss]
   (apply cljs-libs/require-cljs nss))
-
-;; TODO:
-;; Make static bundle work
 
 (defn show!
   "Evaluates the Clojure source in `file-or-ns` and makes Clerk show it in the browser.

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -14,8 +14,7 @@
             [nextjournal.clerk.paths :as paths]
             [nextjournal.clerk.viewer :as v]
             [nextjournal.clerk.webserver :as webserver]
-            [flatland.ordered.set :as oset]
-            [nextjournal.clerk.viewer :as viewer]))
+            [flatland.ordered.set :as oset]))
 
 (defonce ^:private !show-filter-fn (atom nil))
 (defonce ^:private !last-file (atom nil))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -20,18 +20,19 @@
 (defonce ^:private !last-file (atom nil))
 (defonce ^:private !watcher (atom nil))
 
-(defonce sci-snippet-registry (atom {:vars {}
-                                     :order (oset/ordered-set)}))
+(defonce ^:private sci-interned-vars
+  (atom {:vars {}
+         :order (oset/ordered-set)}))
 
 (defn intern-sci-var [ns-name var-name s]
-  (swap! sci-snippet-registry (fn [state]
+  (swap! sci-interned-vars (fn [state]
                                 (-> state
                                     (update :vars assoc-in [ns-name var-name] s)
                                     (update :order conj [ns-name var-name]))))
   nil)
 
 (clojure.core/comment
-  @sci-snippet-registry
+  @sci-interned-vars
   )
 
 (defn show!
@@ -75,7 +76,7 @@
                                  (parser/parse-file {:doc? true} file))
                           (update :blocks (fn [blocks]
                                             (concat
-                                             (let [{:keys [order vars]} @sci-snippet-registry]
+                                             (let [{:keys [order vars]} @sci-interned-vars]
                                                (map (fn [var]
                                                       {:type :code
                                                        :text (format "(nextjournal.clerk/eval-cljs '(do

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -79,8 +79,7 @@
                                  (when-let [path (paths/path-in-cwd file-or-ns)]
                                    {:file-path path})
                                  {:nav-path (webserver/->nav-path file-or-ns)}
-                                 (parser/parse-file {:doc? true} file))
-                          (cljs-libs/update-blocks))
+                                 (parser/parse-file {:doc? true} file)))
                       (catch java.io.FileNotFoundException _e
                         (throw (ex-info (str "`nextjournal.clerk/show!` could not find the file: `" (pr-str file-or-ns) "`")
                                         {:file-or-ns file-or-ns})))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -22,7 +22,8 @@
 
 (defn require-cljs
   "Load (SCI) cljs code from namespaces and transitive dependencies on the
-  classpath. Calling this allows you to refer to functions by symbols in `:render-fn`"
+  classpath. Calling this allows you to refer to functions by symbols in `:render-fn`.
+  This is an EXPERIMENTAL feature and its API is subject to change."
   [& nss]
   (apply cljs-libs/require-cljs nss))
 

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -78,7 +78,9 @@
                                              (let [{:keys [order vars]} @sci-snippet-registry]
                                                (map (fn [var]
                                                       {:type :code
-                                                       :text (format "(nextjournal.clerk/eval-cljs-str \"(create-ns '%s) (intern '%s '%s %s)\")"
+                                                       :text (format "(nextjournal.clerk/eval-cljs '(do
+                                                                                                      (create-ns '%s)
+                                                                                                      (intern '%s '%s %s)))"
                                                                      (first var) (first var) (second var)
                                                                      (get-in vars var))})
                                                     order))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -63,7 +63,7 @@
   )
 
 ;; TODO:
-;; Analyze namespace dependencies, dedupe and load based on that order
+;; Make static bundle work
 
 (defn show!
   "Evaluates the Clojure source in `file-or-ns` and makes Clerk show it in the browser.

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -20,8 +20,8 @@
 (defonce ^:private !last-file (atom nil))
 (defonce ^:private !watcher (atom nil))
 
-(defn require-cljs [ns]
-  (cljs-libs/require-cljs ns))
+(defn require-cljs [& nss]
+  (apply cljs-libs/require-cljs nss))
 
 ;; TODO:
 ;; Make static bundle work

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -14,22 +14,7 @@
             [nextjournal.clerk.paths :as paths]
             [nextjournal.clerk.viewer :as v]
             [nextjournal.clerk.webserver :as webserver]
-            [clojure.tools.namespace.dependency :as tnsd]
-            [clojure.tools.namespace.parse :as tnsp]
             [nextjournal.clerk.cljs-libs :as cljs-libs]))
-
-(clojure.core/comment
-  (let [graph (tnsd/graph)
-        ns-decl '(ns foo (:require [dude :as a] [dade :as b]))
-        nom (tnsp/name-from-ns-decl ns-decl)
-        deps (tnsp/deps-from-ns-decl ns-decl)
-        graph (reduce (fn [acc dep]
-                        (tnsd/depend acc nom dep))
-                      graph deps)]
-    (tnsd/transitive-dependencies graph 'foo))
-
-  )
-
 
 (defonce ^:private !show-filter-fn (atom nil))
 (defonce ^:private !last-file (atom nil))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -14,22 +14,22 @@
             [nextjournal.clerk.paths :as paths]
             [nextjournal.clerk.viewer :as v]
             [nextjournal.clerk.webserver :as webserver]
-            [flatland.ordered.set :as oset]))
+            [clojure.tools.namespace.dependency :as tnsd]
+            [clojure.tools.namespace.parse :as tnsp]))
+
+(clojure.core/comment
+  (let [graph (tnsd/graph)
+        ns-decl '(ns foo (:require [dude :as a]))
+        nom (tnsp/name-from-ns-decl ns-decl)
+        deps (tnsp/deps-from-ns-decl ns-decl)
+        graph (tnsd/depend graph nom (first deps))]
+    (tnsd/transitive-dependencies graph 'foo))
+  )
+
 
 (defonce ^:private !show-filter-fn (atom nil))
 (defonce ^:private !last-file (atom nil))
 (defonce ^:private !watcher (atom nil))
-
-(defonce ^:private sci-interned-vars
-  (atom {:vars {}
-         :order (oset/ordered-set)}))
-
-(defn intern-sci-var [ns-name var-name s]
-  (swap! sci-interned-vars (fn [state]
-                                (-> state
-                                    (update :vars assoc-in [ns-name var-name] s)
-                                    (update :order conj [ns-name var-name]))))
-  nil)
 
 (def required-cljs-files (atom []))
 
@@ -44,10 +44,6 @@
 
 ;; TODO:
 ;; Analyze namespace dependencies, dedupe and load based on that order
-
-(clojure.core/comment
-  @sci-interned-vars
-  )
 
 (defn show!
   "Evaluates the Clojure source in `file-or-ns` and makes Clerk show it in the browser.

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -74,12 +74,12 @@
 
                     :else
                     file-or-ns)
-             doc (try (-> (merge (webserver/get-build-opts)
-                                 opts
-                                 (when-let [path (paths/path-in-cwd file-or-ns)]
-                                   {:file-path path})
-                                 {:nav-path (webserver/->nav-path file-or-ns)}
-                                 (parser/parse-file {:doc? true} file)))
+             doc (try (merge (webserver/get-build-opts)
+                             opts
+                             (when-let [path (paths/path-in-cwd file-or-ns)]
+                               {:file-path path})
+                             {:nav-path (webserver/->nav-path file-or-ns)}
+                             (parser/parse-file {:doc? true} file))
                       (catch java.io.FileNotFoundException _e
                         (throw (ex-info (str "`nextjournal.clerk/show!` could not find the file: `" (pr-str file-or-ns) "`")
                                         {:file-or-ns file-or-ns})))

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -42,6 +42,9 @@
     nil
     ))
 
+;; TODO:
+;; Analyze namespace dependencies, dedupe and load based on that order
+
 (clojure.core/comment
   @sci-interned-vars
   )

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -647,4 +647,5 @@
 
   ;; Clear cache
   (clear-cache!)
+  (halt!)
   )

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -273,7 +273,6 @@
             (report-fn {:stage :parsed :error error :build-opts opts})
             (throw (if-not (string? error) error (ex-info error (dissoc opts :report-fn)))))
         {state :result duration :time-ms} (eval/time-ms (mapv (comp (partial parser/parse-file {:doc? true}) :file) state))
-        state (map cljs-libs/update-blocks state)
         _ (report-fn {:stage :parsed :state state :duration duration})
         {state :result duration :time-ms} (eval/time-ms (reduce (fn [state doc]
                                                                   (try (conj state (-> doc analyzer/build-graph analyzer/hash))

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -14,7 +14,8 @@
             [nextjournal.clerk.paths :as paths]
             [nextjournal.clerk.view :as view]
             [nextjournal.clerk.viewer :as viewer]
-            [nextjournal.clerk.webserver :as webserver]))
+            [nextjournal.clerk.webserver :as webserver]
+            [nextjournal.clerk.cljs-libs :as cljs-libs]))
 
 (def clerk-docs
   (into ["CHANGELOG.md"
@@ -272,6 +273,7 @@
             (report-fn {:stage :parsed :error error :build-opts opts})
             (throw (if-not (string? error) error (ex-info error (dissoc opts :report-fn)))))
         {state :result duration :time-ms} (eval/time-ms (mapv (comp (partial parser/parse-file {:doc? true}) :file) state))
+        state (map cljs-libs/update-blocks state)
         _ (report-fn {:stage :parsed :state state :duration duration})
         {state :result duration :time-ms} (eval/time-ms (reduce (fn [state doc]
                                                                   (try (conj state (-> doc analyzer/build-graph analyzer/hash))

--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -14,8 +14,7 @@
             [nextjournal.clerk.paths :as paths]
             [nextjournal.clerk.view :as view]
             [nextjournal.clerk.viewer :as viewer]
-            [nextjournal.clerk.webserver :as webserver]
-            [nextjournal.clerk.cljs-libs :as cljs-libs]))
+            [nextjournal.clerk.webserver :as webserver]))
 
 (def clerk-docs
   (into ["CHANGELOG.md"

--- a/src/nextjournal/clerk/cljs_libs.clj
+++ b/src/nextjournal/clerk/cljs_libs.clj
@@ -53,7 +53,7 @@
       (when as
         (alias as ns))
       (when-not (contains? already-loaded-sci-namespaces libspec)
-        (if-let [cljs-file (ns->resource ns)]
+        (when-let [cljs-file (ns->resource ns)]
           (let [ns-decl (with-open [rdr (e/reader (io/reader cljs-file))]
                           (tnsp/read-ns-decl rdr))
                 nom (tnsp/name-from-ns-decl ns-decl)
@@ -66,9 +66,7 @@
                                         (tnsd/remove-node graph ns)
                                         (or (seq deps)
                                             [::orphan]))))
-            nil)
-          (binding [*out* *err*]
-            (println "[clerk] Could not require CLJS namespace:" ns)))))))
+            nil))))))
 
 (defn all-ns []
   (remove #(= ::orphan %) (tnsd/topo-sort @cljs-graph)))

--- a/src/nextjournal/clerk/cljs_libs.clj
+++ b/src/nextjournal/clerk/cljs_libs.clj
@@ -4,7 +4,8 @@
    [clojure.string :as str]
    [clojure.tools.namespace.dependency :as tnsd]
    [clojure.tools.namespace.parse :as tnsp]
-   [edamame.core :as e]))
+   [edamame.core :as e]
+   [nextjournal.clerk.viewer :as v]))
 
 (defonce ^:private cljs-graph (atom (tnsd/graph)))
 
@@ -33,6 +34,12 @@
                            (map (fn [resource]
                                   (let [code-str (slurp resource)]
                                     {:type :code
-                                     :text (pr-str `(nextjournal.clerk/eval-cljs-str ~code-str))}))
+                                     :text (pr-str `(nextjournal.clerk/eval-cljs-str ~code-str))
+                                     :result {:nextjournal/value (v/eval-cljs-str code-str)}
+                                     :settings #:nextjournal.clerk{:visibility {:code :hide, :result :hide}}}))
                                 resources))
                          blocks))))
+
+(comment
+  (nextjournal.clerk/eval-cljs-str "(+ 1 2 3)")
+  )

--- a/src/nextjournal/clerk/cljs_libs.clj
+++ b/src/nextjournal/clerk/cljs_libs.clj
@@ -55,7 +55,8 @@
         (swap! cljs-graph (fn [graph]
                             (reduce (fn [acc dep]
                                       (tnsd/depend acc nom dep))
-                                    graph deps)))
+                                    graph (or (seq deps)
+                                              [::orphan]))))
         nil)
       (binding [*out* *err*]
         (println "[clerk] Could not require CLJS namespace:" ns)))))
@@ -66,7 +67,7 @@
 (defn update-blocks [doc]
   (update doc :blocks (fn [blocks]
                         (concat
-                         (let [resources (map ns->resource (tnsd/topo-sort @cljs-graph))]
+                         (let [resources (map ns->resource (remove #(= ::orphan %) (tnsd/topo-sort @cljs-graph)))]
                            (map (fn [resource]
                                   (let [code-str (slurp resource)]
                                     {:type :code

--- a/src/nextjournal/clerk/cljs_libs.clj
+++ b/src/nextjournal/clerk/cljs_libs.clj
@@ -1,0 +1,38 @@
+(ns nextjournal.clerk.cljs-libs
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.tools.namespace.dependency :as tnsd]
+   [clojure.tools.namespace.parse :as tnsp]
+   [edamame.core :as e]))
+
+(defonce ^:private cljs-graph (atom (tnsd/graph)))
+
+(defn- ns->resource [ns]
+  (io/resource (-> (namespace-munge ns)
+                   (str/replace "." "/")
+                   (str ".cljs"))))
+
+(defn require-cljs [ns]
+  (let [cljs-file (ns->resource ns)
+        ns-decl (with-open [rdr (e/reader (io/reader cljs-file))]
+                  (tnsp/read-ns-decl rdr))
+        nom (tnsp/name-from-ns-decl ns-decl)
+        deps (tnsp/deps-from-ns-decl ns-decl)]
+    (run! require-cljs deps)
+    (swap! cljs-graph (fn [graph]
+                        (reduce (fn [acc dep]
+                                  (tnsd/depend acc nom dep))
+                                graph deps)))
+    nil))
+
+(defn update-blocks [doc]
+  (update doc :blocks (fn [blocks]
+                        (concat
+                         (let [resources (map ns->resource (tnsd/topo-sort @cljs-graph))]
+                           (map (fn [resource]
+                                  (let [code-str (slurp resource)]
+                                    {:type :code
+                                     :text (pr-str `(nextjournal.clerk/eval-cljs-str ~code-str))}))
+                                resources))
+                         blocks))))

--- a/src/nextjournal/clerk/cljs_libs.clj
+++ b/src/nextjournal/clerk/cljs_libs.clj
@@ -8,9 +8,31 @@
    [nextjournal.clerk.viewer :as v]))
 
 
-(def ^:private already-loaded-sci-namespaces '#{user clojure.core clojure.set clojure.edn clojure.repl
-                                                clojure.string clojure.walk clojure.template
-                                                nextjournal.clerk})
+(def ^:private already-loaded-sci-namespaces
+  '#{user
+     nextjournal.clerk.render
+     nextjournal.clojure-mode.commands
+     reagent.ratom
+     nextjournal.clerk
+     reagent.core
+     nextjournal.clerk.parser
+     nextjournal.clerk.viewer
+     clojure.core clojure.set
+     cljs.math
+     clojure.edn
+     nextjournal.clojure-mode.keymap
+     reagent.debug
+     cljs.repl
+     clojure.repl
+     applied-science.js-interop
+     nextjournal.clerk.render.navbar
+     clojure.string
+     nextjournal.clojure-mode.extensions.eval-region
+     clojure.walk
+     nextjournal.clerk.render.editor
+     nextjournal.clerk.render.hooks
+     nextjournal.clerk.render.code
+     clojure.template})
 
 (defonce ^:private cljs-graph (atom (tnsd/graph)))
 
@@ -20,6 +42,8 @@
                    (str ".cljs"))))
 
 (defn require-cljs [ns]
+  #_(binding [*out* *err*]
+    (println "[clerk] Loading CLJS namespace:" ns))
   (when-not (contains? already-loaded-sci-namespaces ns)
     (if-let [cljs-file (ns->resource ns)]
       (let [ns-decl (with-open [rdr (e/reader (io/reader cljs-file))]
@@ -54,6 +78,11 @@
 
 (comment
   (nextjournal.clerk/eval-cljs-str "(+ 1 2 3)")
-  (slurp (io/resource "clojure/string.cljs"))
+  ;; [nextjournal.clerk.render.hooks :as hooks]
+  (def decl (tnsp/read-ns-decl (edamame.core/reader (java.io.StringReader. (slurp (io/resource "nextjournal/clerk/render/hooks.cljs"))))))
+  (tnsp/name-from-ns-decl decl)
+  (tnsp/deps-from-ns-decl decl)
+
   (clear-cljs!)
+  @cljs-graph
   )

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -20,7 +20,7 @@
   ([opts {:as doc :keys [ns file]}]
    (reset! x doc)
    (binding [*ns* ns]
-     (-> (merge doc opts) #_cljs-libs/update-blocks  v/notebook v/present))))
+     (-> (merge doc opts) cljs-libs/update-blocks v/notebook v/present))))
 
 #_(doc->viewer (nextjournal.clerk/eval-file "notebooks/hello.clj"))
 #_(nextjournal.clerk/show! "notebooks/test.clj")

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -7,18 +7,9 @@
             [nextjournal.clerk.cljs-libs :as cljs-libs])
   (:import (java.net URI)))
 
-(def x (atom nil))
-
-(comment
-  @x
-  (:blocks @x)
-  (nextjournal.clerk/eval-cljs-str "(prn :x)")
-  )
-
 (defn doc->viewer
   ([doc] (doc->viewer {} doc))
   ([opts {:as doc :keys [ns file]}]
-   (reset! x doc)
    (binding [*ns* ns]
      (-> (merge doc opts) cljs-libs/update-blocks v/notebook v/present))))
 

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -20,7 +20,7 @@
   ([opts {:as doc :keys [ns file]}]
    (reset! x doc)
    (binding [*ns* ns]
-     (-> (merge doc opts) cljs-libs/update-blocks  v/notebook v/present))))
+     (-> (merge doc opts) #_cljs-libs/update-blocks  v/notebook v/present))))
 
 #_(doc->viewer (nextjournal.clerk/eval-file "notebooks/hello.clj"))
 #_(nextjournal.clerk/show! "notebooks/test.clj")

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -3,14 +3,24 @@
             [clojure.string :as str]
             [hiccup.page :as hiccup]
             [nextjournal.clerk.config :as config]
-            [nextjournal.clerk.viewer :as v])
+            [nextjournal.clerk.viewer :as v]
+            [nextjournal.clerk.cljs-libs :as cljs-libs])
   (:import (java.net URI)))
+
+(def x (atom nil))
+
+(comment
+  @x
+  (:blocks @x)
+  (nextjournal.clerk/eval-cljs-str "(prn :x)")
+  )
 
 (defn doc->viewer
   ([doc] (doc->viewer {} doc))
   ([opts {:as doc :keys [ns file]}]
+   (reset! x doc)
    (binding [*ns* ns]
-     (-> (merge doc opts) v/notebook v/present))))
+     (-> (merge doc opts) cljs-libs/update-blocks  v/notebook v/present))))
 
 #_(doc->viewer (nextjournal.clerk/eval-file "notebooks/hello.clj"))
 #_(nextjournal.clerk/show! "notebooks/test.clj")

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -93,7 +93,7 @@
    (extend-type ViewerEval
      IPrintWithWriter
      (-pr-writer [obj w _opts]
-       (-write w (str "#viewer-eval "))
+       (-write w "#viewer-eval ")
        (-write w (pr-str (:form obj))))))
 
 (def data-readers


### PR DESCRIPTION
- Viewers can provide CLJS code in .cljs files
- Those .cljs files can be used in conjunction with the SCI browser REPL
- Viewer .cljs files can require other .cljs files (libraries)
- User notebooks can require viewers that use their own internal CLJS dependencies, like any other viewer 