### PR TITLE
Improve error handling

### DIFF
--- a/test/nextjournal/clerk/eval_test.clj
+++ b/test/nextjournal/clerk/eval_test.clj
@@ -139,8 +139,8 @@
     (eval/eval-string "(ns test-deref-hash (:require [nextjournal.clerk :as clerk])) (defonce !state (atom [(clerk/md \"_hi_\")])) @!state"))
 
   (testing "won't eval forward declarations"
-    (is (thrown? Exception
-                 (eval/eval-string "(ns test-forward-declarations {:nextjournal.clerk/no-cache true})
+    (is (:error
+         (eval/eval-string "(ns test-forward-declarations {:nextjournal.clerk/no-cache true})
 (declare delayed-def)
 (inc delayed-def)
 (def delayed-def 123)")))))


### PR DESCRIPTION
This improves Clerk's error handling by:
* flattening the error hierarchy by not catching and rethrowing eval errors
* not having the whole doc on the exception again which doesn't help and looks strange when custom viewers are used
* updating the in-memory cache when evaluation fails halfway through a notebook
* now throwing during `clerk/show!` when triggered through the file watcher

Before:
<img width="1180" alt="Screenshot 2024-10-08 at 17 57 18" src="https://github.com/user-attachments/assets/fe4b4a38-9c29-48e9-b0ac-54fccc56fd5b">

After:
<img width="1180" alt="Screenshot 2024-10-08 at 17 56 34" src="https://github.com/user-attachments/assets/f6c62b1d-751a-4e2e-94aa-1b3495d7491d">
