### PR TITLE
Fix cljs compilation for apps depending on Clerk render stack

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -45,8 +45,7 @@
                               com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.0.3"}
                               io.github.nextjournal/cas-client {:git/sha "22ef8360689cd3938e43a3223023ab1b9711818f"}
                               org.slf4j/slf4j-nop {:mvn/version "2.0.7"}
-                              org.babashka/cli {:mvn/version "0.5.40"}
-                              io.github.babashka/sci.nrepl {:git/sha "630062b76a4a9ca7d2565fd494d7baaf3460554b"}}
+                              org.babashka/cli {:mvn/version "0.5.40"}}
                  :extra-paths ["dev" "notebooks"]
                  :jvm-opts ["-Dclerk.resource_manifest={\"/js/viewer.js\" \"/js/viewer.js\"}"
                             "-Dclerk.render_repl={}"

--- a/render/deps.edn
+++ b/render/deps.edn
@@ -4,6 +4,7 @@
         cider/cider-nrepl {:mvn/version "0.28.3"}
         org.babashka/sci {:git/url "https://github.com/babashka/sci"
                           :git/sha "c556f4474303c61da72e7a07eef496dcbf66a56e"}
+        io.github.babashka/sci.nrepl {:git/sha "630062b76a4a9ca7d2565fd494d7baaf3460554b"}
         reagent/reagent {:mvn/version "1.2.0"}
         io.github.babashka/sci.configs {:git/sha "0702ea5a21ad92e6d7cca6d36de84271083ea68f"
                                         :exclusions [org.babashka/sci]}

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -49,12 +49,12 @@
 
 
 (defonce render-repl-config
-  (delay (when-some [config (let [prop (System/getProperty "clerk.render_repl")]
-                              (when-not (str/blank? prop)
-                                (merge {:nrepl-port 1339
-                                        :websocket-port 1340}
-                                       (edn/read-string prop))))]
-           (when-some [start! (requiring-resolve 'sci.nrepl.browser-server/start!)]
+  (delay (when-let [config (let [prop (System/getProperty "clerk.render_repl")]
+                             (when-not (str/blank? prop)
+                               (merge {:nrepl-port 1339
+                                       :websocket-port 1340}
+                                      (edn/read-string prop))))]
+           (let [start! (requiring-resolve 'sci.nrepl.browser-server/start!)]
              (doto config
                start!)))))
 

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -49,12 +49,12 @@
 
 
 (defonce render-repl-config
-  (delay (when-let [config (let [prop (System/getProperty "clerk.render_repl")]
-                             (when-not (str/blank? prop)
-                               (merge {:nrepl-port 1339
-                                       :websocket-port 1340}
-                                      (edn/read-string prop))))]
-           (let [start! (requiring-resolve 'sci.nrepl.browser-server/start!)]
+  (delay (when-some [config (let [prop (System/getProperty "clerk.render_repl")]
+                              (when-not (str/blank? prop)
+                                (merge {:nrepl-port 1339
+                                        :websocket-port 1340}
+                                       (edn/read-string prop))))]
+           (when-some [start! (requiring-resolve 'sci.nrepl.browser-server/start!)]
              (doto config
                start!)))))
 


### PR DESCRIPTION
So far sci.nrepl is only mentioned in the `:dev` but it's used in clerk frontend.