### PR TITLE
Implement always-array-map to not flip to hash-map

### DIFF
--- a/src/nextjournal/clerk/always_array_map.clj
+++ b/src/nextjournal/clerk/always_array_map.clj
@@ -4,10 +4,10 @@
 
 (set! *warn-on-reflection* true)
 
-(declare assoc-before)
-
 (defn- assoc-after [aam k v]
   (apply array-map (concat (interleave (keys aam) (vals aam)) [k v])))
+
+(declare ->AlwaysArrayMap)
 
 (deftype AlwaysArrayMap [^clojure.lang.PersistentArrayMap the-map]
   clojure.lang.ILookup

--- a/src/nextjournal/clerk/always_array_map.clj
+++ b/src/nextjournal/clerk/always_array_map.clj
@@ -1,0 +1,66 @@
+(ns nextjournal.clerk.always-array-map
+  "A persistent data structure that is based on array-map, but doesn't turn into a hash-map by using assoc etc.
+   Prints like a normal Clojure map in the order of insertion.")
+
+(set! *warn-on-reflection* true)
+
+(declare assoc-before assoc-after)
+
+(deftype AlwaysArrayMap [^clojure.lang.PersistentArrayMap the-map]
+  clojure.lang.ILookup
+  (valAt [_ k]
+    (get the-map k))
+
+  clojure.lang.Seqable
+  (seq [_]
+    (seq the-map))
+
+  clojure.lang.IPersistentMap
+  (assoc [_ k v]
+    (assoc-after the-map k v))
+
+  (assocEx [_ _k _v]
+    (throw (ex-info "Not implemented" {})))
+
+  (without [_ _k]
+    (throw (ex-info "Not implemented" {})))
+
+  clojure.lang.Associative
+  (containsKey [_ k]
+    (contains? the-map k))
+
+  clojure.lang.IPersistentCollection
+  (equiv [_ other]
+    (= the-map other))
+  (count [_]
+    (count the-map))
+
+  java.lang.Iterable
+  (iterator [_]
+    (.iterator the-map))
+
+  Object
+  (toString [_]
+    "<always-array-map>"))
+
+(defn assoc-before [aam k v]
+  (apply array-map (list* k v (interleave (keys aam) (vals aam)))))
+
+(defn assoc-after [aam k v]
+  (apply array-map (concat (interleave (keys aam) (vals aam)) [k v])))
+
+(defn always-array-map [& kvs]
+  (->AlwaysArrayMap (apply array-map kvs)))
+
+(defmethod print-method AlwaysArrayMap
+  [v ^java.io.Writer writer]
+  (.write writer "{")
+  (doseq [[k v] v]
+    (.write writer (pr-str k))
+    (.write writer " ")
+    (.write writer (pr-str v)))
+  (.write writer "}"))
+
+(comment
+  (pr-str (always-array-map 1 2))
+  )

--- a/src/nextjournal/clerk/always_array_map.clj
+++ b/src/nextjournal/clerk/always_array_map.clj
@@ -65,14 +65,15 @@
 (defmethod print-method AlwaysArrayMap
   [v ^java.io.Writer writer]
   (.write writer "{")
-  (let [end-idx (dec (count v))]
-    (dorun (map-indexed (fn [i [k v]]
-                          (.write writer (pr-str k))
-                          (.write writer " ")
-                          (.write writer (pr-str v))
-                          (when-not (= end-idx i)
-                            (.write writer ", ")))
-                        v)))
+  (let [write-kv! (fn [k v]
+              (.write writer (pr-str k))
+              (.write writer " ")
+              (.write writer (pr-str v)))]
+    (doseq [[k v] (butlast v)]
+      (write-kv! k v)
+      (.write writer ", "))
+    (let [[k v] (last v)]
+      (write-kv! k v)))
   (.write writer "}"))
 
 (comment

--- a/src/nextjournal/clerk/cljs_libs.clj
+++ b/src/nextjournal/clerk/cljs_libs.clj
@@ -7,7 +7,8 @@
    [clojure.tools.namespace.parse :as tnsp]
    [clojure.walk :as w]
    [edamame.core :as e]
-   [nextjournal.clerk.viewer :as v]))
+   [nextjournal.clerk.viewer :as v]
+   [nextjournal.clerk.always-array-map :as aam]))
 
 (def ^:private already-loaded-sci-namespaces
   '#{user
@@ -51,7 +52,7 @@
     (when-not (or (contains? already-loaded-sci-namespaces ns)
                   (contains? (:loaded-libs @state) ns))
       (when-let [cljs-file (ns->resource ns)]
-        (let [ns-decl (with-open [rdr (e/reader (io/reader cljs-file))]
+        (let [ns-decl (with-open [^java.io.Closeable rdr (e/reader (io/reader cljs-file))]
                         (tnsp/read-ns-decl rdr))
               nom (tnsp/name-from-ns-decl ns-decl)
               deps (remove already-loaded-sci-namespaces
@@ -88,7 +89,7 @@
                         (require-cljs* state cljs-ns))))
                   v)
                 doc)
-    (apply array-map
+    (apply aam/always-array-map
            :cljs-libs ;; make sure :cljs-libs is the first key, so these are read + evaluated first
            (let [resources (keep ns->resource (all-ns state))]
              (mapv (fn [resource]


### PR DESCRIPTION
This is necessary since before sending the doc to the browser, a status key was added and this may flip the array-map back to a hash-map.