### PR TITLE
Upgrade SCI + cherry + cherry notebook fixes

### DIFF
--- a/notebooks/cherry.clj
+++ b/notebooks/cherry.clj
@@ -117,6 +117,27 @@
       (emoji-picker)])
   nil)
 
+;; Async also works with `:sci`. Return hiccup instead of calling
+;; `nextjournal.clerk.viewer/html`, which for `:sci` returns a React element
+;; once the promise has resolved, and mount it with the render hooks.
+
+(clerk/eval-cljs
+ {:nextjournal.clerk/render-evaluator :sci}
+ '(defn emoji-picker-sci
+   {:async true}
+   []
+   (await (js/import "https://esm.sh/emoji-picker-element"))
+   [:div [:p "My other emoji picker:"] [:emoji-picker]]))
+
+(clerk/with-viewer
+  '(fn [_]
+     (let [!picker (nextjournal.clerk.render.hooks/use-state nil)]
+       (nextjournal.clerk.render.hooks/use-effect
+        (fn [] (.then (emoji-picker-sci) (fn [hiccup] (reset! !picker hiccup)))))
+       (or @!picker [:span "Loading..."])))
+  {:nextjournal.clerk/render-evaluator :sci}
+  nil)
+
 ;; ## 🧩 Macros
 
 (clerk/eval-cljs

--- a/notebooks/cherry.clj
+++ b/notebooks/cherry.clj
@@ -10,24 +10,28 @@
 #_(clerk/serve! {:port 7777})
 
 ;; Since we set `:nextjournal.clerk/render-evaluator :cherry` on the ns meta, evaluation happens through cherry by default
-;; in all codeblocks below. As a test for checking that Cherry is actually being picked up, we drop some `this-as` expressions
-;; in the code, since that will throw an exceptions when evaluated by SCI.
+;; in all codeblocks below.
 
 (clerk/with-viewer
   '(fn [value]
-     [:pre (time (do (dotimes [_ 100000]
-                       (js/Math.sin 100))
-                     (pr-str (interleave (cycle [1]) (frequencies [1 2 3 1 2 3])))))])
+     (let [result (atom nil)
+           out (with-out-str
+                 (reset! result (time (do (dotimes [_ 100000]
+                                            (js/Math.sin 100))
+                                          (pr-str (interleave (cycle [1]) (frequencies [1 2 3 1 2 3])))))))]
+       [:pre "SCI: " out @result]))
   {:nextjournal.clerk/render-evaluator :sci} nil)
 
 ;; ## ⏱️ Better performance:
 
 (clerk/with-viewer
   '(fn [value]
-     [:pre
-      (time (do (dotimes [_ 100000]
-                  (js/Math.sin 100))
-                (pr-str (interleave (cycle [1]) (frequencies [1 2 3 1 2 3])))))]) nil)
+     (let [result (atom nil)
+           out (with-out-str
+                 (reset! result (time (do (dotimes [_ 100000]
+                                            (js/Math.sin 100))
+                                          (pr-str (interleave (cycle [1]) (frequencies [1 2 3 1 2 3])))))))]
+       [:pre "cherry: " out @result])) nil)
 
 (clerk/with-viewer
   {:render-fn
@@ -98,7 +102,7 @@
  '(defn emoji-picker
    {:async true}
    []
-   (js/await (js/import "https://esm.sh/emoji-picker-element"))
+   (await (js/import "https://esm.sh/emoji-picker-element"))
    (nextjournal.clerk.viewer/html [:div
                                    [:p "My cool emoji picker:"]
                                    [:emoji-picker]])))

--- a/notebooks/cherry.clj
+++ b/notebooks/cherry.clj
@@ -16,10 +16,11 @@
   '(fn [value]
      (let [result (atom nil)
            out (with-out-str
-                 (reset! result (time (do (dotimes [_ 100000]
-                                            (js/Math.sin 100))
-                                          (pr-str (interleave (cycle [1]) (frequencies [1 2 3 1 2 3])))))))]
-       [:pre "SCI: " out @result]))
+                 (reset! result (time (do (loop [i 0 acc 0.0]
+                                            (if (< i 8000000)
+                                              (recur (inc i) (+ acc (js/Math.sin i)))
+                                              acc))))))]
+       [:pre "SCI: " (.trim out) "\n" @result]))
   {:nextjournal.clerk/render-evaluator :sci} nil)
 
 ;; ## ⏱️ Better performance:
@@ -28,10 +29,11 @@
   '(fn [value]
      (let [result (atom nil)
            out (with-out-str
-                 (reset! result (time (do (dotimes [_ 100000]
-                                            (js/Math.sin 100))
-                                          (pr-str (interleave (cycle [1]) (frequencies [1 2 3 1 2 3])))))))]
-       [:pre "cherry: " out @result])) nil)
+                 (reset! result (time (do (loop [i 0 acc 0.0]
+                                            (if (< i 8000000)
+                                              (recur (inc i) (+ acc (js/Math.sin i)))
+                                              acc))))))]
+       [:pre "cherry: " (.trim out) "\n" @result])) nil)
 
 (clerk/with-viewer
   {:render-fn

--- a/render/deps.edn
+++ b/render/deps.edn
@@ -2,7 +2,7 @@
  :deps {applied-science/js-interop {:mvn/version "0.4.2"}
         binaryage/devtools {:mvn/version "1.0.7"}
         cider/cider-nrepl {:mvn/version "0.55.7"}
-        org.babashka/sci {:mvn/version "0.15.56"}
+        org.babashka/sci {:mvn/version "0.15.57"}
         io.github.babashka/sci.nrepl {:mvn/version "0.0.2"}
         reagent/reagent {:mvn/version "1.3.0"}
         io.github.babashka/sci.configs {:git/sha "8253c69a537bcc82e8ff122e5f905fe9d1e303f0"

--- a/render/deps.edn
+++ b/render/deps.edn
@@ -2,7 +2,7 @@
  :deps {applied-science/js-interop {:mvn/version "0.4.2"}
         binaryage/devtools {:mvn/version "1.0.7"}
         cider/cider-nrepl {:mvn/version "0.55.7"}
-        org.babashka/sci {:mvn/version "0.15.57"}
+        org.babashka/sci {:mvn/version "0.15.58"}
         io.github.babashka/sci.nrepl {:mvn/version "0.0.2"}
         reagent/reagent {:mvn/version "1.3.0"}
         io.github.babashka/sci.configs {:git/sha "8253c69a537bcc82e8ff122e5f905fe9d1e303f0"

--- a/render/deps.edn
+++ b/render/deps.edn
@@ -2,7 +2,7 @@
  :deps {applied-science/js-interop {:mvn/version "0.4.2"}
         binaryage/devtools {:mvn/version "1.0.7"}
         cider/cider-nrepl {:mvn/version "0.55.7"}
-        org.babashka/sci {:mvn/version "0.12.51"}
+        org.babashka/sci {:mvn/version "0.15.56"}
         io.github.babashka/sci.nrepl {:mvn/version "0.0.2"}
         reagent/reagent {:mvn/version "1.3.0"}
         io.github.babashka/sci.configs {:git/sha "8253c69a537bcc82e8ff122e5f905fe9d1e303f0"
@@ -10,6 +10,6 @@
         io.github.nextjournal/clojure-mode {:git/sha "1f55406087814a0dda6806396aa596dbe13ea302"}
         thheller/shadow-cljs {:mvn/version "3.2.0"}
         io.github.squint-cljs/cherry {;;:local/root "/Users/borkdude/dev/cherry"
-                                      :git/sha "ffb00e9"
-                                      :git/tag "v0.4.32"
+                                      :git/sha "4b4e421"
+                                      :git/tag "v0.6.38"
                                       :exclusions [org.babashka/sci]}}}

--- a/src/nextjournal/clerk/cherry_env.cljs
+++ b/src/nextjournal/clerk/cherry_env.cljs
@@ -16,6 +16,7 @@
             [nextjournal.clojure-mode.extensions.eval-region]
             [nextjournal.clojure-mode.keymap]
             [reagent.core :as reagent]
+            [reagent.debug :as debug]
             [reagent.ratom :as ratom]
             [sci.configs.reagent.reagent :as sci.configs.reagent]))
 
@@ -32,10 +33,19 @@
   #js {:with-let-values ratom/with-let-values
        :reactive? ratom/reactive?
        :-ratom-context sci.configs.reagent/-ratom-context
+       :-generation sci.configs.reagent/-generation
+       :-ratom-generation sci.configs.reagent/-ratom-generation
+       :-set-ratom-generation! sci.configs.reagent/-set-ratom-generation!
+       :-destroy sci.configs.reagent/-destroy
+       :-destroy! sci.configs.reagent/-destroy!
        :atom reagent.ratom/atom
        :make-reaction reagent.ratom/make-reaction
        :make-track reagent.ratom/make-track
        :track! reagent.ratom/track!})
+
+(def reagent-debug-namespace
+  #js {:-tracking? sci.configs.reagent/-tracking?
+       :track-console debug/track-console})
 
 (defn munge-ns-obj [m]
   (.forEach (js/Object.keys m)
@@ -45,10 +55,12 @@
   m)
 
 (j/update-in! js/globalThis [:reagent :ratom] j/extend! (munge-ns-obj reagent-ratom-namespace))
+(j/update-in! js/globalThis [:reagent :debug] j/extend! (munge-ns-obj reagent-debug-namespace))
 (j/assoc! js/globalThis :global_eval (fn [x]
                                        (js/eval.apply js/globalThis #js [x])))
 
-(def cherry-macros {'reagent.core {'with-let sci.configs.reagent/with-let}})
+(def cherry-macros {'reagent.core {'with-let sci.configs.reagent/with-let}
+                    'reagent.debug {'error sci.configs.reagent/error}})
 
 (defn ^:export cherry-compile-string [s]
   (cherry/compile-string

--- a/src/nextjournal/clerk/sci_env.cljs
+++ b/src/nextjournal/clerk/sci_env.cljs
@@ -149,7 +149,8 @@
     val))
 
 (def initial-sci-opts
-  {:classes {'js (j/assoc! goog/global "import" shadow.esm/dynamic-import)
+  {:unrestricted true
+   :classes {'js (j/assoc! goog/global "import" shadow.esm/dynamic-import)
              'framer-motion framer-motion
              :allow :all}
    :js-libs {"@codemirror/lang-markdown" lang-markdown
@@ -258,8 +259,6 @@
     (set! (.-ws_send ^js goog/global) (fn [msg] (.send ws msg)))))
 
 (sci.ctx-store/reset-ctx! (sci/init initial-sci-opts))
-
-(sci/enable-unrestricted-access!)
 
 (sci/alter-var-root sci/print-fn (constantly *print-fn*))
 (sci/alter-var-root sci/print-err-fn (constantly *print-err-fn*))


### PR DESCRIPTION
- SCI now uses JIT and is not 20x slower anymore in the cherry notebook example (cherry is still faster, but SCI comes close)
- SCI supports `this-as` and `async/await` too, so those benefits aren't unique to cherry anymore
- Some fixes for reagent in the cherry environment