### PR TITLE
Improve error ux by showing ex-cause of error when set

### DIFF
--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -73,8 +73,8 @@
                                              (throw (ex-info (str "`nextjournal.clerk/show!` encountered an eval error with: `" (pr-str file-or-ns) "`") {::doc (assoc doc :blob->result blob->result)} e))))]
          (println (str "Clerk evaluated '" file "' in " time-ms "ms."))
          (webserver/update-doc! result))
-       (catch Exception e
-         (webserver/update-doc! (-> e ex-data ::doc (assoc :error e) (update :ns #(or % (find-ns 'user)))))
+       (catch clojure.lang.ExceptionInfo e
+         (webserver/update-doc! (-> e ex-data ::doc (assoc :error (or (ex-cause e) e)) (update :ns #(or % (find-ns 'user)))))
          (throw e))))))
 
 #_(show! "notebooks/exec_status.clj")


### PR DESCRIPTION
The ux for eval errors could be pretty bad in case there was rich viewers in the doc. This improves it.

Before:
<img width="1104" alt="Screenshot 2024-10-07 at 16 02 02" src="https://github.com/user-attachments/assets/6e91f594-1a0f-430c-b899-9de52c4d3fcf">

After:
<img width="1148" alt="Screenshot 2024-10-07 at 16 02 28" src="https://github.com/user-attachments/assets/84f0bd12-7140-4aec-be2d-db7c555201b4">

