### PR TITLE
Fix SSR builds on Windows

### DIFF
--- a/src/nextjournal/clerk/builder.clj
+++ b/src/nextjournal/clerk/builder.clj
@@ -187,6 +187,12 @@
       tmp)
     url))
 
+(defn- fix-path-for-esm-loader
+  [s]
+  (if (fs/windows?)
+    (str "file:///" (str/escape s {\\ "/"}))
+    s))
+
 (defn- node-ssr!
   [{:keys [viewer-js state]
     :or {viewer-js
@@ -197,7 +203,7 @@
         [viewer-js katex-js] [(local-js viewer-js tmp-dir)
                               (when katex?
                                 (local-js (str/replace viewer-js "viewer.js" "katex.js") tmp-dir))]
-        in (str "import '" viewer-js "';"
+        in (str "import '" (fix-path-for-esm-loader viewer-js) "';"
                 (when katex?
                   (format (str "import * as katex from \"%s\";"
                                "globalThis.clerk$katex = katex;")


### PR DESCRIPTION

This change fixes builds with :ssr true on Windows by adding the `file://` prefix to the viewer js import path and replacing backslashes with forward slashes.

On Windows the error I was getting with node-v22.22.3-x64 looked like

```
? Clerk is building 1 notebooks?
? Parsing? Done in 30.332ms. ?
? Analyzing? Done in 4.943ms. ?
? Building "readme.md"? Done in 17.597ms. ?
? Server Side Rendering? node:internal/modules/esm/load:199
    throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(parsed, schemes);
          ^

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:199:11)
    at defaultLoadSync (node:internal/modules/esm/load:146:3)
    at ModuleLoader.load (node:internal/modules/esm/loader:831:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:609:31)
    at #createModuleJob (node:internal/modules/esm/loader:640:36)
    at #getJobFromResolveResult (node:internal/modules/esm/loader:353:34)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:321:41)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5) {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
}

Node.js v22.22.3
----- Native stack trace -----

 1: 00007FF7EF623A37 node::SetCppgcReference+21127
 2: 00007FF7EF585E26 node::OnFatalError+8550
 3: 00007FF7F01AD738 v8::PropertyDescriptor::writable+80344
 4: 00007FF7F01AB9F2 v8::PropertyDescriptor::writable+72850
 5: 00007FF7F01EB313 v8::PropertyDescriptor::writable+333235
 6: 00007FF7F02CBB0C v8::PropertyDescriptor::writable+1252780
 7: 00007FF7F01DB363 v8::PropertyDescriptor::writable+267779
 8: 00007FF7F01A94EB v8::PropertyDescriptor::writable+63371
 9: 00007FF7F00616F4 v8::Isolate::NumberOfHeapSpaces+2564
10: 00007FF7F00617CB v8::Isolate::NumberOfHeapSpaces+2779
11: 00007FF7F00623F4 v8::Isolate::NumberOfHeapSpaces+5892
12: 00007FF7F0039446 v8::base::CPU::has_sse41+1574
13: 00007FF7F0039160 v8::base::CPU::has_sse41+832
14: 00007FF7F01AD738 v8::PropertyDescriptor::writable+80344
15: 00007FF7703C873E

----- JavaScript stack trace -----

1: asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:123:5)
2: processTicksAndRejections (node:internal/process/task_queues:103:5)


Execution error (ExceptionInfo) at nextjournal.clerk.builder/ssr! (builder.clj:237).
Clerk ssr! failed
```
