### PR TITLE
Fix rendering of numbers whose magnitude is greater than 2^53

### DIFF
--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -867,7 +867,9 @@
    :render-fn 'nextjournal.clerk.render/render-number
    #?@(:clj [:transform-fn (update-val #(cond-> %
                                           (or (instance? clojure.lang.Ratio %)
-                                              (instance? clojure.lang.BigInt %)) pr-str))])})
+                                              (instance? clojure.lang.BigInt %)
+                                              (> % 9007199254740992)
+                                              (< % -9007199254740992)) pr-str))])})
 
 (def number-hex-viewer
   {:name `number-hex-viewer :render-fn '(fn [num] (nextjournal.clerk.render/render-number (str "0x" (.toString (js/Number. num) 16))))})

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -249,7 +249,11 @@
     (is (match? {:nextjournal/value "1142497398145249635243N"}
                 (v/present 1142497398145249635243N)))
     (is (match? {:nextjournal/value "10/33"}
-                (v/present 10/33))))
+                (v/present 10/33)))
+    (is (match? {:nextjournal/value "9007199254740993"}
+                (v/present 9007199254740993)))
+    (is (match? {:nextjournal/value "-9007199254740993"}
+                (v/present -9007199254740993))))
 
   (testing "opts are not propagated to children during presentation"
     (let [count-opts (fn [o]


### PR DESCRIPTION
Only numbers with magnitude no greater than 2^53 are precisely representable in JavaScript Number type.