### PR TITLE
Bump weavejester/dependency for perf increase

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
         babashka/fs {:mvn/version "0.5.28"}
         org.babashka/http-client {:mvn/version "0.4.23"}
         borkdude/edamame {:mvn/version "1.4.28"}
-        weavejester/dependency {:mvn/version "0.2.1"}
+        weavejester/dependency {:mvn/version "1.0.1"}
         com.nextjournal/beholder {:mvn/version "1.0.3"}
         org.flatland/ordered {:mvn/version "1.15.12"}
         io.github.nextjournal/markdown {:mvn/version "0.7.222"}

--- a/notebooks/cherry.clj
+++ b/notebooks/cherry.clj
@@ -98,7 +98,7 @@
  '(defn emoji-picker
    {:async true}
    []
-   (js/await (js/import "https://cdn.skypack.dev/emoji-picker-element"))
+   (js/await (js/import "https://esm.sh/emoji-picker-element"))
    (nextjournal.clerk.viewer/html [:div
                                    [:p "My cool emoji picker:"]
                                    [:emoji-picker]])))

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -222,8 +222,8 @@
   (testing "The hash of weavejester/dependency is the same across OSes"
     (is (match?
          {:jar
-          #"repository/weavejester/dependency/0.2.1/dependency-0.2.1.jar",
-          :hash "5dsZiMRBpbMfWTafMoHEaNdGfEYxpx"}
+          #"repository/weavejester/dependency/1.0.1/dependency-1.0.1.jar",
+          :hash "5dsNERm1mA4nuRvcSovwvX6HPmieCf"}
          (ana/hash-jar (ana/find-location 'weavejester.dependency/graph)))))
 
   (testing "an edge-case with a particular sorting of the graph nodes"


### PR DESCRIPTION
@mk This should give a significant perf boost for showing `book.clj` compared to the main branch.