### PR TITLE
Fix `build-graph` crash on non-Clojure source files (#531)

### DIFF
--- a/src/nextjournal/clerk/analyzer.clj
+++ b/src/nextjournal/clerk/analyzer.clj
@@ -550,8 +550,11 @@
                                  (let [jar? (or (nil? source)
                                                 (str/ends-with? source ".jar"))
                                        gitlib-hash (and (not jar?)
-                                                        (second (re-find #".gitlibs/libs/.*/(\b[0-9a-f]{5,40}\b)/" (utils/unixify source))))]
-                                   (if (or jar? gitlib-hash)
+                                                        (second (re-find #".gitlibs/libs/.*/(\b[0-9a-f]{5,40}\b)/" (utils/unixify source))))
+                                       clojure-source? (and source
+                                                            (some #(str/ends-with? source %)
+                                                                  [".clj" ".cljc" ".cljs" ".bb"]))]
+                                   (if (or jar? gitlib-hash (not clojure-source?))
                                      (update g :->analysis-info merge (into {} (map (juxt identity
                                                                                           (constantly (if source
                                                                                                         (or (when gitlib-hash {:hash gitlib-hash})

--- a/test/nextjournal/clerk/analyzer_test.clj
+++ b/test/nextjournal/clerk/analyzer_test.clj
@@ -390,7 +390,15 @@ my-uuid")]
       (is (match? {:jar string?} (->analysis-info 'weavejester.dependency/graph)))))
   (testing "should establish dependencies across files"
     (let [{:keys [graph]} (analyze-string (slurp "src/nextjournal/clerk.clj"))]
-      (is (dep/depends? graph 'nextjournal.clerk/show! 'nextjournal.clerk.analyzer/hash)))))
+      (is (dep/depends? graph 'nextjournal.clerk/show! 'nextjournal.clerk.analyzer/hash))))
+  (testing "does not try to parse non-Clojure source files (issue #531)"
+    ;; Mimic libpython-clj: a var whose :file meta points to a Python file.
+    (def issue-531-py-var 1)
+    ;; Absolute path, matching how libpython-clj writes :file meta — also forces
+    ;; `var->location` down its on-disk branch so the bad code path is exercised.
+    (alter-meta! #'issue-531-py-var assoc :file
+                 (str (fs/absolutize (fs/file "test" "nextjournal" "clerk" "fixtures" "issue_531_not_clojure.py"))))
+    (is (analyze-string "(ns consumer) (def use-py (nextjournal.clerk.analyzer-test/issue-531-py-var))"))))
 
 (deftest graph-nodes-with-anonymous-ids
   (testing "nodes with \"anonymous ids\" from dependencies in foreign files respect graph dependencies"

--- a/test/nextjournal/clerk/fixtures/issue_531_not_clojure.py
+++ b/test/nextjournal/clerk/fixtures/issue_531_not_clojure.py
@@ -1,0 +1,6 @@
+import numpy as np
+
+
+class BagObj:
+    def __init__(self, obj):
+        self._obj = obj


### PR DESCRIPTION
Skip `parse-file` for sources that aren't `.clj`/`.cljc`/`.cljs`/`.bb` (e.g. `.py` files from libpython-clj vars); hash them opaquely like jars.

Fixes #531.