### PR TITLE
Fix #770 by moving var outside of value

### DIFF
--- a/book.clj
+++ b/book.clj
@@ -477,9 +477,13 @@ int main() {
    {:temperature 29.0 :date (java.time.LocalDate/parse "2022-08-01")}])
 
 ;; As you can see above, the table viewer is being applied to the
-;; value of the `my-dataset` var, not the var itself. If you want your viewer to access the raw var, you can opt out of this with a truthy `:var-from-def?` key on the viewer.
+;; value of the `my-dataset` var, not the var itself. If your viewer
+;; needs to know which var produced the value (e.g. for reactive atoms
+;; or source linking), the wrapped value's
+;; `:nextjournal.clerk/var-from-def` sidecar carries the var reference,
+;; which your `:transform-fn` can read.
 
-^{::clerk/viewer (assoc v/fallback-viewer :var-from-def? true)}
+^{::clerk/viewer v/fallback-viewer}
 (def raw-var :baz)
 
 

--- a/src/nextjournal/clerk/eval.clj
+++ b/src/nextjournal/clerk/eval.clj
@@ -74,17 +74,10 @@
      {:result ret#
       :time-ms (elapsed-ms start#)}))
 
-(defn ^:private var-from-def [var]
-  (let [resolved-var (cond (var? var)
-                           var
-
-                           (symbol? var)
-                           (find-var var)
-
-                           :else
-                           (throw (ex-info "Unable to resolve into a variable" {:data var})))]
-    {:nextjournal.clerk/var-from-def resolved-var
-     :nextjournal.clerk/var-snapshot @resolved-var}))
+(defn ^:private resolve-var [var]
+  (cond (var? var) var
+        (symbol? var) (find-var var)
+        :else (throw (ex-info "Unable to resolve into a variable" {:data var}))))
 
 (defn ^:private lookup-cached-result [introduced-var hash cas-hash]
   (when-let [cached-value (try (thaw-from-cas cas-hash)
@@ -92,12 +85,12 @@
                                  ;; TODO better report this error, anything that can't be read shouldn't be cached in the first place
                                  #_(prn :thaw-error e)
                                  nil))]
-    (wrapped-with-metadata (if introduced-var
-                             (var-from-def (intern (-> introduced-var namespace symbol)
-                                                   (-> introduced-var name symbol)
-                                                   cached-value))
-                             cached-value)
-                           hash)))
+    (cond-> (wrapped-with-metadata cached-value hash)
+      introduced-var
+      (assoc :nextjournal.clerk/var-from-def
+             (resolve-var (intern (-> introduced-var namespace symbol)
+                                  (-> introduced-var name symbol)
+                                  cached-value))))))
 
 
 (defn cachable? [value]
@@ -158,10 +151,11 @@
       (let [blob-id (cond no-cache? (analyzer/->hash-str var-value)
                           (fn? var-value) nil
                           :else hash)
-            result (if var-from-def?
-                     (var-from-def var)
-                     result)]
-        (cond-> (wrapped-with-metadata result blob-id)
+            wrapped-value (if var-from-def?
+                            (-> (wrapped-with-metadata var-value blob-id)
+                                (assoc :nextjournal.clerk/var-from-def (resolve-var var)))
+                            (wrapped-with-metadata result blob-id))]
+        (cond-> wrapped-value
           (seq @!interned-vars)
           (assoc :nextjournal/interned @!interned-vars))))
     (catch Throwable t

--- a/src/nextjournal/clerk/render/editor.cljs
+++ b/src/nextjournal/clerk/render/editor.cljs
@@ -144,9 +144,8 @@
   (update doc :blocks (partial map (fn [{:as cell :keys [type text var form]}]
                                      (cond-> cell
                                        (= :code type)
-                                       (assoc :result {:nextjournal/value
-                                                       (cond->> (eval-string text)
-                                                         var (hash-map :nextjournal.clerk/var-from-def))}))))))
+                                       (assoc :result (cond-> {:nextjournal/value (eval-string text)}
+                                                        var (assoc :nextjournal.clerk/var-from-def var))))))))
 
 (defn eval-notebook [code]
   (->> code

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -1368,7 +1368,7 @@
                                   (cond (render-eval? x) x
                                         (seq? x) (->render-eval x)
                                         (symbol? x) (->render-eval x)
-                                        v (->render-eval (list 'resolve (list 'quote (symbol v))))
+                                        v (->render-eval (symbol v))
                                         (var? x) (->render-eval (list 'resolve (list 'quote (symbol x))))
                                         :else x)))))
    :render-fn '(fn [x opts]

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -426,30 +426,20 @@
   (or (clojure.core/var? x)
       #?(:cljs (instance? sci.lang.Var x))))
 
-(defn var-from-def? [x]
-  (var? (get-safe x :nextjournal.clerk/var-from-def)))
-
-(def var-from-def-viewer
-  {:name `var-from-def-viewer
-   :pred var-from-def?
-   :transform-fn (update-val (some-fn :nextjournal.clerk/var-snapshot
-                                      (comp deref :nextjournal.clerk/var-from-def)))})
-
-(defn apply-viewer-unwrapping-var-from-def
-  "Applies the `viewer` (if set) to the given result `result`. In case
-  the `value` is a `var-from-def?` it will be unwrapped unless the
-  viewer opts out with a truthy `:nextjournal.clerk/var-from-def`."
+(defn apply-viewer-to-result
+  "Applies the `viewer` (if set) to `result`. The value is passed through
+  unchanged; provenance (the `:nextjournal.clerk/var-from-def` sidecar)
+  is preserved on the new wrapped value so downstream viewers like
+  `render-eval-viewer` can read it."
   [{:as result :nextjournal/keys [value viewer]}]
   (if viewer
-    (let [value+viewer (if (or (var? viewer) (fn? viewer))
+    (let [sidecar (when-let [v (:nextjournal.clerk/var-from-def result)]
+                    {:nextjournal.clerk/var-from-def v})
+          value+viewer (if (or (var? viewer) (fn? viewer))
                          (viewer value)
                          {:nextjournal/value value
-                          :nextjournal/viewer (normalize-viewer viewer)})
-          {unwrap-var :transform-fn var-from-def? :pred} var-from-def-viewer]
-      (assoc result :nextjournal/value (cond-> value+viewer
-                                         (and (var-from-def? value)
-                                              (-> value+viewer ->viewer :var-from-def? not))
-                                         unwrap-var)))
+                          :nextjournal/viewer (normalize-viewer viewer)})]
+      (assoc result :nextjournal/value (merge value+viewer sidecar)))
     result))
 
 #?(:clj
@@ -652,10 +642,13 @@
     {:nextjournal/render-opts (-> cell (select-keys [:loc]) (assoc :id (processed-block-id (str id "-code"))))}
     (dissoc cell ::doc :result)))
 
-(defn maybe-wrap-var-from-def [val form]
-  (cond->> val
-    (and (var? val) (parser/deflike? form))
-    (hash-map :nextjournal.clerk/var-from-def)))
+(defn ^:private promote-var-from-def [{:as cell :keys [result]} form]
+  (let [val (:nextjournal/value result)]
+    (if (and (var? val) (parser/deflike? form))
+      (-> cell
+          (assoc-in [:result :nextjournal/value] @val)
+          (assoc-in [:result :nextjournal.clerk/var-from-def] val))
+      cell)))
 
 (defn fragment-seq
   ([cell] (fragment-seq (:form cell) cell))
@@ -668,11 +661,11 @@
                     (assoc ::fragment-item? true)
                     (assoc-in [:result :nextjournal/value] r))))
              fragment (range (count fragment)))
-     (list (update-in cell [:result :nextjournal/value] maybe-wrap-var-from-def form)))))
+     (list (promote-var-from-def cell form)))))
 
 (defn cell->result-viewer [cell]
   (-> cell
-      (update-if :result apply-viewer-unwrapping-var-from-def)
+      (update-if :result apply-viewer-to-result)
       fragment-seq
       (->> (mapv (partial with-viewer
                           (cond-> result-viewer
@@ -1234,7 +1227,7 @@
 (defn extract-sync-atom-vars [{:as _doc :keys [blocks]}]
   (into #{}
         (keep (fn [{:keys [result form]}]
-                (when-let [var (-> result :nextjournal/value (get-safe :nextjournal.clerk/var-from-def))]
+                (when-let [var (:nextjournal.clerk/var-from-def result)]
                   (when (contains? (meta form) :nextjournal.clerk/sync)
                     #?(:clj (throw-if-sync-var-is-invalid var))
                     var))))
@@ -1367,15 +1360,17 @@
 (def render-eval-viewer
   {:name `render-eval-viewer
    :pred render-eval?
-   :var-from-def? true
    :transform-fn (comp mark-presented
-                       (update-val
-                        (fn [x]
-                          (cond (render-eval? x) x
-                                (seq? x) (->render-eval x)
-                                (symbol? x) (->render-eval x)
-                                (var? x) (->render-eval (list 'resolve (list 'quote (symbol x))))
-                                (var-from-def? x) (recur (-> x :nextjournal.clerk/var-from-def symbol))))))
+                       (fn [wrapped-value]
+                         (let [x (:nextjournal/value wrapped-value)
+                               v (:nextjournal.clerk/var-from-def wrapped-value)]
+                           (assoc wrapped-value :nextjournal/value
+                                  (cond (render-eval? x) x
+                                        (seq? x) (->render-eval x)
+                                        (symbol? x) (->render-eval x)
+                                        v (->render-eval (list 'resolve (list 'quote (symbol v))))
+                                        (var? x) (->render-eval (list 'resolve (list 'quote (symbol x))))
+                                        :else x)))))
    :render-fn '(fn [x opts]
                  (if (nextjournal.clerk.render/reagent-atom? x)
                    ;; special atoms handling to support reactivity
@@ -1402,7 +1397,6 @@
    nil-viewer
    boolean-viewer
    map-entry-viewer
-   var-from-def-viewer
    read+inspect-viewer
    vector-viewer
    set-viewer
@@ -2036,7 +2030,6 @@
                                                                    (nextjournal.clerk.render/inspect-presented opts form)]
                                                                   [:div.pt-2.px-4.border-l-2.border-transparent
                                                                    (nextjournal.clerk.render/inspect-presented opts val)]])})
-                       (update-in [:nextjournal/value :val] maybe-wrap-var-from-def (get-in wrapped-value [:nextjournal/value :form]))
                        (update-in [:nextjournal/value :form] code)))})
 
 (def examples-viewer

--- a/src/nextjournal/clerk/viewer.cljc
+++ b/src/nextjournal/clerk/viewer.cljc
@@ -433,13 +433,12 @@
   `render-eval-viewer` can read it."
   [{:as result :nextjournal/keys [value viewer]}]
   (if viewer
-    (let [sidecar (when-let [v (:nextjournal.clerk/var-from-def result)]
-                    {:nextjournal.clerk/var-from-def v})
-          value+viewer (if (or (var? viewer) (fn? viewer))
+    (let [value+viewer (if (or (var? viewer) (fn? viewer))
                          (viewer value)
                          {:nextjournal/value value
                           :nextjournal/viewer (normalize-viewer viewer)})]
-      (assoc result :nextjournal/value (merge value+viewer sidecar)))
+      (assoc result :nextjournal/value
+             (merge value+viewer (select-keys result [:nextjournal.clerk/var-from-def]))))
     result))
 
 #?(:clj

--- a/test/nextjournal/clerk/eval_test.clj
+++ b/test/nextjournal/clerk/eval_test.clj
@@ -53,7 +53,8 @@
       (let [{:keys [blocks]} (eval/eval-string "(ns ^:nextjournal.clerk/no-cache my-test-ns) (def some-var 99)")]
         (is (match? [map?
                      {:type :code,
-                      :result {:nextjournal/value {:nextjournal.clerk/var-from-def var?}}}]
+                      :result {:nextjournal/value 99
+                               :nextjournal.clerk/var-from-def var?}}]
                     blocks))
         (is (= 99 @(find-var 'my-test-ns/some-var))))))
 
@@ -74,7 +75,7 @@
 
   (testing "var gets cached in cas"
     (let [code-str (format "(ns nextjournal.clerk.eval-test-%s) (def my-uuid (java.util.UUID/randomUUID))" (rand-int 100000))
-          get-uuid #(-> % :blocks peek :result :nextjournal/value :nextjournal.clerk/var-from-def deref)]
+          get-uuid #(-> % :blocks peek :result :nextjournal/value)]
       (is (= (get-uuid (eval/eval-string code-str))
              (get-uuid (eval/eval-string code-str))))))
 
@@ -109,7 +110,7 @@
 
   (testing "defonce returns correct result on subsequent evals (when defonce would eval to nil)"
     (eval/eval-string "(ns ^:nextjournal.clerk/no-cache my-defonce-test-ns) (defonce state (atom {}))")
-    (is (match? {:blocks [map? {:result {:nextjournal/value {:nextjournal.clerk/var-from-def var?}}}]}
+    (is (match? {:blocks [map? {:result {:nextjournal.clerk/var-from-def var?}}]}
                 (eval/eval-string "(ns ^:nextjournal.clerk/no-cache my-defonce-test-ns) (defonce state (atom {}))"))))
 
   (testing "assigning viewers from form meta"
@@ -119,7 +120,7 @@
                 (eval/eval-string "^{:nextjournal.clerk/viewer 'nextjournal.clerk.viewer/html} (def markup [:h1 \"hi\"])"))))
 
   (testing "var result that's not from a def should stay untouched"
-    (is (match? {:blocks [{:result {:nextjournal/value {:nextjournal.clerk/var-from-def var?}}}
+    (is (match? {:blocks [{:result {:nextjournal.clerk/var-from-def var?}}
                           {:result {:nextjournal/value var?}}]}
                 (eval/eval-string "(def foo :bar) (var foo)"))))
 
@@ -338,7 +339,7 @@
 (def x 1)"
                            (not cache?)))]
     (doseq [cache? [true false]]
-      (is (match? {:nextjournal.clerk/var-from-def var?
-                   :nextjournal.clerk/var-snapshot 1}
+      (is (match? {:nextjournal/value 1
+                   :nextjournal.clerk/var-from-def var?}
                   (-> (eval/eval-string (notebook cache?))
-                      :blocks last :result :nextjournal/value))))))
+                      :blocks last :result))))))

--- a/test/nextjournal/clerk/viewer_test.clj
+++ b/test/nextjournal/clerk/viewer_test.clj
@@ -213,18 +213,32 @@
 
 (def my-test-var [:h1 "hi"])
 
-(deftest apply-viewer-unwrapping-var-from-def
-  (let [apply+get-value #(-> % v/apply-viewer-unwrapping-var-from-def :nextjournal/value :nextjournal/value)]
-    (testing "unwraps var when viewer doens't opt out"
-      (is (= my-test-var
-             (apply+get-value {:nextjournal/value [:h1 "hi"]                                      :nextjournal/viewer v/html})
-             (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var} :nextjournal/viewer v/html})
-             (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var} :nextjournal/viewer v/html-viewer}))))
+(deftest apply-viewer-to-result
+  (let [apply+get-value #(-> % v/apply-viewer-to-result :nextjournal/value :nextjournal/value)]
+    (testing "viewer receives the value directly (no var-from-def wrapper)"
+      (is (= [:h1 "hi"]
+             (apply+get-value {:nextjournal/value [:h1 "hi"] :nextjournal/viewer v/html})
+             (apply+get-value {:nextjournal/value [:h1 "hi"]
+                               :nextjournal.clerk/var-from-def #'my-test-var
+                               :nextjournal/viewer v/html})
+             (apply+get-value {:nextjournal/value [:h1 "hi"]
+                               :nextjournal.clerk/var-from-def #'my-test-var
+                               :nextjournal/viewer v/html-viewer}))))
 
-    (testing "leaves var wrapped when viewer opts out"
-      (is (= {:nextjournal.clerk/var-from-def #'my-test-var}
-             (apply+get-value {:nextjournal/value {:nextjournal.clerk/var-from-def #'my-test-var}
-                               :nextjournal/viewer (assoc v/html-viewer :var-from-def? true)}))))))
+    (testing "provenance (`:var-from-def` sidecar) is copied onto the returned wrapped value"
+      (is (= #'my-test-var
+             (-> {:nextjournal/value [:h1 "hi"]
+                  :nextjournal.clerk/var-from-def #'my-test-var
+                  :nextjournal/viewer v/html}
+                 v/apply-viewer-to-result
+                 :nextjournal/value
+                 :nextjournal.clerk/var-from-def))))
+
+    (testing "function viewer receives raw value (e.g. clerk/row on a def produces 3 cells)"
+      (is (= [1 2 3]
+             (apply+get-value {:nextjournal/value [1 2 3]
+                               :nextjournal.clerk/var-from-def #'my-test-var
+                               :nextjournal/viewer v/row}))))))
 
 
 (deftest resolve-aliases


### PR DESCRIPTION
Previously the result of a `(def foo v)` was stored as
`{:var-from-def #'foo :var-snapshot v}` inside `:nextjournal/value`.
Viewers that saw this map had to either opt out via `:var-from-def?`
or tolerate being handed a metadata wrapper instead of the value.
This caused https://github.com/nextjournal/clerk/issues/770 (crash on `clerk/row` + def) and produced confusing
output when viewer fns like `clerk/row`/`col` ran on defs.

Now the value itself goes in `:nextjournal/value` and the var
reference goes in `:nextjournal.clerk/var-from-def` on the wrapped
value. `apply-viewer-to-result` copies the sidecar forward, and
`render-eval-viewer`'s `:transform-fn` reads it for SCI resolution.
Removes `var-from-def?`, `var-from-def-viewer`,
`maybe-wrap-var-from-def`, and the `:var-from-def?` opt-out flag.