### PR TITLE
CLJS graph is no longer global but inferred from :require-cljs viewer key

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,7 @@
         borkdude/edamame {:mvn/version "1.4.24"}
         weavejester/dependency {:mvn/version "0.2.1"}
         com.nextjournal/beholder {:mvn/version "1.0.2"}
-        org.flatland/ordered {:mvn/version "1.15.11"}
+        org.flatland/ordered {:mvn/version "1.15.12"}
 
         io.github.nextjournal/markdown {:mvn/version "0.5.148"}
         babashka/process {:mvn/version "0.4.16"}

--- a/notebooks/viewers/viewer_with_cljs_source.clj
+++ b/notebooks/viewers/viewer_with_cljs_source.clj
@@ -1,6 +1,8 @@
 (ns viewers.viewer-with-cljs-source)
 
+(alias 'this 'viewers.viewer-with-cljs-source) ;; an ode to JS this
+
 (def my-cool-viewer
-  {:render-fn 'viewers.viewer-with-cljs-source/my-already-defined-function2
-   :require-cljs 'viewers.viewer-with-cljs-source
+  {:render-fn `this/my-already-defined-function2
+   :require-cljs true
    :transform-fn (fn [x] x)})

--- a/notebooks/viewers/viewer_with_cljs_source.clj
+++ b/notebooks/viewers/viewer_with_cljs_source.clj
@@ -1,8 +1,6 @@
-(ns viewers.viewer-with-cljs-source
-  (:require [nextjournal.clerk :as clerk]))
-
-(clerk/require-cljs '[viewers.viewer-with-cljs-source :as cljs-view])
+(ns viewers.viewer-with-cljs-source)
 
 (def my-cool-viewer
-  {:render-fn `cljs-view/my-already-defined-function2
+  {:render-fn 'viewers.viewer-with-cljs-source/my-already-defined-function2
+   :require-cljs 'viewers.viewer-with-cljs-source
    :transform-fn (fn [x] x)})

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -20,13 +20,6 @@
 (defonce ^:private !last-file (atom nil))
 (defonce ^:private !watcher (atom nil))
 
-(defn require-cljs
-  "Load (SCI) cljs code from namespaces and transitive dependencies on the
-  classpath. Calling this allows you to refer to functions by symbols in `:render-fn`.
-  This is an EXPERIMENTAL feature and its API is subject to change."
-  [& nss]
-  (apply cljs-libs/require-cljs nss))
-
 (defn show!
   "Evaluates the Clojure source in `file-or-ns` and makes Clerk show it in the browser.
 

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -13,8 +13,7 @@
             [nextjournal.clerk.parser :as parser]
             [nextjournal.clerk.paths :as paths]
             [nextjournal.clerk.viewer :as v]
-            [nextjournal.clerk.webserver :as webserver]
-            [nextjournal.clerk.cljs-libs :as cljs-libs]))
+            [nextjournal.clerk.webserver :as webserver]))
 
 (defonce ^:private !show-filter-fn (atom nil))
 (defonce ^:private !last-file (atom nil))

--- a/src/nextjournal/clerk/cljs_libs.clj
+++ b/src/nextjournal/clerk/cljs_libs.clj
@@ -89,11 +89,12 @@
                         (require-cljs* state cljs-ns))))
                   v)
                 doc)
-    (into (omap/ordered-map :effects (let [resources (keep ns->resource (all-ns state))]
-                                       (mapv (fn [resource]
-                                               (let [code-str (slurp resource)]
-                                                 (v/->ViewerEval `(load-string ~code-str))))
-                                             resources)))
+    (into (omap/ordered-map :cljs-libs
+                            (let [resources (keep ns->resource (all-ns state))]
+                              (mapv (fn [resource]
+                                      (let [code-str (slurp resource)]
+                                        (v/->ViewerEval `(load-string ~code-str))))
+                                    resources)))
           doc)))
 
 (comment

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -35,7 +35,8 @@
             [sci.core :as sci]
             [sci.ctx-store]
             [sci.nrepl.server :as nrepl]
-            [shadow.esm]))
+            [shadow.esm]
+            [flatland.ordered.map :as omap]))
 
 (def legacy-ns-aliases
   {"j" "applied-science.js-interop"
@@ -73,6 +74,9 @@
          (js/console.error "error in viewer-eval" e form)
          (ex-info (str "error in viewer-eval: " (.-message e)) {:form form} e))))
 
+(defn ordered-map-reader-cljs [coll]
+  (omap/ordered-map (vec coll)))
+
 (defonce !edamame-opts
   (atom {:all true
          :row-key :line
@@ -86,7 +90,8 @@
                (get {'viewer-fn ->viewer-fn-with-error
                      'viewer-fn/cherry cherry-env/->viewer-fn-with-error
                      'viewer-eval ->viewer-eval-with-error
-                     'viewer-eval/cherry cherry-env/->viewer-eval-with-error} tag)
+                     'viewer-eval/cherry cherry-env/->viewer-eval-with-error
+                     'ordered/map ordered-map-reader-cljs} tag)
                (fn [value]
                  (viewer/with-viewer `viewer/tagged-value-viewer
                    {:tag tag

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -11,7 +11,7 @@
   ([doc] (doc->viewer {} doc))
   ([opts {:as doc :keys [ns file]}]
    (binding [*ns* ns]
-     (-> (merge doc opts) cljs-libs/update-blocks v/notebook v/present))))
+     (-> (merge doc opts) v/notebook v/present cljs-libs/update-blocks))))
 
 #_(doc->viewer (nextjournal.clerk/eval-file "notebooks/hello.clj"))
 #_(nextjournal.clerk/show! "notebooks/test.clj")

--- a/src/nextjournal/clerk/view.clj
+++ b/src/nextjournal/clerk/view.clj
@@ -11,7 +11,7 @@
   ([doc] (doc->viewer {} doc))
   ([opts {:as doc :keys [ns file]}]
    (binding [*ns* ns]
-     (-> (merge doc opts) v/notebook v/present cljs-libs/update-blocks))))
+     (-> (merge doc opts) v/notebook v/present cljs-libs/prepend-required-cljs))))
 
 #_(doc->viewer (nextjournal.clerk/eval-file "notebooks/hello.clj"))
 #_(nextjournal.clerk/show! "notebooks/test.clj")

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -99,7 +99,8 @@
 (def data-readers
   {'viewer-fn ->viewer-fn
    'viewer-eval ->viewer-eval
-   'ordered/map omap/ordered-map-reader-clj})
+   'ordered/map #?(:clj omap/ordered-map-reader-clj
+                   :cljs  omap/ordered-map-reader-cljs)})
 
 #_(binding [*data-readers* {'viewer-fn ->viewer-fn}]
     (read-string (pr-str (->viewer-fn '(fn [x] x)))))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1472,7 +1472,8 @@
         viewers (->viewers hoisted-wrapped-value)
         _ (when (empty? viewers)
             (throw (ex-info "cannot apply empty viewers" {:wrapped-value wrapped-value})))
-        {:as viewer viewers-to-add :add-viewers :keys [render-fn transform-fn]} (viewer-for viewers hoisted-wrapped-value)
+        {:as viewer viewers-to-add :add-viewers :keys [render-fn transform-fn]}
+        (viewer-for viewers hoisted-wrapped-value)
         transformed-value (cond-> (ensure-wrapped-with-viewers viewers
                                                                (cond-> (-> hoisted-wrapped-value
                                                                            (dissoc :nextjournal/viewer)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -5,7 +5,7 @@
             [clojure.datafy :as datafy]
             [clojure.set :as set]
             [clojure.walk :as w]
-            [flatland.ordered.map :refer [ordered-map]]
+            [flatland.ordered.map :as omap :refer [ordered-map]]
             #?@(:clj [[babashka.fs :as fs]
                       [clojure.repl :refer [demunge]]
                       [clojure.tools.reader :as tools.reader]
@@ -98,7 +98,8 @@
 
 (def data-readers
   {'viewer-fn ->viewer-fn
-   'viewer-eval ->viewer-eval})
+   'viewer-eval ->viewer-eval
+   'ordered/map omap/ordered-map-reader-clj})
 
 #_(binding [*data-readers* {'viewer-fn ->viewer-fn}]
     (read-string (pr-str (->viewer-fn '(fn [x] x)))))

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -96,11 +96,11 @@
        (-write w "#viewer-eval ")
        (-write w (pr-str (:form obj))))))
 
-(def data-readers
-  {'viewer-fn ->viewer-fn
-   'viewer-eval ->viewer-eval
-   'ordered/map #?(:clj omap/ordered-map-reader-clj
-                   :cljs  omap/ordered-map-reader-cljs)})
+#?(:clj
+   (def data-readers
+     {'viewer-fn ->viewer-fn
+      'viewer-eval ->viewer-eval
+      'ordered/map omap/ordered-map-reader-clj}))
 
 #_(binding [*data-readers* {'viewer-fn ->viewer-fn}]
     (read-string (pr-str (->viewer-fn '(fn [x] x)))))


### PR DESCRIPTION
- [x] The CLJS graph is no longer global, but inferred from `:require-cljs` keys in viewers
- [x] The `require-cljs` API call is no longer needed
- [x] Support `:require-cljs true` and infer namespace from `:render-fn` 

Will follow up with another PR to support unqualified render fns, if desired. Not 100% convinced if we really want this, so let's do this PR first.