### PR TITLE
Fix #770: unwrap var-from-def before applying the viewer

### DIFF
--- a/src/nextjournal/clerk/experimental.clj
+++ b/src/nextjournal/clerk/experimental.clj
@@ -33,8 +33,6 @@
   ([!state] (slider {} !state))
   ([opts !state] (viewer/with-viewer (assoc viewer/render-eval-viewer :render-fn (render-slider opts)) !state)))
 
-(alter-var-root #'slider with-meta {:var-from-def? true})
-
 
 (defn render-text-input
   ([] (render-slider {}))
@@ -50,6 +48,4 @@
 (defn text-input
   ([!state] (text-input {} !state))
   ([opts !state] (viewer/with-viewer (assoc viewer/render-eval-viewer :render-fn (render-text-input opts)) !state)))
-
-(alter-var-root #'text-input with-meta {:var-from-def? true})
 

--- a/src/nextjournal/clerk/experimental.clj
+++ b/src/nextjournal/clerk/experimental.clj
@@ -33,6 +33,8 @@
   ([!state] (slider {} !state))
   ([opts !state] (viewer/with-viewer (assoc viewer/render-eval-viewer :render-fn (render-slider opts)) !state)))
 
+(alter-var-root #'slider with-meta {:var-from-def? true})
+
 
 (defn render-text-input
   ([] (render-slider {}))
@@ -48,4 +50,6 @@
 (defn text-input
   ([!state] (text-input {} !state))
   ([opts !state] (viewer/with-viewer (assoc viewer/render-eval-viewer :render-fn (render-text-input opts)) !state)))
+
+(alter-var-root #'text-input with-meta {:var-from-def? true})
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -429,27 +429,30 @@
 (defn var-from-def? [x]
   (var? (get-safe x :nextjournal.clerk/var-from-def)))
 
+(def unwrap-var-value (some-fn :nextjournal.clerk/var-snapshot
+                               (comp deref :nextjournal.clerk/var-from-def)))
+
 (def var-from-def-viewer
   {:name `var-from-def-viewer
    :pred var-from-def?
-   :transform-fn (update-val (some-fn :nextjournal.clerk/var-snapshot
-                                      (comp deref :nextjournal.clerk/var-from-def)))})
+   :transform-fn (update-val unwrap-var-value)})
 
 (defn apply-viewer-unwrapping-var-from-def
   "Applies the `viewer` (if set) to the given result `result`. In case
-  the `value` is a `var-from-def?` it will be unwrapped unless the
-  viewer opts out with a truthy `:nextjournal.clerk/var-from-def`."
+  the `value` is a `var-from-def?` it will be unwrapped (so that the
+  viewer operates on the def's value) unless the viewer map opts out
+  with a truthy `:var-from-def?`."
   [{:as result :nextjournal/keys [value viewer]}]
   (if viewer
-    (let [value+viewer (if (or (var? viewer) (fn? viewer))
-                         (viewer value)
-                         {:nextjournal/value value
-                          :nextjournal/viewer (normalize-viewer viewer)})
-          {unwrap-var :transform-fn var-from-def? :pred} var-from-def-viewer]
-      (assoc result :nextjournal/value (cond-> value+viewer
-                                         (and (var-from-def? value)
-                                              (-> value+viewer ->viewer :var-from-def? not))
-                                         unwrap-var)))
+    (let [opts-out? (and (map? viewer) (:var-from-def? viewer))
+          value' (cond-> value
+                   (and (var-from-def? value) (not opts-out?))
+                   unwrap-var-value)
+          value+viewer (if (or (var? viewer) (fn? viewer))
+                         (viewer value')
+                         {:nextjournal/value value'
+                          :nextjournal/viewer (normalize-viewer viewer)})]
+      (assoc result :nextjournal/value value+viewer))
     result))
 
 #?(:clj

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -438,13 +438,15 @@
    :transform-fn (update-val unwrap-var-value)})
 
 (defn apply-viewer-unwrapping-var-from-def
-  "Applies the `viewer` (if set) to the given result `result`. In case
-  the `value` is a `var-from-def?` it will be unwrapped (so that the
-  viewer operates on the def's value) unless the viewer map opts out
-  with a truthy `:var-from-def?`."
+  "Applies the `viewer` (if set) to the given result `result`. By default
+  the `value` of a `var-from-def?` is unwrapped so that the viewer
+  operates on the def's value. To opt out, a viewer map must carry
+  `:var-from-def? true`, or a viewer fn must have `:var-from-def? true`
+  in its metadata (use `with-meta` / `alter-var-root`)."
   [{:as result :nextjournal/keys [value viewer]}]
   (if viewer
-    (let [opts-out? (and (map? viewer) (:var-from-def? viewer))
+    (let [opts-out? (or (and (map? viewer) (:var-from-def? viewer))
+                        (and (ifn? viewer) (:var-from-def? (meta viewer))))
           value' (cond-> value
                    (and (var-from-def? value) (not opts-out?))
                    unwrap-var-value)

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -440,20 +440,34 @@
 (defn apply-viewer-unwrapping-var-from-def
   "Applies the `viewer` (if set) to the given result `result`. By default
   the `value` of a `var-from-def?` is unwrapped so that the viewer
-  operates on the def's value. To opt out, a viewer map must carry
-  `:var-from-def? true`, or a viewer fn must have `:var-from-def? true`
-  in its metadata (use `with-meta` / `alter-var-root`)."
+  operates on the def's value. A viewer can opt out by setting
+  `:var-from-def? true` — on a viewer map directly, or on the viewer
+  map that a fn viewer returns (the fn will be called a second time
+  with the raw `var-from-def?` value in that case)."
   [{:as result :nextjournal/keys [value viewer]}]
   (if viewer
-    (let [opts-out? (or (and (map? viewer) (:var-from-def? viewer))
-                        (and (ifn? viewer) (:var-from-def? (meta viewer))))
-          value' (cond-> value
-                   (and (var-from-def? value) (not opts-out?))
-                   unwrap-var-value)
-          value+viewer (if (or (var? viewer) (fn? viewer))
-                         (viewer value')
-                         {:nextjournal/value value'
-                          :nextjournal/viewer (normalize-viewer viewer)})]
+    (let [fn-viewer? (or (var? viewer) (fn? viewer))
+          is-var? (var-from-def? value)
+          map-opts-out? (and (map? viewer) (:var-from-def? viewer))
+          apply-vw (fn [v]
+                     (if fn-viewer?
+                       (viewer v)
+                       {:nextjournal/value v
+                        :nextjournal/viewer (normalize-viewer viewer)}))
+          first-try (apply-vw (cond-> value
+                                (and is-var? fn-viewer? (not map-opts-out?))
+                                unwrap-var-value))
+          return-opts-out? (boolean (-> first-try ->viewer :var-from-def?))
+          value+viewer (cond
+                         ;; map viewer w/ var-from-def, no opt-out → unwrap
+                         (and is-var? (not fn-viewer?) (not map-opts-out?))
+                         (update first-try :nextjournal/value unwrap-var-value)
+
+                         ;; fn viewer whose return opts out → re-run with raw wrapper
+                         (and is-var? fn-viewer? return-opts-out?)
+                         (apply-vw value)
+
+                         :else first-try)]
       (assoc result :nextjournal/value value+viewer))
     result))
 

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -448,23 +448,23 @@
   (if viewer
     (let [fn-viewer? (or (var? viewer) (fn? viewer))
           is-var? (var-from-def? value)
-          map-opts-out? (and (map? viewer) (:var-from-def? viewer))
+          keep-wrapped? (and (map? viewer) (:var-from-def? viewer))
           apply-vw (fn [v]
                      (if fn-viewer?
                        (viewer v)
                        {:nextjournal/value v
                         :nextjournal/viewer (normalize-viewer viewer)}))
           first-try (apply-vw (cond-> value
-                                (and is-var? fn-viewer? (not map-opts-out?))
+                                (and is-var? fn-viewer? (not keep-wrapped?))
                                 unwrap-var-value))
-          return-opts-out? (boolean (-> first-try ->viewer :var-from-def?))
+          return-keep-wrapped? (boolean (-> first-try ->viewer :var-from-def?))
           value+viewer (cond
                          ;; map viewer w/ var-from-def, no opt-out → unwrap
-                         (and is-var? (not fn-viewer?) (not map-opts-out?))
+                         (and is-var? (not fn-viewer?) (not keep-wrapped?))
                          (update first-try :nextjournal/value unwrap-var-value)
 
                          ;; fn viewer whose return opts out → re-run with raw wrapper
-                         (and is-var? fn-viewer? return-opts-out?)
+                         (and is-var? fn-viewer? return-keep-wrapped?)
                          (apply-vw value)
 
                          :else first-try)]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -440,10 +440,10 @@
 (defn apply-viewer-unwrapping-var-from-def
   "Applies the `viewer` (if set) to the given result `result`. By default
   the `value` of a `var-from-def?` is unwrapped so that the viewer
-  operates on the def's value. A viewer can opt out by setting
-  `:var-from-def? true` — on a viewer map directly, or on the viewer
-  map that a fn viewer returns (the fn will be called a second time
-  with the raw `var-from-def?` value in that case)."
+  operates on the def's value. A viewer that wants the raw wrapper
+  sets `:var-from-def? true` — on the viewer map directly, or on the
+  viewer map that a fn viewer returns (the fn will be called a second
+  time with the raw `var-from-def?` value in that case)."
   [{:as result :nextjournal/keys [value viewer]}]
   (if viewer
     (let [fn-viewer? (or (var? viewer) (fn? viewer))
@@ -459,11 +459,11 @@
                                 unwrap-var-value))
           return-keep-wrapped? (boolean (-> first-try ->viewer :var-from-def?))
           value+viewer (cond
-                         ;; map viewer w/ var-from-def, no opt-out → unwrap
+                         ;; map viewer that doesn't want the wrapper -> unwrap
                          (and is-var? (not fn-viewer?) (not keep-wrapped?))
                          (update first-try :nextjournal/value unwrap-var-value)
 
-                         ;; fn viewer whose return opts out → re-run with raw wrapper
+                         ;; fn viewer returned a viewer that wants the wrapper -> re-run with it
                          (and is-var? fn-viewer? return-keep-wrapped?)
                          (apply-vw value)
 

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -240,9 +240,8 @@
                                                  :nextjournal.clerk/var-snapshot [1 2 3]}
                              :nextjournal/viewer v/row}))))
 
-  (testing "function viewer tagged with `:var-from-def? true` metadata receives the raw var-from-def (e.g. cx/slider)"
-    (let [viewer-fn (with-meta (fn [v] (v/with-viewer v/html-viewer v))
-                               {:var-from-def? true})]
+  (testing "function viewer whose returned viewer opts out keeps the raw var-from-def (e.g. cx/slider via render-eval-viewer)"
+    (let [viewer-fn (fn [v] (v/with-viewer (assoc v/html-viewer :var-from-def? true) v))]
       (is (= {:nextjournal.clerk/var-from-def #'my-test-var
               :nextjournal.clerk/var-snapshot [:h1 "hi"]}
              (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -238,7 +238,16 @@
     (is (= [1 2 3]
            (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var
                                                  :nextjournal.clerk/var-snapshot [1 2 3]}
-                             :nextjournal/viewer v/row})))))
+                             :nextjournal/viewer v/row}))))
+
+  (testing "function viewer tagged with `:var-from-def? true` metadata receives the raw var-from-def (e.g. cx/slider)"
+    (let [viewer-fn (with-meta (fn [v] (v/with-viewer v/html-viewer v))
+                               {:var-from-def? true})]
+      (is (= {:nextjournal.clerk/var-from-def #'my-test-var
+              :nextjournal.clerk/var-snapshot [:h1 "hi"]}
+             (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var
+                                                   :nextjournal.clerk/var-snapshot [:h1 "hi"]}
+                               :nextjournal/viewer viewer-fn}))))))
 
 
 (deftest resolve-aliases

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -212,19 +212,33 @@
     (is (= [{:render-fn 'foo}] (v/get-viewers 'nextjournal.clerk.viewer-test.random-ns-name)))))
 
 (def my-test-var [:h1 "hi"])
+(def my-test-var2 1)
+
+(def apply+get-value #(-> % v/apply-viewer-unwrapping-var-from-def :nextjournal/value :nextjournal/value))
 
 (deftest apply-viewer-unwrapping-var-from-def
-  (let [apply+get-value #(-> % v/apply-viewer-unwrapping-var-from-def :nextjournal/value :nextjournal/value)]
-    (testing "unwraps var when viewer doens't opt out"
-      (is (= my-test-var
-             (apply+get-value {:nextjournal/value [:h1 "hi"]                                      :nextjournal/viewer v/html})
-             (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var} :nextjournal/viewer v/html})
-             (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var} :nextjournal/viewer v/html-viewer}))))
+  (testing "unwraps var when viewer doens't opt out"
+    (is (= my-test-var
+           (apply+get-value {:nextjournal/value [:h1 "hi"]                                      :nextjournal/viewer v/html})
+           (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var} :nextjournal/viewer v/html})
+           (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var} :nextjournal/viewer v/html-viewer}))))
 
-    (testing "leaves var wrapped when viewer opts out"
-      (is (= {:nextjournal.clerk/var-from-def #'my-test-var}
-             (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var}
-                               :nextjournal/viewer (assoc v/html-viewer :var-from-def? true)}))))))
+  (testing "leaves var wrapped when viewer opts out"
+    (is (= {:nextjournal.clerk/var-from-def #'my-test-var}
+           (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var}
+                             :nextjournal/viewer (assoc v/html-viewer :var-from-def? true)}))))
+
+  (testing "function viewer receives the deref'd value, not the var-from-def wrapper (fixes #770)"
+    (is (= [my-test-var2]
+           (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var2
+                                                 :nextjournal.clerk/var-snapshot my-test-var2}
+                             :nextjournal/viewer v/row}))))
+
+  (testing "function viewer on a seq-valued def spreads across row cells"
+    (is (= [1 2 3]
+           (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var
+                                                 :nextjournal.clerk/var-snapshot [1 2 3]}
+                             :nextjournal/viewer v/row})))))
 
 
 (deftest resolve-aliases


### PR DESCRIPTION
When a `def` has an explicit viewer like `^{::clerk/viewer clerk/row}`, the viewer should see the def's value, not the internal `{:var-from-def ... :var-snapshot ...}` map Clerk adds around it. Before, that map was passed to function viewers, which either crashed (#770) or rendered the raw map. Now the value is unwrapped first, unless the viewer opts out with `:var-from-def? true` (as `render-eval-viewer` does).