### PR TITLE
Add build and scripts directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,8 @@ You can use the following BibTeX citation:
   year         = 2023
 }
 ```
+
+## Directories
+
+* `build`: Directory for build outputs.
+* `scripts`: Directory for utility scripts.

--- a/build.clj
+++ b/build.clj
@@ -7,13 +7,13 @@
    [shared]))
 
 (def lib 'io.github.nextjournal/clerk)
-(def class-dir "target/classes")
+(def class-dir "build/classes")
 
 (def basis (-> (b/create-basis {:project "deps.edn"})
                (update :libs dissoc 'io.github.nextjournal/dejavu)))
 
 (def version (shared/version))
-(def jar-file (format "target/%s-%s.jar" (name lib) version))
+(def jar-file (format "build/%s-%s.jar" (name lib) version))
 
 (defn package-clerk-asset-map [{:as opts :keys [target-dir]}]
   (when-not target-dir
@@ -22,7 +22,7 @@
     (spit (str target-dir java.io.File/separator "clerk-asset-map.edn") asset-map)))
 
 (defn jar [_]
-  (b/delete {:path "target"})
+  (b/delete {:path "build"})
   (println "Producing jar:" jar-file)
   (b/write-pom {:class-dir class-dir
                 :lib lib


### PR DESCRIPTION
Add `build` directory for build outputs and `scripts` directory for utility scripts.

* **`build.clj`**
  - Update `class-dir` and `jar-file` paths to use `build` directory.
  - Change `b/delete` path to `build`.

* **`README.md`**
  - Add a section mentioning the `build` and `scripts` directories.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/clerk?shareId=XXXX-XXXX-XXXX-XXXX).