### PR TITLE
Introduce global `viewer/!sync-state`

### DIFF
--- a/notebooks/global_sync.clj
+++ b/notebooks/global_sync.clj
@@ -1,6 +1,7 @@
 ;; # ⚡️ Global Sync
 (ns global-sync
-  (:require [nextjournal.clerk :as clerk]))
+  (:require [nextjournal.clerk :as clerk]
+            [nextjournal.clerk.viewer :as viewer]))
 
 ^::clerk/no-cache
 (shuffle (range 100))
@@ -9,10 +10,12 @@
                     '(fn [_ opts]
                        [:div
                         [:button
-                         {:on-click #(swap! nextjournal.clerk.render/!sync-state assoc :foo (rand-int 1000))}
+                         {:on-click #(swap! nextjournal.clerk.viewer/!sync-state assoc :foo (rand-int 1000))}
                          "clickme"]
-                        (pr-str @nextjournal.clerk.render/!sync-state)
+                        [nextjournal.clerk.render/inspect @nextjournal.clerk.viewer/!sync-state]
                         #_(nextjournal.clerk.render/inspect @nextjournal.clerk.render/!sync-state)])}
   {})
 
-#_(swap! nextjournal.clerk.webserver/!sync-state assoc :foo (rand-int 1000))
+@viewer/!sync-state
+
+#_(swap! nextjournal.clerk.viewer/!sync-state assoc :foo (rand-int 1000))

--- a/notebooks/global_sync.clj
+++ b/notebooks/global_sync.clj
@@ -11,7 +11,8 @@
                         [:button
                          {:on-click #(swap! nextjournal.clerk.render/!sync-state assoc :foo (rand-int 1000))}
                          "clickme"]
-                        (nextjournal.clerk.render/inspect @nextjournal.clerk.render/!sync-state)])}
+                        (pr-str @nextjournal.clerk.render/!sync-state)
+                        #_(nextjournal.clerk.render/inspect @nextjournal.clerk.render/!sync-state)])}
   {})
 
 #_(swap! nextjournal.clerk.webserver/!sync-state assoc :foo (rand-int 1000))

--- a/notebooks/global_sync.clj
+++ b/notebooks/global_sync.clj
@@ -1,0 +1,8 @@
+;; # ⚡️ Global Sync
+(ns global-sync
+  (:require [nextjournal.clerk :as clerk]))
+
+^::clerk/no-cache
+(shuffle (range 100))
+
+#_(swap! nextjournal.clerk.webserver/!sync-state assoc :foo (rand-int 1000))

--- a/notebooks/global_sync.clj
+++ b/notebooks/global_sync.clj
@@ -6,16 +6,15 @@
 ^::clerk/no-cache
 (shuffle (range 100))
 
-(clerk/with-viewer {:render-fn
-                    '(fn [_ opts]
-                       [:div
-                        [:button
-                         {:on-click #(swap! nextjournal.clerk.viewer/!sync-state assoc :foo (rand-int 1000))}
-                         "clickme"]
-                        [nextjournal.clerk.render/inspect @nextjournal.clerk.viewer/!sync-state]
-                        #_(nextjournal.clerk.render/inspect @nextjournal.clerk.render/!sync-state)])}
+(clerk/with-viewer {:render-fn '(fn [_ {:as opts :keys [path swap-sync-state!]}]
+                                  [:div
+                                   [:button
+                                    {:on-click #(swap-sync-state! assoc path (rand-int 1000))}
+                                    "clickme"]
+                                   [nextjournal.clerk.render/inspect @nextjournal.clerk.viewer/!sync-state]])}
   {})
 
 @viewer/!sync-state
 
 #_(swap! nextjournal.clerk.viewer/!sync-state assoc :foo (rand-int 1000))
+#_(reset! nextjournal.clerk.viewer/!sync-state {})

--- a/notebooks/global_sync.clj
+++ b/notebooks/global_sync.clj
@@ -6,12 +6,12 @@
 ^::clerk/no-cache
 (shuffle (range 100))
 
-(clerk/with-viewer {:render-fn '(fn [_ {:as opts :keys [path swap-sync-state!]}]
+(clerk/with-viewer {:render-fn '(fn [_ {:as opts :keys [id path swap-sync-state! !sync-state]}]
                                   [:div
                                    [:button
-                                    {:on-click #(swap-sync-state! assoc path (rand-int 1000))}
+                                    {:on-click #(swap-sync-state! assoc (into [id] path) (rand-int 1000))}
                                     "clickme"]
-                                   [nextjournal.clerk.render/inspect @nextjournal.clerk.viewer/!sync-state]])}
+                                   [nextjournal.clerk.render/inspect @!sync-state]])}
   {})
 
 @viewer/!sync-state

--- a/notebooks/global_sync.clj
+++ b/notebooks/global_sync.clj
@@ -5,4 +5,13 @@
 ^::clerk/no-cache
 (shuffle (range 100))
 
+(clerk/with-viewer {:render-fn
+                    '(fn [_ opts]
+                       [:div
+                        [:button
+                         {:on-click #(swap! nextjournal.clerk.render/!sync-state assoc :foo (rand-int 1000))}
+                         "clickme"]
+                        (nextjournal.clerk.render/inspect @nextjournal.clerk.render/!sync-state)])}
+  {})
+
 #_(swap! nextjournal.clerk.webserver/!sync-state assoc :foo (rand-int 1000))

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -33,10 +33,12 @@
   (r/atom {:eval-counter 0
            :doc nil
            :viewers viewer/!viewers
-           :panels {}}))
+           :panels {}
+           :sync {}}))
 
 (defonce !eval-counter (r/cursor !state [:eval-counter]))
 (defonce !doc (r/cursor !state [:doc]))
+(defonce !sync-state (r/cursor !state [:sync]))
 (defonce !viewers (r/cursor !state [:viewers]))
 (defonce !panels (r/cursor !state [:panels]))
 

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -33,12 +33,10 @@
   (r/atom {:eval-counter 0
            :doc nil
            :viewers viewer/!viewers
-           :panels {}
-           :sync {}}))
+           :panels {}}))
 
 (defonce !eval-counter (r/cursor !state [:eval-counter]))
 (defonce !doc (r/cursor !state [:doc]))
-(defonce !sync-state (r/cursor !state [:sync]))
 (defonce !viewers (r/cursor !state [:viewers]))
 (defonce !panels (r/cursor !state [:panels]))
 
@@ -806,7 +804,7 @@
 
 (defn ^:export init [{:as state :keys [render-router path->doc]}]
   (setup-router! state)
-  (add-watch !sync-state 'nextjournal.clerk.webserver/!sync-state atom-changed)
+  (add-watch viewer/!sync-state `viewer/!sync-state atom-changed)
   (when (contains? #{:bundle :serve} render-router)
     (set-state! (case render-router
                   :bundle {:doc (get path->doc (or (path-from-url-hash (->URL (.-href js/location))) ""))}

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -269,6 +269,9 @@
          :nested-prose "w-full max-w-prose"
          "w-full max-w-prose px-8")])))
 
+(def swap-sync-state!
+  (partial swap! viewer/!sync-state))
+
 (defn render-result [{:nextjournal/keys [fetch-opts hash presented]} {:keys [id auto-expand-results?]}]
   (let [!desc (hooks/use-state-with-deps presented [hash])
         !expanded-at (hooks/use-state-with-deps (when (map? @!desc) (->expanded-at auto-expand-results? @!desc)) [hash])
@@ -298,7 +301,7 @@
          [:div.relative
           [:div.overflow-x-auto
            {:ref ref-fn}
-           [inspect-presented {:!expanded-at !expanded-at} @!desc]]]]]])))
+           [inspect-presented {:!expanded-at !expanded-at :swap-sync-state! swap-sync-state!} @!desc]]]]]])))
 
 (defn toggle-expanded [!expanded-at path event]
   (.preventDefault event)

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -301,7 +301,7 @@
          [:div.relative
           [:div.overflow-x-auto
            {:ref ref-fn}
-           [inspect-presented {:!expanded-at !expanded-at :swap-sync-state! swap-sync-state!} @!desc]]]]]])))
+           [inspect-presented {:!expanded-at !expanded-at :swap-sync-state! swap-sync-state! :!sync-state viewer/!sync-state} @!desc]]]]]])))
 
 (defn toggle-expanded [!expanded-at path event]
   (.preventDefault event)

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -806,6 +806,7 @@
 
 (defn ^:export init [{:as state :keys [render-router path->doc]}]
   (setup-router! state)
+  (add-watch !sync-state 'nextjournal.clerk.webserver/!sync-state atom-changed)
   (when (contains? #{:bundle :serve} render-router)
     (set-state! (case render-router
                   :bundle {:doc (get path->doc (or (path-from-url-hash (->URL (.-href js/location))) ""))}

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1265,8 +1265,15 @@
   {:nextjournal/presented (present error)
    :nextjournal/blob-id (str (gensym "error"))})
 
+(defn sync-state []
+  (->viewer-eval
+   (list 'reset!
+         'nextjournal.clerk.render/!sync-state
+         @@(resolve 'nextjournal.clerk.webserver/!sync-state))))
+
 (defn process-blocks [viewers {:as doc :keys [ns]}]
   (-> doc
+      (assoc :sync-state (sync-state))
       (assoc :atom-var-name->state (atom-var-name->state doc))
       (assoc :ns (->viewer-eval (list 'ns (if ns (ns-name ns) 'user))))
       (update :blocks (partial into [] (comp (mapcat (partial with-block-viewer (dissoc doc :error)))
@@ -1278,13 +1285,15 @@
       (update :file str)
 
       (select-keys [:atom-var-name->state
-                    :blocks :package
+                    :blocks
+                    :package
                     :doc-css-class
                     :error
                     :file
                     :open-graph
                     :ns
                     :title
+                    :sync-state
                     :toc
                     :toc-visibility
                     :header

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -542,7 +542,7 @@
                                                                          (dissoc cell :result ::doc) ;; TODO: reintroduce doc once we know why it OOMs the static build on CI (some walk issue probably)
                                                                          opts-from-block
                                                                          (ensure-wrapped-with-viewers (or viewers (get-viewers (get-*ns*))) value)
-                                                                         {:sync-state @!sync-state})
+                                                                         {:!sync-state !sync-state})
         presented-result (-> (present to-present)
                              (update :nextjournal/render-opts
                                      (fn [{:as opts existing-id :id}]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -914,11 +914,11 @@
 (defn ->opts [wrapped-value]
   (select-keys wrapped-value [:nextjournal/budget :nextjournal/css-class :nextjournal/width :nextjournal/render-opts
                               :nextjournal/render-evaluator
-                              :!budget :store!-wrapped-value :present-elision-fn :path :offset]))
+                              :!budget :store!-wrapped-value :sync-state :present-elision-fn :path :offset]))
 
 (defn inherit-opts [{:as wrapped-value :nextjournal/keys [viewers]} value path-segment]
   (-> (ensure-wrapped-with-viewers viewers value)
-      (merge (select-keys wrapped-value [:!budget :store!-wrapped-value :present-elision-fn :nextjournal/budget :path :sync-state]))
+      (merge (select-keys wrapped-value [:!budget :store!-wrapped-value :sync-state :present-elision-fn :nextjournal/budget :path]))
       (update :path (fnil conj []) path-segment)))
 
 (defn present-ex-data [parent throwable-map]
@@ -1772,7 +1772,8 @@
         (merge {:store!-wrapped-value (fn [{:as wrapped-value :keys [path]}]
                                         (swap! !path->wrapped-value assoc path wrapped-value))
                 :present-elision-fn (partial present-elision* !path->wrapped-value)
-                :path (:path opts [])}
+                :path (:path opts [])
+                :sync-state @!sync-state}
                (make-!budget-opts opts)
                opts)
         present*

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -918,7 +918,7 @@
 
 (defn inherit-opts [{:as wrapped-value :nextjournal/keys [viewers]} value path-segment]
   (-> (ensure-wrapped-with-viewers viewers value)
-      (merge (select-keys wrapped-value [:!budget :store!-wrapped-value :present-elision-fn :nextjournal/budget :path]))
+      (merge (select-keys wrapped-value [:!budget :store!-wrapped-value :present-elision-fn :nextjournal/budget :path :sync-state]))
       (update :path (fnil conj []) path-segment)))
 
 (defn present-ex-data [parent throwable-map]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1265,11 +1265,14 @@
   {:nextjournal/presented (present error)
    :nextjournal/blob-id (str (gensym "error"))})
 
+(defonce !sync-state
+  (#?(:clj atom :cljs ratom/atom) {}))
+
 (defn sync-state []
   (->viewer-eval
    (list 'reset!
-         'nextjournal.clerk.render/!sync-state
-         @@(resolve 'nextjournal.clerk.webserver/!sync-state))))
+         `!sync-state
+         @!sync-state)))
 
 (defn process-blocks [viewers {:as doc :keys [ns]}]
   (-> doc

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -918,7 +918,7 @@
 
 (defn inherit-opts [{:as wrapped-value :nextjournal/keys [viewers]} value path-segment]
   (-> (ensure-wrapped-with-viewers viewers value)
-      (merge (select-keys (->opts wrapped-value) [:!budget :store!-wrapped-value :present-elision-fn :nextjournal/budget :path]))
+      (merge (select-keys wrapped-value [:!budget :store!-wrapped-value :present-elision-fn :nextjournal/budget :path]))
       (update :path (fnil conj []) path-segment)))
 
 (defn present-ex-data [parent throwable-map]

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -16,8 +16,12 @@
             [sci.nrepl.browser-server :as sci.nrepl])
   (:import (java.nio.file Files)))
 
+(defn sync-atom-changed [key atom old-state new-state]
+  (eval '(nextjournal.clerk/recompute!)))
+
 (defonce !clients (atom #{}))
-(defonce !sync-state (atom {}))
+(defonce !sync-state (doto (atom {})
+                       (add-watch `!sync-state sync-atom-changed)))
 (defonce !doc (atom nil))
 (defonce !last-sender-ch (atom nil))
 
@@ -133,9 +137,6 @@
     (assoc :headers {"Content-Type" "text/javascript"})))
 
 #_(serve-resource (io/resource "public/clerk_service_worker.js"))
-
-(defn sync-atom-changed [key atom old-state new-state]
-  (eval '(nextjournal.clerk/recompute!)))
 
 (defn maybe-cancel-send-status-future [doc]
   (when-let [scheduled-send-status-future (-> doc meta ::!send-status-future)]

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -16,12 +16,7 @@
             [sci.nrepl.browser-server :as sci.nrepl])
   (:import (java.nio.file Files)))
 
-(defn sync-atom-changed [key atom old-state new-state]
-  (eval '(nextjournal.clerk/recompute!)))
-
 (defonce !clients (atom #{}))
-(defonce watch-sync
-  (add-watch v/!sync-state `v/!sync-state sync-atom-changed))
 (defonce !doc (atom nil))
 (defonce !last-sender-ch (atom nil))
 
@@ -137,6 +132,12 @@
     (assoc :headers {"Content-Type" "text/javascript"})))
 
 #_(serve-resource (io/resource "public/clerk_service_worker.js"))
+
+(defn sync-atom-changed [key atom old-state new-state]
+  (eval '(nextjournal.clerk/recompute!)))
+
+(defonce watch-sync
+  (add-watch v/!sync-state `v/!sync-state sync-atom-changed))
 
 (defn maybe-cancel-send-status-future [doc]
   (when-let [scheduled-send-status-future (-> doc meta ::!send-status-future)]

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -17,6 +17,7 @@
   (:import (java.nio.file Files)))
 
 (defonce !clients (atom #{}))
+(defonce !sync-state (atom {}))
 (defonce !doc (atom nil))
 (defonce !last-sender-ch (atom nil))
 

--- a/src/nextjournal/clerk/webserver.clj
+++ b/src/nextjournal/clerk/webserver.clj
@@ -20,8 +20,8 @@
   (eval '(nextjournal.clerk/recompute!)))
 
 (defonce !clients (atom #{}))
-(defonce !sync-state (doto (atom {})
-                       (add-watch `!sync-state sync-atom-changed)))
+(defonce watch-sync
+  (add-watch v/!sync-state `v/!sync-state sync-atom-changed))
 (defonce !doc (atom nil))
 (defonce !last-sender-ch (atom nil))
 


### PR DESCRIPTION
This introduces an experimental global `viewer/!sync-state` atom to provide a default state store primitive for writing interactive applications. The goal is to support customization of reading and writing in order to also make it useable when using Clerk's viewer api embedded outside of Clerk.