### PR TITLE
Delay viewer eval

### DIFF
--- a/notebooks/delay_viewer_eval.md
+++ b/notebooks/delay_viewer_eval.md
@@ -14,7 +14,7 @@
 * [x] Move away from doing stuff on read, use qualified symbol to tag a value in plain data and eval in postwalk
 * [x] Restore try/catch to not fail update when render-fn can't be evaluated
 * [x] Restore cherry evaluator support
-* [ ] Drop cherry data readers / writers
+* [x] Drop cherry data readers / writers
 * [ ] Consider dropping or keeping viewer fn data readers for unreadable edn, or move to more specific `#clerk/unreadable-edn-atom` tag?
 * [ ] Restore `rewrite-for-cherry`
 * [ ] Drop `ViewerEval` type

--- a/notebooks/delay_viewer_eval.md
+++ b/notebooks/delay_viewer_eval.md
@@ -12,9 +12,13 @@
 ## The Plan
 
 * [x] Move away from doing stuff on read, use qualified symbol to tag a value in plain data and eval in postwalk
-* [ ] Restore try/catch to not fail update when render-fn can't be evaluated
-* [ ] Restore cherry evaluator support
+* [x] Restore try/catch to not fail update when render-fn can't be evaluated
+* [x] Restore cherry evaluator support
+* [ ] Drop cherry data readers / writers
+* [ ] Consider dropping or keeping viewer fn data readers for unreadable edn, or move to more specific `#clerk/unreadable-edn-atom` tag?
+* [ ] Restore `rewrite-for-cherry`
 * [ ] Drop `ViewerEval` type
+
       
 
 

--- a/notebooks/delay_viewer_eval.md
+++ b/notebooks/delay_viewer_eval.md
@@ -15,7 +15,7 @@
 * [x] Restore try/catch to not fail update when render-fn can't be evaluated
 * [x] Restore cherry evaluator support
 * [x] Drop cherry data readers / writers
-* [ ] Consider dropping or keeping viewer fn data readers for unreadable edn, or move to more specific `#clerk/unreadable-edn-atom` tag?
+* [x] Move to more specific `#clerk/unreadable-edn` tag for unreadable keywords and symbols
 * [ ] Restore `rewrite-for-cherry`
 * [ ] Drop `ViewerEval` type
 

--- a/notebooks/delay_viewer_eval.md
+++ b/notebooks/delay_viewer_eval.md
@@ -1,0 +1,20 @@
+# Delay Viewer Eval
+
+## The Problem
+
+* Currently doing eval on read
+  * This leads to problems: 
+    * no control over when eval happens but sync atoms need to be interned before eval
+    * no editscript diff for sync atom values
+    * can't show error when clerk-eval fails because errors need to be reset before read
+  * Want to move to doing it in postprocess instead
+
+## The Plan
+
+* [x] Move away from doing stuff on read, use qualified symbol to tag a value in plain data and eval in postwalk
+* [ ] Restore try/catch to not fail update when render-fn can't be evaluated
+* [ ] Restore cherry evaluator support
+* [ ] Drop `ViewerEval` type
+      
+
+

--- a/src/nextjournal/clerk/cherry_env.cljs
+++ b/src/nextjournal/clerk/cherry_env.cljs
@@ -53,21 +53,6 @@
 
 (declare eval-form)
 
-(defn ->viewer-fn-with-error [form]
-  (try (binding [*eval* eval-form]
-         (viewer/->viewer-fn form))
-       (catch js/Error e
-         (viewer/map->ViewerFn
-          {:form form
-           :f (fn [_]
-                [render/error-view (ex-info (str "error in render-fn: " (.-message e)) {:render-fn form} e)])}))))
-
-(defn ->viewer-eval-with-error [form]
-  (try (eval-form form)
-       (catch js/Error e
-         (js/console.error "error in viewer-eval" e)
-         (ex-info (str "error in viewer-eval: " (.-message e)) {:form form} e))))
-
 (defn ^:export cherry-compile-string [s]
   (cherry/compile-string
    s

--- a/src/nextjournal/clerk/cljs_libs.clj
+++ b/src/nextjournal/clerk/cljs_libs.clj
@@ -183,7 +183,7 @@
                     (if-let [r (:require-cljs viewer)]
                       (let [cljs-ns (if (true? r)
                                       ;; at this point, the render-fn has been transformed to a `ViewerFn`, which contains a :form
-                                      (-> viewer :render-fn :form namespace symbol)
+                                      (-> viewer :render-fn peek namespace symbol)
                                       r)]
                         (require-cljs* state cljs-ns))
                       v)

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -696,11 +696,8 @@
 (defn eval-viewer-fns [doc]
   (intern-atoms! doc)
   (w/postwalk (fn [x] (if (viewer/render-eval? x)
-                        (do
-                          (prn :=> ((get viewer/viewer-fn-tag->instance (first x))
-                                    (second x)))
-                          ((get viewer/viewer-fn-tag->instance (first x))
-                           (second x)))
+                        ((get viewer/viewer-fn-tag->instance (first x))
+                         (peek x))
                         x))
               doc))
 

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -696,8 +696,9 @@
 (defn eval-viewer-fns [doc]
   (intern-atoms! doc)
   (w/postwalk (fn [x] (if (viewer/render-eval? x)
-                        ((get viewer/viewer-fn-tag->instance (first x))
-                         (peek x))
+                        ;; TODO: pass this down from init instead of doing resolve
+                        ((resolve 'nextjournal.clerk.sci-env/eval-render-fn)
+                         x)
                         x))
               doc))
 

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -95,9 +95,7 @@
          (fn [tag]
            (or (get @cljs.reader/*tag-table* tag)
                (get {'viewer-fn ->viewer-fn-with-error
-                     'viewer-fn/cherry cherry-env/->viewer-fn-with-error
                      'viewer-eval ->viewer-eval-with-error
-                     'viewer-eval/cherry cherry-env/->viewer-eval-with-error
                      'ordered/map ordered-map-reader-cljs} tag)
                (fn [value]
                  (viewer/with-viewer `viewer/tagged-value-viewer

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -84,6 +84,15 @@
 (defn ordered-map-reader-cljs [coll]
   (omap/ordered-map (vec coll)))
 
+(defn unreadable-edn
+  "Reader fn for unreadable edn atoms. Currently only used for symbols
+  and keywords. Same usages
+  (symbol \"foo bar\")
+  (keyword \"foo bar\")
+  (keyword \"my-ns\" \"foo bar\")"
+  [form]
+  (eval form))
+
 (defonce !edamame-opts
   (atom {:all true
          :row-key :line
@@ -94,7 +103,8 @@
          :readers
          (fn [tag]
            (or (get @cljs.reader/*tag-table* tag)
-               (get {'viewer-fn ->viewer-fn-with-error
+               (get {'clerk/unreadable-edn unreadable-edn
+                     'viewer-fn ->viewer-fn-with-error
                      'viewer-eval ->viewer-eval-with-error
                      'ordered/map ordered-map-reader-cljs} tag)
                (fn [value]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -396,18 +396,20 @@
    (defmethod print-method clojure.lang.Keyword [o w]
      (if (roundtrippable? o)
        (print-simple o w)
-       (.write w (pr-str (->viewer-eval (if-let [ns (namespace o)]
-                                          (list 'keyword ns (name o))
-                                          (list 'keyword (name o)))))))))
+       (.write w (str "#clerk/unreadable-edn "
+                      (pr-str (if-let [ns (namespace o)]
+                                (list 'keyword ns (name o))
+                                (list 'keyword (name o)))))))))
 
 #?(:clj
    (defmethod print-method clojure.lang.Symbol [o w]
      (if (or (roundtrippable? o)
              (= (name o) "?@"))  ;; splicing reader conditional, see issue #338
        (print-simple o w)
-       (.write w (pr-str (->viewer-eval (if-let [ns (namespace o)]
-                                          (list 'symbol ns (name o))
-                                          (list 'symbol (name o)))))))))
+       (.write w (str "#clerk/unreadable-edn "
+                      (pr-str (if-let [ns (namespace o)]
+                                (list 'symbol ns (name o))
+                                (list 'symbol (name o)))))))))
 
 #?(:clj
    (defn ->edn [x]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -99,11 +99,15 @@
 
 #?(:clj
    (defmethod print-method ViewerFn [v ^java.io.Writer w]
-     (.write w (str [`viewer-fn (:form v)]))))
+     (.write w (str "#viewer-fn" (when (= :cherry (:render-evaluator v))
+                                   "/cherry")
+                    " " (pr-str (:form v))))))
 
 #?(:clj
    (defmethod print-method ViewerEval [v ^java.io.Writer w]
-     (.write w (str [`viewer-eval (:form v)])))
+     (.write w (str "#viewer-eval" (when (= :cherry (:render-evaluator v))
+                                     "/cherry")
+                    " " (pr-str (:form v)))))
    :cljs
    (extend-type ViewerEval
      IPrintWithWriter

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -97,15 +97,11 @@
 
 #?(:clj
    (defmethod print-method ViewerFn [v ^java.io.Writer w]
-     (.write w (str "#viewer-fn" (when (= :cherry (:render-evaluator v))
-                                   "/cherry")
-                    " " (pr-str (:form v))))))
+     (.write w (str "#viewer-fn " (pr-str (:form v))))))
 
 #?(:clj
    (defmethod print-method ViewerEval [v ^java.io.Writer w]
-     (.write w (str "#viewer-eval" (when (= :cherry (:render-evaluator v))
-                                     "/cherry")
-                    " " (pr-str (:form v)))))
+     (.write w (str "#viewer-eval " (pr-str (:form v)))))
    :cljs
    (extend-type ViewerEval
      IPrintWithWriter

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -66,9 +66,7 @@
   ([aliases form] (w/postwalk #(cond->> % (qualified-symbol? %) (resolve-symbol-alias aliases)) form)))
 
 (defn ->render-eval [tag opts form]
-  (if opts
-    [tag opts form]
-    [tag form]))
+  [tag (or opts {}) form])
 
 (defn tag-viewer-fn [opts form]
   (->render-eval `viewer-fn opts form))

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -338,9 +338,7 @@
     (is (not-empty (-> (view/doc->viewer (eval/eval-string "(ns nextjournal.clerk.test.sync-vars (:require [nextjournal.clerk :as clerk]))
                                      ^::clerk/sync (def sync-me (atom {:a ['b 'c 3]}))"))
                        :nextjournal/value
-                       :atom-var-name->state
-                       :form
-                       second)))
+                       :atom-var-name->state)))
 
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
@@ -468,21 +466,21 @@
             (->> (eval/eval-string "^{:nextjournal.clerk/budget 5}(reduce (fn [acc _i] (vector acc)) :fin (range 100 0 -1))")
                  view/doc->viewer v/->value :blocks
                  (tree-seq coll? seq)
-                 (filter (every-pred map? (comp #{'nextjournal.clerk.render/render-coll} :form :render-fn)))))))
+                 (filter (every-pred map? (comp #{(v/tag-viewer-fn {} 'nextjournal.clerk.render/render-coll)} :render-fn)))))))
 
     (is (= 5
            (count
             (->> (eval/eval-string "(nextjournal.clerk/with-viewer {} {:nextjournal.clerk/budget 5} (reduce (fn [acc i] (vector acc)) :fin (range 15 0 -1)))")
                  view/doc->viewer v/->value :blocks
                  (tree-seq coll? seq)
-                 (filter (every-pred map? (comp #{'nextjournal.clerk.render/render-coll} :form :render-fn)))))))
+                 (filter (every-pred map? (comp #{(v/tag-viewer-fn {} 'nextjournal.clerk.render/render-coll)} :render-fn)))))))
 
     (is (= 101
            (count
             (->> (eval/eval-string "^{:nextjournal.clerk/budget nil}(reduce (fn [acc i] (vector i acc)) :fin (range 101 0 -1))")
                  view/doc->viewer v/->value :blocks
                  (tree-seq coll? seq)
-                 (filter (every-pred map? (comp #{'nextjournal.clerk.render/render-coll} :form :render-fn)))))))))
+                 (filter (every-pred map? (comp #{(v/tag-viewer-fn {} 'nextjournal.clerk.render/render-coll)} :render-fn)))))))))
 
 (deftest ->edn
   (testing "normal symbols and keywords"

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -490,21 +490,21 @@
     (is (= ":namespaced/keyword" (pr-str :namespaced/keyword))))
 
   (testing "unreadable symbols and keywords print as viewer-eval"
-    (is (= "#viewer-eval (keyword \"with spaces\")"
+    (is (= "#clerk/unreadable-edn (keyword \"with spaces\")"
            (pr-str (keyword "with spaces"))))
-    (is (= "#viewer-eval (keyword \"with ns\" \"and spaces\")"
+    (is (= "#clerk/unreadable-edn (keyword \"with ns\" \"and spaces\")"
            (pr-str (keyword "with ns" "and spaces"))))
-    (is (= "#viewer-eval (symbol \"with spaces\")"
+    (is (= "#clerk/unreadable-edn (symbol \"with spaces\")"
            (pr-str (symbol "with spaces"))))
-    (is (= "#viewer-eval (symbol \"with ns\" \"and spaces\")"
+    (is (= "#clerk/unreadable-edn (symbol \"with ns\" \"and spaces\")"
            (pr-str (symbol "with ns" "and spaces"))))
-    (is (= "#viewer-eval (symbol \"~\")"
+    (is (= "#clerk/unreadable-edn (symbol \"~\")"
            (pr-str (symbol "~")))))
 
   (testing "symbols and keywords with two slashes readable by `read-string` but not `tools.reader/read-string` print as viewer-eval"
-    (is (= "#viewer-eval (symbol \"foo\" \"bar/baz\")"
+    (is (= "#clerk/unreadable-edn (symbol \"foo\" \"bar/baz\")"
            (pr-str (read-string "foo/bar/baz"))))
-    (is (= "#viewer-eval (keyword \"foo\" \"bar/baz\")"
+    (is (= "#clerk/unreadable-edn (keyword \"foo\" \"bar/baz\")"
            (pr-str (read-string ":foo/bar/baz")))))
 
   (testing "splicing reader conditional prints normally (issue #338)"


### PR DESCRIPTION
Currently doing eval on read, this leads to problems: 
    * no control over when eval happens but sync atoms need to be interned before eval
    * no editscript diff for sync atom values
    * can't show error when clerk-eval fails because errors need to be reset before read