### PR TITLE
Render data from unhandled ex-info exceptions

### DIFF
--- a/src/nextjournal/clerk/render.cljs
+++ b/src/nextjournal/clerk/render.cljs
@@ -479,7 +479,10 @@
       [:div.font-bold.mt-1 (:message unhandled)]
       (when (:data unhandled)
         [:div.mt-1
-         [nextjournal.clerk.render/inspect (:data unhandled)]])]
+         [nextjournal.clerk.render/inspect (:data unhandled)]])
+      (when (ex-data unhandled)
+        [:div.mt-1
+         [nextjournal.clerk.render/inspect (ex-data unhandled)]])]
      (when-let [caused-by (not-empty (rest via))]
        [:div.border-t.border-red-200.text-xs.px-5.py-2.first:border-t-0
         [:div.text-xs.text-red-600.font-bold.hover:underline.cursor-pointer.flex.items-center.gap-2


### PR DESCRIPTION
If something like `(throw (ex-info "message" {:some "data"}))` goes unhandled, it would be useful to be able to see the data in the error message. Currntly that is not visible:
<img width="1038" height="860" alt="Screenshot 2025-12-07 175223" src="https://github.com/user-attachments/assets/335f63cd-e268-4b29-aaa7-f5f303a83d64" />

