### PR TITLE
Delay viewer fn eval to invoke

### DIFF
--- a/src/nextjournal/clerk/cherry_env.cljs
+++ b/src/nextjournal/clerk/cherry_env.cljs
@@ -59,8 +59,8 @@
        (catch js/Error e
          (viewer/map->ViewerFn
           {:form form
-           :f (fn [_]
-                [render/error-view (ex-info (str "error in render-fn: " (.-message e)) {:render-fn form} e)])}))))
+           :f (delay (fn [_]
+                       [render/error-view (ex-info (str "error in render-fn: " (.-message e)) {:render-fn form} e)]))}))))
 
 (defn ->viewer-eval-with-error [form]
   (try (eval-form form)

--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -547,9 +547,9 @@
        ;; each view function must be called in its own 'functional component' so that it gets its own hook state.
        ^{:key hash}
        [:> ErrorBoundary {:hash hash}
-        [(:f (:render-fn viewer)) value (merge opts
-                                               (:nextjournal/render-opts x)
-                                               {:viewer viewer :path path})]]))))
+        [(:render-fn viewer) value (merge opts
+                                          (:nextjournal/render-opts x)
+                                          {:viewer viewer :path path})]]))))
 
 (defn inspect [value]
   (r/with-let [!state   (r/atom nil)

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -61,9 +61,9 @@
                (sci/resolve (sci.ctx-store/get-ctx) (resolve-legacy-alias unresolved-sym)))
       (viewer/map->ViewerFn
        {:form form
-        :f (fn [] [render/error-view (ex-info (str "We now require `:render-fn`s to use fully-qualified symbols, and we have removed the old aliases from Clerk. "
-                                                   "Please change `" unresolved-sym "` to `" (resolve-legacy-alias unresolved-sym) "` in your `:render-fn` to resolve this issue.")
-                                              {:render-fn form} e)])}))))
+        :f (delay (fn [] [render/error-view (ex-info (str "We now require `:render-fn`s to use fully-qualified symbols, and we have removed the old aliases from Clerk. "
+                                                          "Please change `" unresolved-sym "` to `" (resolve-legacy-alias unresolved-sym) "` in your `:render-fn` to resolve this issue.")
+                                                     {:render-fn form} e)]))}))))
 
 (defn ->viewer-fn-with-error [form]
   (try (viewer/->viewer-fn form)
@@ -71,8 +71,8 @@
          (or (maybe-handle-legacy-alias-error form e)
              (viewer/map->ViewerFn
               {:form form
-               :f (fn [_]
-                    [render/error-view (ex-info (str "error in render-fn: " (.-message e)) {:render-fn form} e)])})))))
+               :f (delay (fn [_]
+                           [render/error-view (ex-info (str "error in render-fn: " (.-message e)) {:render-fn form} e)]))})))))
 
 (defn ->viewer-eval-with-error [form]
   (try (*eval* form)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -36,8 +36,8 @@
 
 (defrecord ViewerFn [form #?(:cljs f)]
   #?@(:cljs [IFn
-             (-invoke [_ x] (f x))
-             (-invoke [_ x y] (f x y))]))
+             (-invoke [_ x] (@f x))
+             (-invoke [_ x y] (@f x y))]))
 
 ;; Make sure `ViewerFn` and `ViewerEval` is changed atomically
 #?(:clj
@@ -67,7 +67,7 @@
 
 (defn ->viewer-fn [form]
   (map->ViewerFn {:form form
-                  #?@(:cljs [:f (*eval* form)])}))
+                  #?@(:cljs [:f (delay (eval form))])}))
 
 (defn ->viewer-eval [form]
   (map->ViewerEval {:form form}))


### PR DESCRIPTION
Should be a first simple step towards no longer doing eval on read. In a second step, we should be able to implement ViewerEval on top of this delayed ViewerFn.

Alternative to #711.