### PR TITLE
Bump render & dev deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: 🔧 Install java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: '11.0.7'
-          cache: 'maven'
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: 🔧 Install clojure
         uses: DeLaGuardo/setup-clojure@master
@@ -80,9 +80,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: 🔧 Install java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: '11.0.7'
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: 🔧 Install clojure
         uses: DeLaGuardo/setup-clojure@master
@@ -113,9 +114,10 @@ jobs:
           fetch-depth: 0
 
       - name: 🔧 Install java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: '11.0.7'
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: 🔧 Install clojure
         uses: DeLaGuardo/setup-clojure@master
@@ -182,9 +184,10 @@ jobs:
           fetch-depth: 0
 
       - name: 🔧 Install java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: '11.0.7'
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: 🔧 Install clojure
         uses: DeLaGuardo/setup-clojure@master

--- a/deps.edn
+++ b/deps.edn
@@ -37,11 +37,11 @@
 
            :sci {:extra-deps {io.github.nextjournal/clerk.render {:local/root "render"}}}
 
-           :dev {:extra-deps {org.clojure/clojure {:mvn/version "1.12.0-beta1"} ;; for `:as-alias` & `add-lib` support but only in dev
+           :dev {:extra-deps {org.clojure/clojure {:mvn/version "1.12.0"} ;; for `:as-alias` & `add-lib` support but only in dev
                               arrowic/arrowic {:mvn/version "0.1.1"}
                               binaryage/devtools {:mvn/version "1.0.3"}
-                              cider/cider-nrepl {:mvn/version "0.49.3"}
-                              nrepl/nrepl {:mvn/version "1.3.0"}
+                              cider/cider-nrepl {:mvn/version "0.55.7"}
+                              nrepl/nrepl {:mvn/version "1.3.1"}
                               com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.3.0"}
                               io.github.nextjournal/cas-client {:git/sha "d9f838937ebc8b645fe5764949e72a6df8e344de"}
                               org.slf4j/slf4j-nop {:mvn/version "2.0.7"}

--- a/render/deps.edn
+++ b/render/deps.edn
@@ -1,17 +1,15 @@
 {:paths ["."]
- :deps {applied-science/js-interop {:mvn/version "0.3.3"}
-        binaryage/devtools {:mvn/version "1.0.3"}
-        cider/cider-nrepl {:mvn/version "0.28.3"}
-        org.babashka/sci #_{:local/root "../../babashka/sci"}
-        {:git/url "https://github.com/babashka/sci"
-         :git/sha "1e15f0f6a129ef7512351efc65f7475209d8cc4c"}
-        org.clojure/clojurescript {:mvn/version "1.11.132"}
+ :deps {applied-science/js-interop {:mvn/version "0.4.2"}
+        binaryage/devtools {:mvn/version "1.0.7"}
+        cider/cider-nrepl {:mvn/version "0.55.7"}
+        org.babashka/sci {:mvn/version "0.9.45"}
         io.github.babashka/sci.nrepl {:mvn/version "0.0.2"}
-        reagent/reagent {:mvn/version "1.2.0"}
+        reagent/reagent {:mvn/version "1.3.0"}
         io.github.babashka/sci.configs {:git/sha "8253c69a537bcc82e8ff122e5f905fe9d1e303f0"
                                         :exclusions [org.babashka/sci]}
         io.github.nextjournal/clojure-mode {:git/sha "1f55406087814a0dda6806396aa596dbe13ea302"}
-        thheller/shadow-cljs {:mvn/version "2.23.1"}
+        thheller/shadow-cljs {:mvn/version "3.0.4"}
         io.github.squint-cljs/cherry {;; :local/root "/Users/borkdude/dev/cherry"
-                                      :git/sha "ac89d93f136ee8fab91f62949de5b5822ba08b3c"
+                                      :git/sha "8de9f27"
+                                      :git/tag "v0.4.26"
                                       :exclusions [org.babashka/sci]}}}


### PR DESCRIPTION
Latest clojurescript now requires JDK 21+ so bump JDK on CI to 21.