### PR TITLE
Untangle parser from analyzer

### DIFF
--- a/notebooks/hello.clj
+++ b/notebooks/hello.clj
@@ -2,6 +2,7 @@
 
 ;; Clerk enables a _rich_, local-first notebook experience using standard Clojure namespaces.
 (ns hello
+  {:nextjournal.clerk/no-cache true}
   (:require [nextjournal.clerk :as clerk]))
 
 ;; Here's a visualization of unemployment in the US.

--- a/notebooks/hello.md
+++ b/notebooks/hello.md
@@ -1,0 +1,21 @@
+# Hello Markdown 👋
+
+Clerk enables a _rich_, local-first notebook experience using standard
+Clojure namespaces and markdown.
+
+```clojure
+(ns hello-markdown
+  {:nextjournal.clerk/no-cache true
+   :nextjournal.clerk/visibility {:code :fold}}
+  (:require [nextjournal.clerk :as clerk]))
+```
+
+Here's a visualization of unemployment in the US.
+
+```clojure
+(clerk/vl {:width 700 :height 400 :data {:url "https://vega.github.io/vega-datasets/data/us-10m.json"
+                                         :format {:type "topojson" :feature "counties"}}
+           :transform [{:lookup "id" :from {:data {:url "https://vega.github.io/vega-datasets/data/unemployment.tsv"}
+                                            :key "id" :fields ["rate"]}}]
+           :projection {:type "albersUsa"} :mark "geoshape" :encoding {:color {:field "rate" :type "quantitative"}}})
+```

--- a/notebooks/hello.md
+++ b/notebooks/hello.md
@@ -13,9 +13,10 @@ Clojure namespaces and markdown.
 Here's a visualization of unemployment in the US.
 
 ```clojure
-(clerk/vl {:width 700 :height 400 :data {:url "https://vega.github.io/vega-datasets/data/us-10m.json"
-                                         :format {:type "topojson" :feature "counties"}}
-           :transform [{:lookup "id" :from {:data {:url "https://vega.github.io/vega-datasets/data/unemployment.tsv"}
-                                            :key "id" :fields ["rate"]}}]
-           :projection {:type "albersUsa"} :mark "geoshape" :encoding {:color {:field "rate" :type "quantitative"}}})
+^{::clerk/viewer clerk/vl}
+{:width 700 :height 400 :data {:url "https://vega.github.io/vega-datasets/data/us-10m.json"
+ :format {:type "topojson" :feature "counties"}}
+ :transform [{:lookup "id" :from {:data {:url "https://vega.github.io/vega-datasets/data/unemployment.tsv"}
+ :key "id" :fields ["rate"]}}]
+ :projection {:type "albersUsa"} :mark "geoshape" :encoding {:color {:field "rate" :type "quantitative"}}}
 ```

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -648,7 +648,7 @@
   (show! "notebooks/onwards.md")
   (show! "notebooks/pagination.clj")
   (show! "notebooks/how_clerk_works.clj")
-  (show! "notebooks/hello_clojurescript.cljs")
+  (show! "notebooks/hello.cljs")
   (show! "notebooks/conditional_read.cljc")
   (show! "src/nextjournal/clerk/analyzer.clj")
   (show! "src/nextjournal/clerk.clj")

--- a/src/nextjournal/clerk.clj
+++ b/src/nextjournal/clerk.clj
@@ -57,7 +57,7 @@
                              (when-let [path (paths/path-in-cwd file-or-ns)]
                                {:file-path path})
                              {:nav-path (webserver/->nav-path file-or-ns)}
-                             (parser/parse-file {:doc? true} file))
+                             (parser/parse-file file))
                       (catch java.io.FileNotFoundException e
                         (throw (ex-info (str "`nextjournal.clerk/show!` could not find the file: `" (pr-str file-or-ns) "`")
                                         {:file-or-ns file-or-ns}

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -353,9 +353,9 @@
                                  (update :blocks conj (cond-> (dissoc block+analysis :deps :no-cache? :ns-effect?)
                                                         (parser/ns? form) (assoc :ns? true)
                                                         doc? (assoc :text-without-meta (parser/text-with-clerk-metadata-removed text (ns-resolver notebook-ns)))))
-                                 (cond->
-                                     (and doc? (not (contains? state :ns)))
-                                   (merge (parser/->doc-settings form) {:ns *ns*}))))))
+                                 (cond-> #_doc
+                                   (not (contains? state :ns))
+                                   (assoc :ns *ns*))))))
 
                        (-> state
                            (cond-> doc? (merge doc))
@@ -365,9 +365,7 @@
                        (:blocks doc))
 
          true (dissoc :doc?)
-         doc? (-> parser/add-block-settings
-                  parser/add-open-graph-metadata
-                  parser/filter-code-blocks-without-form))))))
+         doc? parser/filter-code-blocks-without-form)))))
 
 #_(let [parsed (parser/parse-clojure-string "clojure.core/dec")]
     (build-graph (analyze-doc parsed)))

--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -352,10 +352,7 @@
                                  (track-var->block+redefs block+analysis)
                                  (update :blocks conj (cond-> (dissoc block+analysis :deps :no-cache? :ns-effect?)
                                                         (parser/ns? form) (assoc :ns? true)
-                                                        doc? (assoc :text-without-meta (parser/text-with-clerk-metadata-removed text (ns-resolver notebook-ns)))))
-                                 (cond-> #_doc
-                                   (not (contains? state :ns))
-                                   (assoc :ns *ns*))))))
+                                                        doc? (assoc :text-without-meta (parser/text-with-clerk-metadata-removed text (ns-resolver notebook-ns)))))))))
 
                        (-> state
                            (cond-> doc? (merge doc))

--- a/src/nextjournal/clerk/config.clj
+++ b/src/nextjournal/clerk/config.clj
@@ -8,8 +8,8 @@
       ".clerk/cache"))
 
 (def cache-disabled?
-  (when-let [prop (System/getProperty "clerk.disable_cache")]
-    (not= "false" prop)))
+  (boolean (when-let [prop (System/getProperty "clerk.disable_cache")]
+             (not= "false" prop))))
 
 (def resource-manifest-from-props
   (when-let [prop (System/getProperty "clerk.resource_manifest")]

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -135,8 +135,7 @@
           var-from-def? (and var (var? result) (= var (symbol result)))
           no-cache? (or ns-effect?
                         no-cache?
-                        (boolean (seq @!interned-vars))
-                        config/cache-disabled?)]
+                        (boolean (seq @!interned-vars)))]
       (when (and (not no-cache?)
                  (not ns-effect?)
                  freezable?
@@ -287,14 +286,18 @@
 (defn eval-doc
   "Evaluates the given `doc`."
   ([doc] (eval-doc {} doc))
-  ([in-memory-cache doc] (+eval-results in-memory-cache doc)))
+  ([in-memory-cache doc]
+   (+eval-results in-memory-cache
+                  (cond-> doc
+                    config/cache-disabled?
+                    (assoc :no-cache true)))))
 
 (defn eval-file
   "Reads given `file` (using `slurp`) and evaluates it."
   ([file] (eval-file {} file))
   ([in-memory-cache file]
    (->> file
-        (parser/parse-file {:doc? true})
+        parser/parse-file
         (eval-doc in-memory-cache))))
 
 #_(eval-file "notebooks/hello.clj")

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -270,6 +270,9 @@
         (set-status-fn {:progress 0.10 :status "Analyzing…"}))
       (let [{:as analyzed-doc :keys [ns]} (analyzer/build-graph
                                            (assoc parsed-doc :blob->result in-memory-cache))]
+        (when (and (not-empty (:var->block-id analyzed-doc))
+                   (not ns))
+          (throw (ex-info "namespace must be set" (select-keys analyzed-doc [:file :ns]))))
         (binding [*ns* ns]
           (-> analyzed-doc
               analyzer/hash

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -296,6 +296,6 @@
   "Evaluated the given `code-string` using the optional `in-memory-cache` map."
   ([code-string] (eval-string {} code-string))
   ([in-memory-cache code-string]
-   (eval-doc in-memory-cache (parser/parse-clojure-string {:doc? true} code-string))))
+   (eval-doc in-memory-cache (parser/parse-clojure-string code-string))))
 
 #_(eval-string "(+ 39 3)")

--- a/src/nextjournal/clerk/home.clj
+++ b/src/nextjournal/clerk/home.clj
@@ -1,5 +1,6 @@
 (ns nextjournal.clerk.home
-  {:nextjournal.clerk/visibility {:code :hide :result :hide}}
+  {:nextjournal.clerk/visibility {:code :hide :result :hide}
+   :nextjournal.clerk/no-cache true}
   (:require [babashka.fs :as fs]
             [clojure.string :as str]
             [nextjournal.clerk :as clerk]

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -211,6 +211,12 @@
                                                                (merge (-> first-form second meta)
                                                                       (first (filter map? first-form)))))))
                                  false)
+             :no-cache (boolean
+                        (:nextjournal.clerk/no-cache
+                         (or (when (map? first-form)
+                               first-form)
+                             (when (ns? first-form)
+                               (first (filter map? first-form))))))
              :block-settings (merge-with merge
                                          {:nextjournal.clerk/visibility {:code :show :result :show}}
                                          (parse-global-block-settings first-form))}
@@ -554,3 +560,7 @@
   (parse-file "notebooks/elements.clj")
   (parse-file "notebooks/rule_30.clj")
   (parse-file "notebooks/src/demo/lib.cljc"))
+
+#_(select-keys 
+   (parse-file "test/nextjournal/clerk/fixtures/hello.clj")
+   [:file :no-cache])

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -85,6 +85,7 @@
   #{:nextjournal.clerk/auto-expand-results?
     :nextjournal.clerk/budget
     :nextjournal.clerk/css-class
+    :nextjournal.clerk/no-cache
     :nextjournal.clerk/render-opts
     :nextjournal.clerk/page-size
     :nextjournal.clerk/render-evaluator
@@ -418,7 +419,7 @@
          add-open-graph-metadata
          add-doc-settings)))
   ([{:as opts :keys [skip-doc?]} initial-state s]
-   (binding [*ns* *ns*]
+   (binding [*ns* (:ns initial-state *ns*)]
      (loop [{:as state :keys [nodes blocks block-settings add-comment-on-line? add-block-id]}
 
             (assoc initial-state

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -540,7 +540,10 @@
            (-> state
                (update :blocks #(cond-> % (seq md-slice) (conj {:type :markdown :doc {:type :doc :content md-slice}})))
                (dissoc ::md-slice :md-context)
-               (merge (select-keys ctx md-context-keys-to-select)))))))))
+               (merge (select-keys ctx md-context-keys-to-select))
+               add-open-graph-metadata
+               add-doc-settings
+               add-block-settings)))))))
 
 #_(parse-markdown-string "# Hello\n```\n1\n;; # 1️⃣ Hello\n2\n\n```\nhey\n```\n3\n;; # 2️⃣ Hello\n4\n```\n")
 
@@ -560,7 +563,3 @@
   (parse-file "notebooks/elements.clj")
   (parse-file "notebooks/rule_30.clj")
   (parse-file "notebooks/src/demo/lib.cljc"))
-
-#_(select-keys 
-   (parse-file "test/nextjournal/clerk/fixtures/hello.clj")
-   [:file :no-cache])

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -418,12 +418,12 @@
                                           s)]
      (-> (select-keys (cond-> parsed-doc
                         (not skip-doc?) (merge (:md-context parsed-doc)))
-                      [:file :blocks :title :toc :footnotes])
+                      [:file :blocks :title :toc :footnotes :ns])
          add-open-graph-metadata
          add-doc-settings
          add-block-settings)))
   ([{:as opts :keys [skip-doc?]} initial-state s]
-   (binding [*ns* (or *ns* (create-ns 'user))]
+   (binding [*ns* *ns*]
      (loop [{:as state :keys [nodes blocks add-comment-on-line? add-block-id]}
 
             (assoc initial-state

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -335,7 +335,6 @@
 
 (defn update-markdown-blocks [{:as state :keys [md-context]} md]
   (let [doc (markdown/parse* (assoc md-context :content []) md)]
-    (prn :update-md md :parsed doc)
     (-> state
         (assoc :md-context doc)
         (update :blocks conj {:type :markdown

--- a/src/nextjournal/clerk/parser.cljc
+++ b/src/nextjournal/clerk/parser.cljc
@@ -340,7 +340,7 @@
 
 (defn guess-var
   "An best guess to say if the given `form` defines a var without running
-  macroexpansion."
+  macroexpansion. Will be refined during analysis."
   [form]
   (when (and (sequential? form)
              (simple-symbol? (first form))
@@ -354,8 +354,10 @@
 
 (defn get-block-id [!id->count {:as block :keys [form type doc]}]
   (let [id->count @!id->count
-        id (if-let [guessed-var (guess-var form)]
-             guessed-var
+        id (if-let [var (if (contains? block :vars)
+                          (:var block)
+                          (guess-var form))]
+             var
              (let [hash-fn (fn [x]
                              #?(:clj (-> x nippy/fast-freeze sha1-base58)
                                 :cljs (throw (ex-info "hash-fn cljs not implemented for cljs yet" {}))))]
@@ -389,7 +391,7 @@
 #_(extract-file (clojure.java.io/resource "nextjournal/clerk.clj"))
 
 (defn add-loc [{:as opts :keys [file]} loc form]
-  #?(:cljs (throw "not yet implemented for cljs" {})
+  #?(:cljs (throw (ex-info "not yet implemented for cljs" {}))
      :clj (cond-> form
             (instance? clojure.lang.IObj form)
             (vary-meta merge (cond-> loc

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -85,16 +85,6 @@
     (is (= '#{nextjournal.clerk.analyzer/BoundedCountCheck}
            (:deps (ana/analyze 'nextjournal.clerk.analyzer/-exceeds-bounded-count-limit?))))))
 
-(deftest read-string-tests
-  (testing "read-string should read regex's such that value equalility is preserved"
-    (is (= '(fn [x] (clojure.string/split x (clojure.core/re-pattern "/")))
-           (ana/read-string "(fn [x] (clojure.string/split x #\"/\"))"))))
-
-  (testing "read-string can handle syntax quote"
-    (is (match? '['nextjournal.clerk.analyzer-test/foo 'nextjournal.clerk/foo 'nextjournal.clerk/foo]
-                (with-ns-binding 'nextjournal.clerk.analyzer-test
-                  (ana/read-string "[`foo `clerk/foo `nextjournal.clerk/foo]"))))))
-
 (deftest analyze
   (testing "quoted forms aren't confused with variable dependencies"
     (is (match? {:deps #{`inc}}

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -289,13 +289,6 @@
                                   (inc a#))))))))
 
 (deftest analyze-doc
-  (testing "reading a bad block shows block and file info in raised exception"
-    (is (thrown-match? ExceptionInfo
-                       {:block {:type :code :text "##boom"}
-                        :file any?}
-                       (-> (parser/parse-clojure-string {:doc? true} "(ns some-ns (:require []))")
-                           (update-in [:blocks 0 :text] (constantly "##boom"))
-                           ana/analyze-doc))))
   (is (match? #{{}
                 {:form '(ns example-notebook),
                  :deps set?}
@@ -329,16 +322,6 @@
 (deftest analyze-file
   (testing "should analyze depedencies"
     (is (-> (ana/analyze-file "src/nextjournal/clerk/classpath.clj") :->analysis-info not-empty))))
-
-(deftest add-block-ids
-  (testing "assigns block ids"
-    (is (= '[foo/anon-expr-5drCkCGrPisMxHpJVeyoWwviSU3pfm
-             foo/bar
-             foo/bar#2
-             foo/anon-expr-5dsbEK7B7yDZqzyteqsY2ndKVE9p3G
-             foo/anon-expr-5dsbEK7B7yDZqzyteqsY2ndKVE9p3G#2]
-           (->> "(ns foo {:nextjournal.clerk/visibility {:code :fold}}) (def bar :baz) (def bar :baz) (rand-int 42) (rand-int 42)"
-                analyze-string :blocks (mapv :id))))))
 
 (deftest no-cache-dep
   (is (match? [{:no-cache? true} {:no-cache? true} {:no-cache? true}]

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -193,7 +193,7 @@
     (is (re-find #"dependency-.*\.jar" (ana/find-location 'weavejester.dependency/graph)))))
 
 (defn analyze-string [s]
-  (-> (parser/parse-clojure-string {:doc? true} s)
+  (-> (parser/parse-clojure-string s)
       ana/build-graph))
 
 (deftest hash-test

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -371,6 +371,7 @@ my-uuid")]
     (is (dep/depends? (:graph analyzed)
                       'nextjournal.clerk.analyzer-test.graph-nodes/some-dependent-var
                       'nextjournal.clerk.git/read-git-attrs))
+    #_ FIXME
     (is (not (contains? (dep/nodes (:graph analyzed))
                         'nextjournal.clerk.fixtures.dep-a/some-function-with-defs-inside)))
 

--- a/test/nextjournal/clerk/parser_test.clj
+++ b/test/nextjournal/clerk/parser_test.clj
@@ -1,6 +1,5 @@
 (ns nextjournal.clerk.parser-test
   (:require [clojure.test :refer [deftest is testing]]
-            [matcher-combinators.matchers :as m]
             [matcher-combinators.test :refer [match?]]
             [nextjournal.clerk.analyzer-test :refer [analyze-string]]
             [nextjournal.clerk.parser :as parser]
@@ -28,20 +27,20 @@ line\"")
 
 (deftest parse-clojure-string
   (testing "is returning blocks with types and markdown structure attached"
-    (is (match? (m/equals {:blocks [{:type :code, :text "^:nextjournal.clerk/no-cache ^:nextjournal.clerk/toc (ns example-notebook)"}
-                                    {:type :markdown, :doc {:type :doc :content [{:type :heading}
-                                                                                 {:type :heading}
-                                                                                 {:type :paragraph}]}}
-                                    {:type :code, :text "#{3 1 2}"}
-                                    {:type :markdown, :doc {:type :doc :content [{:type :heading}]}}
-                                    {:type :code, :text "{2 \"bar\" 1 \"foo\"}"},
-                                    {:type :code, :text "\"multi
+    (is (match? {:blocks [{:type :code, :text "^:nextjournal.clerk/no-cache ^:nextjournal.clerk/toc (ns example-notebook)"}
+                          {:type :markdown, :doc {:type :doc :content [{:type :heading}
+                                                                       {:type :heading}
+                                                                       {:type :paragraph}]}}
+                          {:type :code, :text "#{3 1 2}"}
+                          {:type :markdown, :doc {:type :doc :content [{:type :heading}]}}
+                          {:type :code, :text "{2 \"bar\" 1 \"foo\"}"},
+                          {:type :code, :text "\"multi
 line\""}]
-                           :title "📶 Sorting",
-                           :footnotes []
-                           :toc {:type :toc,
-                                 :children [{:type :toc :children [{:type :toc}
-                                                                   {:type :toc}]}]}})
+                 :title "📶 Sorting",
+                 :footnotes []
+                 :toc {:type :toc,
+                       :children [{:type :toc :children [{:type :toc}
+                                                         {:type :toc}]}]}}
                 (parser/parse-clojure-string {:doc? true} notebook))))
 
   (testing "reading a bad block shows block and file info in raised exception"

--- a/test/nextjournal/clerk/parser_test.clj
+++ b/test/nextjournal/clerk/parser_test.clj
@@ -202,10 +202,11 @@ par two"))))
   (testing "parsing a Clojure file"
     (is (match?
          {:file "test/nextjournal/clerk/fixtures/hello.clj"
+          :no-cache true
           :blocks [{:type :code}
                    {:type :code
                     :id 'nextjournal.clerk.fixtures.hello/answer}]}
-         (parser/parse-file {:doc? true} "test/nextjournal/clerk/fixtures/hello.clj"))))
+         (parser/parse-file "test/nextjournal/clerk/fixtures/hello.clj"))))
 
   (testing "parsing a markdown file"
     (is (match?

--- a/test/nextjournal/clerk/parser_test.clj
+++ b/test/nextjournal/clerk/parser_test.clj
@@ -202,6 +202,7 @@ par two"))))
   (testing "parsing a Clojure file"
     (is (match?
          {:file "test/nextjournal/clerk/fixtures/hello.clj"
+          :ns (create-ns 'nextjournal.clerk.fixtures.hello)
           :no-cache true
           :blocks [{:type :code}
                    {:type :code
@@ -212,6 +213,7 @@ par two"))))
     (is (match?
          {:file "notebooks/hello.md"
           :ns (create-ns 'hello-markdown)
+          :no-cache true
           :blocks [{:type :markdown}
                    {:type :code}
                    {:type :markdown}

--- a/test/nextjournal/clerk/parser_test.clj
+++ b/test/nextjournal/clerk/parser_test.clj
@@ -163,6 +163,16 @@ par two"))))
     (is (= (parser/text-with-clerk-metadata-removed "^{:un :balanced :map} (do nothing)" clerk-ns-alias)
            "^{:un :balanced :map} (do nothing)"))))
 
+(deftest read-string-tests
+  (testing "read-string should read regex's such that value equalility is preserved"
+    (is (= '(fn [x] (clojure.string/split x (clojure.core/re-pattern "/")))
+           (parser/read-string "(fn [x] (clojure.string/split x #\"/\"))"))))
+
+  (testing "read-string can handle syntax quote"
+    (is (match? '['nextjournal.clerk.parser-test/foo 'nextjournal.clerk.view/foo 'nextjournal.clerk/foo]
+                (binding [*ns* (find-ns 'nextjournal.clerk.parser-test)]
+                  (parser/read-string "[`foo `view/foo `nextjournal.clerk/foo]"))))))
+
 (deftest presenting-a-parsed-document
   (testing "presenting a parsed document doesn't produce garbage"
     (is (match? [{:nextjournal/viewer {:name 'nextjournal.clerk.viewer/cell-viewer}

--- a/test/nextjournal/clerk/parser_test.clj
+++ b/test/nextjournal/clerk/parser_test.clj
@@ -215,7 +215,7 @@ par two"))))
           :ns (create-ns 'hello-markdown)
           :no-cache true
           :blocks [{:type :markdown}
-                   {:type :code}
+                   {:type :code :settings {:nextjournal.clerk/visibility {:code :fold, :result :hide}}}
                    {:type :markdown}
-                   {:type :code}]}
+                   {:type :code :settings {:nextjournal.clerk/visibility {:code :fold, :result :show}}}]}
          (parser/parse-file "notebooks/hello.md")))))

--- a/test/nextjournal/clerk/parser_test.clj
+++ b/test/nextjournal/clerk/parser_test.clj
@@ -205,4 +205,14 @@ par two"))))
           :blocks [{:type :code}
                    {:type :code
                     :id 'nextjournal.clerk.fixtures.hello/answer}]}
-         (parser/parse-file {:doc? true} "test/nextjournal/clerk/fixtures/hello.clj")))))
+         (parser/parse-file {:doc? true} "test/nextjournal/clerk/fixtures/hello.clj"))))
+
+  (testing "parsing a markdown file"
+    (is (match?
+         {:file "notebooks/hello.md"
+          :ns (create-ns 'hello-markdown)
+          :blocks [{:type :markdown}
+                   {:type :code}
+                   {:type :markdown}
+                   {:type :code}]}
+         (parser/parse-file "notebooks/hello.md")))))


### PR DESCRIPTION
Make the parser step independent of the analyzer. This allows us to skip analysis when caching is disabled for the whole namespace.