### PR TITLE
Support `:as-alias` in `:require-cljs` namespaces

### DIFF
--- a/notebooks/viewers/viewer_lib.cljc
+++ b/notebooks/viewers/viewer_lib.cljc
@@ -1,5 +1,8 @@
 (ns viewers.viewer-lib
-  #?(:cljs (:require [nextjournal.clerk :as clerk])))
+  #?(:cljs (:require [nextjournal.clerk :as clerk]
+                     [foo.bar :as-alias foo])))
+
+#?(:cljs `foo/x)
 
 #?(:cljs (defn my-already-defined-function [x]
           [:div

--- a/src/nextjournal/clerk/cljs_libs.clj
+++ b/src/nextjournal/clerk/cljs_libs.clj
@@ -66,7 +66,13 @@
            :else (recur)))))))
 
 (defn deps-from-ns-decl [parsed-ns-decl]
-  (filter symbol? (map :lib (:requires parsed-ns-decl))))
+  (keep (fn [req]
+          (when-not (:as-alias req)
+            (let [lib (:lib req)]
+              (when (symbol? lib)
+                lib)))) (:requires parsed-ns-decl)))
+
+#_(deps-from-ns-decl (e/parse-ns-form '(ns foo (:require [foo] [bar :as-alias dude]))))
 
 (defn name-from-ns-decl [parsed-ns-decl]
   (:current parsed-ns-decl))


### PR DESCRIPTION
Fixes #707.