### PR TITLE
Improve bounded count check

### DIFF
--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -652,13 +652,15 @@
   (-exceeds-bounded-count-limit? [x limit]))
 
 (extend-protocol BoundedCountCheck
-  nil (-exceeds-bounded-count-limit? [_ _] false)
-  Object (-exceeds-bounded-count-limit? [_ _] false)
-  clojure.lang.IPersistentCollection (-exceeds-bounded-count-limit? [x limit]
-                                       (or (some #(-exceeds-bounded-count-limit? % limit) x) false))
-  clojure.lang.ISeq (-exceeds-bounded-count-limit? [xs limit]
-                      (or (<= limit (bounded-count limit xs))
-                          (some #(-exceeds-bounded-count-limit? % limit) xs))))
+  nil
+  (-exceeds-bounded-count-limit? [_ _] false)
+  Object
+  (-exceeds-bounded-count-limit? [_ _] false)
+  clojure.lang.IPersistentCollection
+  (-exceeds-bounded-count-limit? [xs limit]
+    (or (<= limit (bounded-count limit xs))
+        (some #(-exceeds-bounded-count-limit? % limit) xs)
+        false)))
 
 (defn exceeds-bounded-count-limit? [x]
   (-exceeds-bounded-count-limit? x config/*bounded-count-limit*))

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -51,6 +51,7 @@
 
 (deftest exceeds-bounded-count-limit?
   (is (ana/exceeds-bounded-count-limit? (range config/*bounded-count-limit*)))
+  (is (ana/exceeds-bounded-count-limit? (vec (range config/*bounded-count-limit*))))
   (is (not (ana/exceeds-bounded-count-limit? (range (dec config/*bounded-count-limit*)))))
   (is (ana/exceeds-bounded-count-limit? (map inc (range))))
   (is (ana/exceeds-bounded-count-limit? {:a-range (range)})))

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -52,9 +52,9 @@
 (deftest exceeds-bounded-count-limit?
   (is (ana/exceeds-bounded-count-limit? (range config/*bounded-count-limit*)))
   (is (ana/exceeds-bounded-count-limit? (vec (range config/*bounded-count-limit*))))
-  (is (not (ana/exceeds-bounded-count-limit? (range (dec config/*bounded-count-limit*)))))
   (is (ana/exceeds-bounded-count-limit? (map inc (range))))
-  (is (ana/exceeds-bounded-count-limit? {:a-range (range)})))
+  (is (ana/exceeds-bounded-count-limit? {:a-range (range)}))
+  (is (not (ana/exceeds-bounded-count-limit? (range (dec config/*bounded-count-limit*))))))
 
 (deftest deps
   (is (match? #{'clojure.string/includes?


### PR DESCRIPTION
An [ISeq is always an IPersistentCollection](https://github.com/clojure/clojure/blob/48b1fe5b50d48603f2c1fbd38223a7284520d1ed/src/jvm/clojure/lang/ISeq.java#L18) but the converse is not true. 

Vectors and maps are not ISeq and for instances of such, the current protocol implementation doesn't check the limit on the whole collection, but only on its items.